### PR TITLE
add option to select orthonormal (unitary) DFT scaling

### DIFF
--- a/pyfftw/builders/_utils.py
+++ b/pyfftw/builders/_utils.py
@@ -229,7 +229,7 @@ class _FFTWWrapper(pyfftw.FFTW):
                              axes, direction, flags, threads)
 
     def __call__(self, input_array=None, output_array=None,
-            normalise_idft=True):
+            normalise_idft=True, ortho=False):
         '''Wrap :meth:`pyfftw.FFTW.__call__` by firstly slicing the
         passed-in input array and then copying it into a sliced version
         of the internal array. These slicers are set at instantiation.
@@ -264,7 +264,8 @@ class _FFTWWrapper(pyfftw.FFTW):
             sliced_internal[:] = sliced_input
 
         output = super(_FFTWWrapper, self).__call__(input_array=None,
-                output_array=output_array, normalise_idft=normalise_idft)
+                output_array=output_array, normalise_idft=normalise_idft,
+                ortho=ortho)
 
         return output
 

--- a/pyfftw/interfaces/_utils.py
+++ b/pyfftw/interfaces/_utils.py
@@ -48,7 +48,7 @@ from . import cache
 
 def _Xfftn(a, s, axes, overwrite_input, planner_effort,
         threads, auto_align_input, auto_contiguous,
-        calling_func, normalise_idft=True):
+        calling_func, normalise_idft=True, ortho=False):
 
     work_with_copy = False
 
@@ -132,7 +132,7 @@ def _Xfftn(a, s, axes, overwrite_input, planner_effort,
         if cache.is_enabled():
             cache._fftw_cache.insert(FFTW_object, key)
 
-        output_array = FFTW_object(normalise_idft=normalise_idft)
+        output_array = FFTW_object(normalise_idft=normalise_idft, ortho=ortho)
 
     else:
         orig_output_array = FFTW_object.output_array
@@ -144,6 +144,6 @@ def _Xfftn(a, s, axes, overwrite_input, planner_effort,
             output_shape, output_dtype, n=output_alignment)
 
         FFTW_object(input_array=a, output_array=output_array,
-                normalise_idft=normalise_idft)
+                normalise_idft=normalise_idft, ortho=ortho)
 
     return output_array

--- a/pyfftw/interfaces/numpy_fft.py
+++ b/pyfftw/interfaces/numpy_fft.py
@@ -67,105 +67,148 @@ __all__ = ['fft','ifft', 'fft2', 'ifft2', 'fftn', 'ifftn',
            'rfft', 'irfft', 'rfft2', 'irfft2', 'rfftn', 'irfftn',
            'hfft', 'ihfft', 'fftfreq', 'fftshift', 'ifftshift']
 
-def fft(a, n=None, axis=-1, overwrite_input=False,
+def _unitary(norm):
+    """_unitary() utility copied from numpy"""
+    if norm not in (None, "ortho"):
+        raise ValueError("Invalid norm value %s, should be None or \"ortho\"."
+                         % norm)
+    return norm is not None
+
+def fft(a, n=None, axis=-1, norm=None, overwrite_input=False,
         planner_effort='FFTW_MEASURE', threads=1,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D FFT.
 
-    The first three arguments are as per :func:`numpy.fft.fft`;
+    The first four arguments are as per :func:`numpy.fft.fft`;
     the rest of the arguments are documented
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     '''
 
     calling_func = 'fft'
+    if _unitary(norm):
+        ortho = True
+        normalise_idft = False
+    else:
+        ortho = False
+        normalise_idft = True
 
     return _Xfftn(a, n, axis, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
-            calling_func)
+            calling_func, normalise_idft=normalise_idft, ortho=ortho)
 
-def ifft(a, n=None, axis=-1, overwrite_input=False,
+def ifft(a, n=None, axis=-1, norm=None, overwrite_input=False,
         planner_effort='FFTW_MEASURE', threads=1,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D inverse FFT.
 
-    The first three arguments are as per :func:`numpy.fft.ifft`;
+    The first four arguments are as per :func:`numpy.fft.ifft`;
     the rest of the arguments are documented
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     '''
     calling_func = 'ifft'
+    if _unitary(norm):
+        ortho = True
+        normalise_idft = False
+    else:
+        ortho = False
+        normalise_idft = True
 
     return _Xfftn(a, n, axis, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
-            calling_func)
+            calling_func, normalise_idft=normalise_idft, ortho=ortho)
 
 
-def fft2(a, s=None, axes=(-2,-1), overwrite_input=False,
+def fft2(a, s=None, axes=(-2,-1), norm=None, overwrite_input=False,
         planner_effort='FFTW_MEASURE', threads=1,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 2D FFT.
 
-    The first three arguments are as per :func:`numpy.fft.fft2`;
+    The first four arguments are as per :func:`numpy.fft.fft2`;
     the rest of the arguments are documented
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     '''
     calling_func = 'fft2'
+    if _unitary(norm):
+        ortho = True
+        normalise_idft = False
+    else:
+        ortho = False
+        normalise_idft = True
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
-            calling_func)
+            calling_func, normalise_idft=normalise_idft, ortho=ortho)
 
