### PR TITLE
BLD: use optional STATIC_FFTW_DIR environment variable to link static…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,7 @@ def get_extensions():
         common_extension_args['libraries'] = []
     else:
         # otherwise we use dynamic libraries
-        extra_link_args = []
+        common_extension_args['extra_link_args'] = []
         common_extension_args['libraries'] = libraries
 
     ext_modules = [

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,9 @@ MICRO = 1
 ISRELEASED = False
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
+static_fftw_path = os.environ.get('STATIC_FFTW_DIR', None)
+link_static_fftw = static_fftw_path is not None
+
 def get_package_data():
     from pkg_resources import get_build_platform
 
@@ -121,8 +124,27 @@ def get_extensions():
 
         have_cython = False
 
+    if link_static_fftw:
+        from pkg_resources import get_build_platform
+        if get_build_platform() in ('win32', 'win-amd64'):
+            lib_pre = ''
+            lib_ext = '.lib'
+        else:
+            lib_pre = 'lib'
+            lib_ext = '.a'
+        extra_link_args = []
+        for lib in common_extension_args['libraries']:
+            extra_link_args.append(
+                os.path.join(static_fftw_path, lib_pre + lib + lib_ext))
+        # now that full paths to libraries are in extra_link_args remove them
+        # from common_extension_args
+        common_extension_args['libraries'] = []
+    else:
+        extra_link_args = []
+
     ext_modules = [
         Extension('pyfftw.pyfftw', sources=sources,
+                  extra_link_args=extra_link_args,
                   **common_extension_args)]
 
     if have_cython:

--- a/setup.py
+++ b/setup.py
@@ -53,9 +53,6 @@ MICRO = 1
 ISRELEASED = False
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
-static_fftw_path = os.environ.get('STATIC_FFTW_DIR', None)
-link_static_fftw = static_fftw_path is not None
-
 def get_package_data():
     from pkg_resources import get_build_platform
 
@@ -104,10 +101,13 @@ def get_libraries():
 def get_extensions():
     from distutils.extension import Extension
 
+    # will use static linking if STATIC_FFTW_DIR defined
+    static_fftw_path = os.environ.get('STATIC_FFTW_DIR', None)
+    link_static_fftw = static_fftw_path is not None
+
     common_extension_args = {
         'include_dirs': get_include_dirs(),
-        'library_dirs': get_library_dirs(),
-        'libraries': get_libraries()}
+        'library_dirs': get_library_dirs()}
 
     try:
         from Cython.Build import cythonize
@@ -124,6 +124,7 @@ def get_extensions():
 
         have_cython = False
 
+    libraries = get_libraries()
     if link_static_fftw:
         from pkg_resources import get_build_platform
         if get_build_platform() in ('win32', 'win-amd64'):
@@ -133,18 +134,19 @@ def get_extensions():
             lib_pre = 'lib'
             lib_ext = '.a'
         extra_link_args = []
-        for lib in common_extension_args['libraries']:
+        for lib in libraries:
             extra_link_args.append(
                 os.path.join(static_fftw_path, lib_pre + lib + lib_ext))
-        # now that full paths to libraries are in extra_link_args remove them
-        # from common_extension_args
+
+        common_extension_args['extra_link_args'] = extra_link_args
         common_extension_args['libraries'] = []
     else:
+        # otherwise we use dynamic libraries
         extra_link_args = []
+        common_extension_args['libraries'] = libraries
 
     ext_modules = [
         Extension('pyfftw.pyfftw', sources=sources,
-                  extra_link_args=extra_link_args,
                   **common_extension_args)]
 
     if have_cython:


### PR DESCRIPTION
I am trying to get a version of conda packages for `fftw` and `pyFFTW` that do suffer from the MKL symbol clashing issues on linux that were reported in #40 and #106.  I am taking the approach proposed by @jonycgn where the FFTW libs are compiled with the -fPIC flag so that they can be statically linked.

The current `fftw` package in my PR at conda-forge/fftw-feedstock#4 builds both static and dynamic libraries.  A problem I encountered is that the current pyFFTW `setup.py` will link to the dynamic libraries rather than the desired static ones so that the suggested solution of `CFLAGS="-I${PREFIX}/include -Xlinker -Bsymbolic" pip install pyFFTW` does not work.

This PR modifies `setup.py` to use the absolute path to the static FFTW libs if a STATIC_FFTW_DIR environment variable is defined.  I would appreciate if you have other ideas of a better way to do this.

If the following two exports are made prior to installing pyFFTW, the problems with MKL should not occur.
1.) export STATIC_FFTW_DIR=${PREFIX}/lib  where ${PREFIX} is the base of the current anaconda environment with the `fftw` package installed.
2.) export CFLAGS="$CFLAGS -Wl,-Bsymbolic"

A `pyFFTW` package that is built in this manner would then be made available through [condo-forge](https://conda-forge.github.io).  Rather than use a custom patch to setup.py in the build recipe, I thought I would try a PR here first.