### PR TITLE
Use complete scipy import in __init__ feature test.

### DIFF
--- a/pyfftw/interfaces/__init__.py
+++ b/pyfftw/interfaces/__init__.py
@@ -225,6 +225,9 @@ try:
 except ImportError:
     pass
 else:
-    del scipy
+    del (dct, idct, diff, tilbert, itilbert,
+        hilbert, ihilbert, cs_diff, sc_diff, ss_diff, cc_diff,
+        shift, fftshift, ifftshift, fftfreq, rfftfreq,
+        convolve, _fftpack)
     from . import scipy_fftpack
 

--- a/pyfftw/interfaces/__init__.py
+++ b/pyfftw/interfaces/__init__.py
@@ -218,7 +218,10 @@ from . import (
         cache,)
 
 try:
-    import scipy.fftpack
+    from scipy.fftpack import (dct, idct, diff, tilbert, itilbert,
+        hilbert, ihilbert, cs_diff, sc_diff, ss_diff, cc_diff,
+        shift, fftshift, ifftshift, fftfreq, rfftfreq,
+        convolve, _fftpack)
 except ImportError:
     pass
 else:


### PR DESCRIPTION
I was working on a Centos 6.4 machine whose package manager provides scipy 0.7.2.  This version does not have scipy.fftpack.dct (it was introduced in 0.8.0).  This leads to a situation where the try/except guard on the scipy import passes (pyfftw/interfaces/**init**.py), but actually loading the interface fails (pyfftw/interfaces/scipy_fftpack.py).  This pull request copies the actual scipy import used by the interface into the try/except block so that I can still import pyfftw if I've got an old version of scipy on my system.