-def ifft2(a, s=None, axes=(-2,-1), overwrite_input=False,
+def ifft2(a, s=None, axes=(-2,-1), norm=None, overwrite_input=False,
         planner_effort='FFTW_MEASURE', threads=1,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 2D inverse FFT.
 
-    The first three arguments are as per :func:`numpy.fft.ifft2`;
+    The first four arguments are as per :func:`numpy.fft.ifft2`;
     the rest of the arguments are documented
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     '''
     calling_func = 'ifft2'
+    if _unitary(norm):
+        ortho = True
+        normalise_idft = False
+    else:
+        ortho = False
+        normalise_idft = True
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
-            calling_func)
+            calling_func, normalise_idft=normalise_idft, ortho=ortho)
 
 
-def fftn(a, s=None, axes=None, overwrite_input=False,
+def fftn(a, s=None, axes=None, norm=None, overwrite_input=False,
         planner_effort='FFTW_MEASURE', threads=1,
         auto_align_input=True, auto_contiguous=True):
     '''Perform an n-D FFT.
 
-    The first three arguments are as per :func:`numpy.fft.fftn`;
+    The first four arguments are as per :func:`numpy.fft.fftn`;
     the rest of the arguments are documented
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     '''
     calling_func = 'fftn'
+    if _unitary(norm):
+        ortho = True
+        normalise_idft = False
+    else:
+        ortho = False
+        normalise_idft = True
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
-            calling_func)
+            calling_func, normalise_idft=normalise_idft, ortho=ortho)
 
-def ifftn(a, s=None, axes=None, overwrite_input=False,
+def ifftn(a, s=None, axes=None, norm=None, overwrite_input=False,
         planner_effort='FFTW_MEASURE', threads=1,
         auto_align_input=True, auto_contiguous=True):
     '''Perform an n-D inverse FFT.
 
-    The first three arguments are as per :func:`numpy.fft.ifftn`;
+    The first four arguments are as per :func:`numpy.fft.ifftn`;
     the rest of the arguments are documented
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     '''
     calling_func = 'ifftn'
+    if _unitary(norm):
+        ortho = True
+        normalise_idft = False
+    else:
+        ortho = False
+        normalise_idft = True
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
-            calling_func)
+            calling_func, normalise_idft=normalise_idft, ortho=ortho)
 
 def rfft(a, n=None, axis=-1, overwrite_input=False,
         planner_effort='FFTW_MEASURE', threads=1,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D real FFT.
 
-    The first three arguments are as per :func:`numpy.fft.rfft`;
+    The three four arguments are as per :func:`numpy.fft.rfft`;
     the rest of the arguments are documented
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     '''

--- a/pyfftw/interfaces/scipy_fftpack.py
+++ b/pyfftw/interfaces/scipy_fftpack.py
@@ -83,7 +83,7 @@ def fft(x, n=None, axis=-1, overwrite_x=False,
     the rest of the arguments are documented
     in the :ref:`additional argument docs<interfaces_additional_args>`.
     '''
-    return numpy_fft.fft(x, n, axis, overwrite_x, planner_effort,
+    return numpy_fft.fft(x, n, axis, None, overwrite_x, planner_effort,
             threads, auto_align_input, auto_contiguous)
 
 def ifft(x, n=None, axis=-1, overwrite_x=False,
@@ -96,8 +96,8 @@ def ifft(x, n=None, axis=-1, overwrite_x=False,
     in the :ref:`additional argument docs<interfaces_additional_args>`.
     '''
 
-    return numpy_fft.ifft(x, n, axis, overwrite_x, planner_effort,
-            threads, auto_align_input, auto_contiguous)
+    return numpy_fft.ifft(x, n, axis, None, overwrite_x,
+            planner_effort, threads, auto_align_input, auto_contiguous)
 
 
 def fft2(x, shape=None, axes=(-2,-1), overwrite_x=False,
@@ -110,8 +110,8 @@ def fft2(x, shape=None, axes=(-2,-1), overwrite_x=False,
     in the :ref:`additional argument docs<interfaces_additional_args>`.
     '''
 
-    return numpy_fft.fft2(x, shape, axes, overwrite_x, planner_effort,
-            threads, auto_align_input, auto_contiguous)
+    return numpy_fft.fft2(x, shape, axes, None, overwrite_x,
+            planner_effort, threads, auto_align_input, auto_contiguous)
 
 
 def ifft2(x, shape=None, axes=(-2,-1), overwrite_x=False,
@@ -124,8 +124,8 @@ def ifft2(x, shape=None, axes=(-2,-1), overwrite_x=False,
     :ref:`additional argument docs <interfaces_additional_args>`.
     '''
 
-    return numpy_fft.ifft2(x, shape, axes, overwrite_x, planner_effort,
-            threads, auto_align_input, auto_contiguous)
+    return numpy_fft.ifft2(x, shape, axes, None, overwrite_x,
+            planner_effort, threads, auto_align_input, auto_contiguous)
 
 
 def fftn(x, shape=None, axes=None, overwrite_x=False,
@@ -148,8 +148,8 @@ def fftn(x, shape=None, axes=None, overwrite_x=False,
                     'of axes if it is not. If this is problematic, consider '
                     'using the numpy interface.')
 
-    return numpy_fft.fftn(x, shape, axes, overwrite_x, planner_effort,
-            threads, auto_align_input, auto_contiguous)
+    return numpy_fft.fftn(x, shape, axes, None, overwrite_x,
+            planner_effort, threads, auto_align_input, auto_contiguous)
 
 
 def ifftn(x, shape=None, axes=None, overwrite_x=False,
@@ -172,8 +172,8 @@ def ifftn(x, shape=None, axes=None, overwrite_x=False,
                     'of axes if it is not. If this is problematic, consider '
                     'using the numpy interface.')
 
-    return numpy_fft.ifftn(x, shape, axes, overwrite_x, planner_effort,
-            threads, auto_align_input, auto_contiguous)
+    return numpy_fft.ifftn(x, shape, axes, None, overwrite_x,
+            planner_effort, threads, auto_align_input, auto_contiguous)
 
 def _complex_to_rfft_output(complex_output, output_shape, axis):
     '''Convert the complex output from pyfftw to the real output expected

--- a/pyfftw/pyfftw.pyx
+++ b/pyfftw/pyfftw.pyx
@@ -1359,8 +1359,11 @@ cdef class FFTW:
 
         If ``ortho`` is ``True``, then the output of both forward
         and inverse DFT operations is scaled by 1/sqrt(N), where N is the
-        product of the lengths of input array on which the FFT is taken.  If
-        ortho is True then the 2-norm of fft(A) will equal the 2-norm of A.
+        product of the lengths of input array on which the FFT is taken.  This
+        ensures that the DFT is a unitary operation, meaning that it satisfies
+        Parseval's theorem (the sum of the squared values of the transform
+        output is equal to the sum of the squared values of the input).  In
+        other words, the energy of the signal is preserved.
 
         If either ``normalise_idft`` or ``ortho`` are ``True``, then
         ifft(fft(A)) = A.

--- a/pyfftw/pyfftw.pyx
+++ b/pyfftw/pyfftw.pyx
@@ -654,6 +654,7 @@ cdef class FFTW:
     cdef object _flags_used
 
     cdef double _normalisation_scaling
+    cdef double _sqrt_normalisation_scaling
 
     cdef int _rank
     cdef _fftw_iodim *_dims
@@ -977,6 +978,7 @@ cdef class FFTW:
 
         self._N = total_N
         self._normalisation_scaling = 1/float(self.N)
+        self._sqrt_normalisation_scaling = np.sqrt(self._normalisation_scaling)
 
         # Now we can validate the array shapes
         cdef validator _validator
@@ -1337,8 +1339,9 @@ cdef class FFTW:
             free(self._howmany_dims)
 
     def __call__(self, input_array=None, output_array=None,
-            normalise_idft=True):
-        '''__call__(input_array=None, output_array=None, normalise_idft=True)
+            normalise_idft=True, ortho=False):
+        '''__call__(input_array=None, output_array=None, normalise_idft=True,
+                    ortho=False)
 
         Calling the class instance (optionally) updates the arrays, then
         calls :meth:`~pyfftw.FFTW.execute`, before optionally normalising
@@ -1353,6 +1356,14 @@ cdef class FFTW:
         scaled by 1/N, where N is the product of the lengths of input array on
         which the FFT is taken. If the direction is ``'FFTW_FORWARD'``, this
         flag makes no difference to the output array.
+
+        If ``ortho`` is ``True``, then the output of both forward
+        and inverse DFT operations is scaled by 1/sqrt(N), where N is the
+        product of the lengths of input array on which the FFT is taken.  If
+        ortho is True then the 2-norm of fft(A) will equal the 2-norm of A.
+
+        If either ``normalise_idft`` or ``ortho`` are ``True``, then
+        ifft(fft(A)) = A.
 
         When ``input_array`` is something other than None, then the passed in
         array is coerced to be the same dtype as the input array used when the
@@ -1393,6 +1404,10 @@ cdef class FFTW:
         need the data to persist longer than a subsequent call, you should
         copy the returned array.
         '''
+
+        if ortho and normalise_idft:
+            raise ValueError('Invalid options: ortho and normalise_idft cannot'
+                             ' both be True.')
 
         if input_array is not None or output_array is not None:
 
@@ -1438,7 +1453,9 @@ cdef class FFTW:
 
         self.execute()
 
-        if self._direction == FFTW_BACKWARD and normalise_idft:
+        if ortho == True:
+            self._output_array *= self._sqrt_normalisation_scaling
+        elif self._direction == FFTW_BACKWARD and normalise_idft:
             self._output_array *= self._normalisation_scaling
 
         return self._output_array

--- a/test/test_pyfftw_call.py
+++ b/test/test_pyfftw_call.py
@@ -416,6 +416,46 @@ class FFTWCallTest(unittest.TestCase):
 
         self.assertTrue(numpy.alltrue(ref_output == test_output))
 
+    def test_call_with_ortho_on(self):
+        _input_array = empty_aligned((256, 512), dtype='complex128', n=16)
+
+        ifft = FFTW(self.output_array, _input_array,
+                    direction='FFTW_BACKWARD')
+
+        self.fft(ortho=True, normalise_idft=False)
+
+        # ortho case preserves the norm in forward direction
+        self.assertTrue(
+            numpy.allclose(numpy.linalg.norm(self.input_array),
+                           numpy.linalg.norm(self.output_array)))
+
+        ifft(ortho=True, normalise_idft=False)
+
+        # ortho case preserves the norm in backward direction
+        self.assertTrue(
+            numpy.allclose(numpy.linalg.norm(_input_array),
+                           numpy.linalg.norm(self.output_array)))
+
+        self.assertTrue(numpy.allclose(self.input_array, _input_array))
+
+        # cant select both ortho and normalise_idft
+        self.assertRaisesRegex(ValueError, 'Invalid options',
+                               self.fft, normalise_idft=True, ortho=True)
+        # cant specify orth=True with default normalise_idft=True
+        self.assertRaisesRegex(ValueError, 'Invalid options',
+                               self.fft, ortho=True)
+
+    def test_call_with_ortho_off(self):
+        _input_array = empty_aligned((256, 512), dtype='complex128', n=16)
+
+        ifft = FFTW(self.output_array, _input_array,
+                    direction='FFTW_BACKWARD')
+
+        self.fft(ortho=False)
+        ifft(ortho=False)
+
+        # Scaling by normalise_idft is performed by default
+        self.assertTrue(numpy.allclose(self.input_array, _input_array))
 
 test_cases = (
         FFTWCallTest,)

--- a/test/test_pyfftw_scipy_interface.py
+++ b/test/test_pyfftw_scipy_interface.py
@@ -193,6 +193,9 @@ for each_func in funcs:
     globals()[class_name] = type(class_name,
             (parent_class,), class_dict)
 
+    # unlike numpy, none of the scipy functions support the norm kwarg
+    globals()[class_name].has_norm_kwarg = False
+
     built_classes.append(globals()[class_name])
 
 built_classes = tuple(built_classes)


### PR DESCRIPTION
I am usually interested in applying a unitary DFT operator (i.e. one that satisfies Parseval's theorem).  This differs from the current FFTW default only in the scaling of the forward and inverse transforms:

**ortho (unitary) case:**  scale both forward and inverse by 1/srqt(N)
**current pyFFTW (and Matlab) default:**  forward unscaled,  inverse scaled by 1/N

If the proposed approach seems acceptable, I can also add modifications to the `numpy.fft` interfaces to support the `norm` keyword that was added in numpy 1.10.  In recent numpy, if `norm='ortho'` the behavior matches what I have proposed here.