### PR TITLE
make pyfftw.interfaces.scipy_fftpack rfft and irfft consistent with scipy. It currently mimics numpy behaviour.

### DIFF
--- a/pyfftw/interfaces/scipy_fftpack.py
+++ b/pyfftw/interfaces/scipy_fftpack.py
@@ -180,7 +180,7 @@ def irfft(x, n=None, axis=-1, overwrite_x=False,
     xm = x[...,1:-1].flatten().view('complex%i' % ctype).reshape(shapem)
     xn = x[...,-1:] + 0.j
     x = concatenate([x1, xm, xn], axis=-1)
-    f = numpy_fft.irfft(x, n, axis, overwrite_x, planner_effort,
+    f = numpy_fft.irfft(x, n, -1, overwrite_x, planner_effort,
                         threads, auto_align_input, auto_contiguous)
     if swap:
         f = f.swapaxes(axis, -1)


### PR DESCRIPTION
The behaviour of the rfft and irfft routines and scipy.fftpack and numpy differ.

Most importantly is the output.
For scipy:
rfft returns [y(0),Re(y(1)),Im(y(1)),...,Re(y(n/2))]
while numpy
rfft returns [y(0) + 0j, Re(y(1)) + j*Im(y(1)),...,Re(y(n/2)) + 0j]

As well, the behaviour of the axis parameter differs.

FFTW3, and hence pyFFTW, behaves similarly to numpy
(except it doesn't upcast 32-bit numbers to 64-bit ones as numpy).

Since pyfftw.interfaces.scipy_fftpack uses FFTW3, it mimics the behaviour
of numpy's rfft and irfft. So, had one developed their code with scipy's
rfft and irfft's in mind, we can't simply drop in the pyfftw.interfaces.scipy_fftpack
as a replacement, we need to convert to (from) the numpy format for rfft (irfft).

This commit does that so pyfftw.interfaces.scipy_fftpack behaves like scipy.fftpack.

See http://mail.scipy.org/pipermail/numpy-discussion/2006-September/022977.html
http://comments.gmane.org/gmane.comp.python.scientific.user/19691
for some further discussion.
