### PR TITLE
Fixes to aid downstream building.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,12 +2,14 @@ include CHANGELOG.md
 include LICENSE.txt
 include requirements.txt
 include README.rst
-include pyfftw/pyfftw.c
 include pyfftw/pyfftw.pyx
 include pyfftw/pyfftw.pxd
 include pyfftw/cpu.pxd
 include pyfftw/utils.pxi
 include test/test_*.py
 include test/__init__.py
+include conf.py
+include index.rst
+recursive-include pyfftw *.rst
+recursive-include sphinx *.rst
 recursive-include include *.h
-recursive-include docs *.html *.css *.png *.js *.rst

--- a/setup.py
+++ b/setup.py
@@ -327,11 +327,12 @@ def get_version_info():
     FULLVERSION = VERSION
     if os.path.exists('.git'):
         GIT_REVISION = git_version()
-    elif os.path.exists('pyfftw/version.py'):
+    elif os.path.exists(os.path.join('pyfftw', 'version.py')):
         # must be a source distribution, use existing version file
         # load it as a separate module in order not to load __init__.py
         import imp
-        version = imp.load_source('pyfftw.version', 'pyfftw/version.py')
+        version = imp.load_source(
+            'pyfftw.version', os.path.join('pyfftw', 'version.py'))
         GIT_REVISION = version.git_revision
     else:
         GIT_REVISION = "Unknown"
@@ -342,7 +343,11 @@ def get_version_info():
     return FULLVERSION, GIT_REVISION
 
 # borrowed from scipy via pyNFFT
-def write_version_py(filename='pyfftw/version.py'):
+def write_version_py(filename=None):
+
+    if filename is None:
+        filename = os.path.join('pyfftw', 'version.py')
+
     cnt = """
 # THIS FILE IS GENERATED FROM SETUP.PY
 short_version = '%(version)s'
@@ -374,7 +379,7 @@ def setup_package():
     FULLVERSION, GIT_REVISION = get_version_info()
 
     # Refresh version file if we're not a source release
-    if ISRELEASED and os.path.exists('pyfftw/version.py'):
+    if ISRELEASED and os.path.exists(os.path.join('pyfftw', 'version.py')):
         pass
     else:
         write_version_py()

--- a/setup.py
+++ b/setup.py
@@ -373,8 +373,11 @@ def setup_package():
     # Get current version
     FULLVERSION, GIT_REVISION = get_version_info()
 
-    # Refresh version file
-    write_version_py()
+    # Refresh version file if we're not a source release
+    if ISRELEASED and os.path.exists('pyfftw/version.py'):
+        pass
+    else:
+        write_version_py()
 
     # Figure out whether to add ``*_requires = ['numpy']``.
     build_requires = []


### PR DESCRIPTION
Tentative fixes for #31, #32, #86 and #87.

Specifically, don't mess with the version.py file and only include source files not built files in a source release.