### PR TITLE
Resolves issue #92.

### DIFF
--- a/pyfftw/interfaces/_utils.py
+++ b/pyfftw/interfaces/_utils.py
@@ -5,6 +5,9 @@
 # Henry Gomersall
 # heng@kedevelopments.co.uk
 #
+# Michael McNeil Forbes
+# michael.forbes+pyfftw@gmail.com
+#
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -47,7 +50,7 @@ def _Xfftn(a, s, axes, overwrite_input, planner_effort,
         threads, auto_align_input, auto_contiguous, 
         calling_func, normalise_idft=True):
 
-    reload_after_transform = False
+    work_with_copy = False
 
     a = numpy.asanyarray(a)
 
@@ -63,21 +66,35 @@ def _Xfftn(a, s, axes, overwrite_input, planner_effort,
 
     if calling_func in ('irfft2', 'irfftn'):
         # overwrite_input is not an argument to irfft2 or irfftn
-        args = (a, s, axes, planner_effort, threads, 
-                auto_align_input, auto_contiguous)
+        args = (planner_effort, threads, auto_align_input, auto_contiguous)
 
         if not overwrite_input:
             # Only irfft2 and irfftn have overwriting the input
             # as the default (and so require the input array to 
             # be reloaded).
-            reload_after_transform = True
+            work_with_copy = True
     else:
-        args = (a, s, axes, overwrite_input, planner_effort, threads, 
+        args = (overwrite_input, planner_effort, threads,
                 auto_align_input, auto_contiguous)
     
+        if not a.flags.writeable:
+            # Special case of a locked array - always work with a
+            # copy.  See issue #92.
+            work_with_copy = True
+
+            if overwrite_input:
+                raise ValueError(
+                    "Cannot set overwrite_input when not a.flags.writeable")
+
+    if work_with_copy:
+        # We make the copy before registering the key so that the
+        # copy's stride information will be cached since this will be
+        # used for planning.
+        a = a.copy()
+
     if cache.is_enabled():
         key = (calling_func, a.shape, a.strides, a.dtype, s.__hash__(), 
-                axes.__hash__(), args[3:])
+               axes.__hash__(), args)
 
         try:
             if key in cache._fftw_cache:
@@ -92,18 +109,21 @@ def _Xfftn(a, s, axes, overwrite_input, planner_effort,
 
     if not cache.is_enabled() or FFTW_object is None:
 
-        # If we're going to create a new FFTW object, we need to copy
-        # the input array to preserve it, otherwise we can't actually
-        # take the transform of the input array! (in general, we have
-        # to assume that the input array will be destroyed during 
-        # planning).
-        a_copy = a.copy()
+        # If we're going to create a new FFTW object and are not
+        # working with a copy, then we need to copy the input array to
+        # preserve it, otherwise we can't actually  take the transform
+        # of the input array! (in general, we have to assume that the
+        # input array will be destroyed during planning).
+        if not work_with_copy:
+            a_copy = a.copy()
 
-        FFTW_object = getattr(builders, calling_func)(*args)
+        planner_args = (a, s, axes) + args
+
+        FFTW_object = getattr(builders, calling_func)(*planner_args)
     
         # Only copy if the input array is what was actually used
         # (otherwise it shouldn't be overwritten)
-        if FFTW_object.input_array is a:
+        if not work_with_copy and FFTW_object.input_array is a:
             a[:] = a_copy
 
         if cache.is_enabled():
@@ -112,9 +132,6 @@ def _Xfftn(a, s, axes, overwrite_input, planner_effort,
         output_array = FFTW_object(normalise_idft=normalise_idft)
 
     else:
-        if reload_after_transform:
-            a_copy = a.copy()
-
         orig_output_array = FFTW_object.output_array
         output_shape = orig_output_array.shape
         output_dtype = orig_output_array.dtype
@@ -126,7 +143,4 @@ def _Xfftn(a, s, axes, overwrite_input, planner_effort,
         FFTW_object(input_array=a, output_array=output_array, 
                 normalise_idft=normalise_idft)
     
-    if reload_after_transform:
-        a[:] = a_copy
-
     return output_array

--- a/pyfftw/interfaces/_utils.py
+++ b/pyfftw/interfaces/_utils.py
@@ -89,8 +89,11 @@ def _Xfftn(a, s, axes, overwrite_input, planner_effort,
     if work_with_copy:
         # We make the copy before registering the key so that the
         # copy's stride information will be cached since this will be
-        # used for planning.
-        a = a.copy()
+        # used for planning.  Make sure the copy is byte aligned to
+        # prevent further copying
+        a_original = a
+        a = pyfftw.empty_aligned(shape=a.shape, dtype=a.dtype)
+        a[...] = a_original
 
     if cache.is_enabled():
         key = (calling_func, a.shape, a.strides, a.dtype, s.__hash__(), 

--- a/pyfftw/interfaces/_utils.py
+++ b/pyfftw/interfaces/_utils.py
@@ -83,8 +83,8 @@ def _Xfftn(a, s, axes, overwrite_input, planner_effort,
             work_with_copy = True
 
             if overwrite_input:
-                raise ValueError(
-                    "Cannot set overwrite_input when not a.flags.writeable")
+                raise ValueError('overwrite_input cannot be True when the ' +
+                                 'input array flags.writeable is False')
 
     if work_with_copy:
         # We make the copy before registering the key so that the

--- a/test/test_pyfftw_interfaces_cache.py
+++ b/test/test_pyfftw_interfaces_cache.py
@@ -33,6 +33,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
+import copy
 
 from pyfftw import interfaces, builders
 import numpy
@@ -58,12 +59,14 @@ class InterfacesNumpyFFTCacheTestFFT(InterfacesNumpyFFTTestFFT):
             )
 
     def validate(self, array_type, test_shape, dtype, 
-            s, kwargs):
+                 s, kwargs, copy_func=copy.copy):
 
         # Do it with the cache
         interfaces.cache.enable()        
-        output = self._validate(array_type, test_shape, dtype, s, kwargs)
-        output2 = self._validate(array_type, test_shape, dtype, s, kwargs)
+        output = self._validate(array_type, test_shape, dtype, s, kwargs,
+                                copy_func=copy_func)
+        output2 = self._validate(array_type, test_shape, dtype, s, kwargs,
+                                 copy_func=copy_func)
 
         self.assertIsNot(output, output2) 
 

--- a/test/test_pyfftw_numpy_interface.py
+++ b/test/test_pyfftw_numpy_interface.py
@@ -593,7 +593,8 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
 
         self.assertRaisesRegex(
             ValueError,
-            'Cannot set overwrite_input when not a.flags.writeable',
+            'overwrite_input cannot be True when the ' +
+            'input array flags.writeable is False',
             interfaces.numpy_fft.fft,
             a, overwrite_input=True)
 

--- a/test/test_pyfftw_numpy_interface.py
+++ b/test/test_pyfftw_numpy_interface.py
@@ -582,19 +582,11 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
                               test_shape, dtype, s, kwargs,
                               copy_func=copy_with_writeable)
 
-    def test_regression_issue_92(self):
-        '''Quick regression test for issue 92.
-
-        The previous unit tests do not cover this when quick_tests is
-        run because one needs the complex dtype for failure.
+    def test_overwrite_input_for_issue_92(self):
+        '''Tests that trying to overwrite a locked array fails.
         '''
-        numpy.random.seed(1)
-        a = numpy.random.random((100,)) + 1j
-        interfaces.numpy_fft.fft(a)
-        a = numpy.random.random((4, 4)) + 1j
+        a = numpy.zeros((4,))
         a.flags.writeable = False
-        assert numpy.allclose(np_fft.fft(a), interfaces.numpy_fft.fft(a))
-
         self.assertRaisesRegex(
             ValueError,
             'overwrite_input cannot be True when the ' +

--- a/test/test_pyfftw_numpy_interface.py
+++ b/test/test_pyfftw_numpy_interface.py
@@ -591,6 +591,12 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
         a.flags.writeable = False
         assert numpy.allclose(np_fft.fft(a), interfaces.numpy_fft.fft(a))
 
+        self.assertRaisesRegex(
+            ValueError,
+            'Cannot set overwrite_input when not a.flags.writeable',
+            interfaces.numpy_fft.fft,
+            a, overwrite_input=True)
+
 
 class InterfacesNumpyFFTTestIFFT(InterfacesNumpyFFTTestFFT):
     func = 'ifft'


### PR DESCRIPTION
The essence of this change is to use copies of the input array `a` for planning purposes or when the array must be restored after a transform.  This prevents accessing the input array as much as possible, allowing it to be locked, and thereby resolving issue #92 in all cases except when `overwrite_input == True`.  One might like to raise an error if this is the case while `a.flags.writeable == True` but I have kept the changes minimal in this PR.