### PR TITLE
ENH: process float16 inputs in single precision

### DIFF
--- a/pyfftw/builders/_utils.py
+++ b/pyfftw/builders/_utils.py
@@ -99,12 +99,21 @@ def _Xfftn(a, s, axes, overwrite_input,
 
     # Make the input dtype correct
     if a.dtype.char not in _rc_dtype_pairs:
-        # We make it the default dtype
-        if not real or inverse:
-            # It's going to be complex
-            a = numpy.asarray(a, dtype=_rc_dtype_pairs[_default_dtype.char])
+        if a.dtype == numpy.dtype('float16'):
+            # convert half-precision to single precision rather than double
+            if not real or inverse:
+                a = numpy.asarray(
+                    a, dtype=_rc_dtype_pairs[numpy.dtype('float32').char])
+            else:
+                a = numpy.asarray(a, dtype=_default_dtype.char)
         else:
-            a = numpy.asarray(a, dtype=_default_dtype)
+            # We make it the default dtype
+            if not real or inverse:
+                # It's going to be complex
+                a = numpy.asarray(
+                    a, dtype=_rc_dtype_pairs[_default_dtype.char])
+            else:
+                a = numpy.asarray(a, dtype=_default_dtype)
 
     elif not (real and not inverse) and not a_is_complex:
         # We need to make it a complex dtype

--- a/pyfftw/builders/_utils.py
+++ b/pyfftw/builders/_utils.py
@@ -105,7 +105,7 @@ def _Xfftn(a, s, axes, overwrite_input,
                 a = numpy.asarray(
                     a, dtype=_rc_dtype_pairs[numpy.dtype('float32').char])
             else:
-                a = numpy.asarray(a, dtype=_default_dtype.char)
+                a = numpy.asarray(a, dtype=numpy.dtype('float32').char)
         else:
             # We make it the default dtype
             if not real or inverse:

--- a/pyfftw/interfaces/numpy_fft.py
+++ b/pyfftw/interfaces/numpy_fft.py
@@ -44,8 +44,8 @@ generally return an output array with the same precision as the input
 array, and the transform that is chosen is chosen based on the precision
 of the input array. That is, if the input array is 32-bit floating point,
 then the transform will be 32-bit floating point and so will the returned
-array. If any type conversion is required, the default will be double
-precision.
+array. Half precision input will be converted to single precision.  Otherwise,
+if any type conversion is required, the default will be double precision.
 
 One known caveat is that repeated axes are handled differently to
 :mod:`numpy.fft`; axes that are repeated in the axes argument are considered

--- a/pyfftw/interfaces/scipy_fftpack.py
+++ b/pyfftw/interfaces/scipy_fftpack.py
@@ -47,8 +47,8 @@ generally return an output array with the same precision as the input
 array, and the transform that is chosen is chosen based on the precision
 of the input array. That is, if the input array is 32-bit floating point,
 then the transform will be 32-bit floating point and so will the returned
-array. If any type conversion is required, the default will be double
-precision.
+array. Half precision input will be converted to single precision.  Otherwise,
+if any type conversion is required, the default will be double precision.
 
 Some corner (mis)usages of :mod:`scipy.fftpack` may not transfer neatly.
 For example, using :func:`scipy.fftpack.fft2` with a non 1D array and

--- a/test/test_pyfftw_numpy_interface.py
+++ b/test/test_pyfftw_numpy_interface.py
@@ -50,8 +50,8 @@ if LooseVersion(numpy.version.version) <= LooseVersion('1.6.2'):
     from ._cook_nd_args import _cook_nd_args
     numpy.fft.fftpack._cook_nd_args = _cook_nd_args
 
-complex_dtypes = (numpy.complex64, numpy.complex128, numpy.clongdouble)
-real_dtypes = (numpy.float32, numpy.float64, numpy.longdouble)
+complex_dtypes = (numpy.complex64, numpy.complex64, numpy.complex128, numpy.clongdouble)
+real_dtypes = (numpy.float16, numpy.float32, numpy.float64, numpy.longdouble)
 
 def make_complex_data(shape, dtype):
     ar, ai = dtype(numpy.random.randn(2, *shape))
@@ -243,7 +243,12 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
                 numpy.allclose(output_array, test_out_array,
                     rtol=1e-2, atol=1e-4))
 
-        input_precision_dtype = numpy.asanyarray(input_array).real.dtype
+        if numpy.asanyarray(input_array).real.dtype == numpy.float16:
+            # FFTW output will never be single precision for half precision
+            # inputs as there is no half-precision FFTW routine
+            input_precision_dtype = numpy.float32
+        else:
+            input_precision_dtype = numpy.asanyarray(input_array).real.dtype
 
         self.assertEqual(input_precision_dtype,
                 output_array.real.dtype)

--- a/test/test_pyfftw_scipy_interface.py
+++ b/test/test_pyfftw_scipy_interface.py
@@ -76,10 +76,15 @@ def make_c2r_real_data(shape, dtype):
 
 make_complex_data = test_pyfftw_numpy_interface.make_complex_data
 
-# scipy.fftpack will raise an error for inputs of type float16, so unlike in
-# the numpy interfaces, we cannot validate vs. scipy.fftpack for float16 input
-complex_dtypes = (numpy.complex64, numpy.complex128, numpy.clongdouble)
-real_dtypes = (numpy.float32, numpy.float64, numpy.longdouble)
+if scipy.__version__ < '0.19':
+    # Older scipy will raise an error for inputs of type float16, so we
+    # cannot validate transforms with float16 input vs. scipy.fftpack
+    complex_dtypes = (numpy.complex64, numpy.complex128, numpy.clongdouble)
+    real_dtypes = (numpy.float32, numpy.float64, numpy.longdouble)
+else:
+    # reuse all dtypes from numpy tests (including float16)
+    complex_dtypes = test_pyfftw_numpy_interface.complex_dtypes
+    real_dtypes = test_pyfftw_numpy_interface.real_dtypes
 
 def numpy_fft_replacement(a, s, axes, overwrite_input, planner_effort,
         threads, auto_align_input, auto_contiguous):

--- a/test/test_pyfftw_scipy_interface.py
+++ b/test/test_pyfftw_scipy_interface.py
@@ -76,8 +76,10 @@ def make_c2r_real_data(shape, dtype):
 
 make_complex_data = test_pyfftw_numpy_interface.make_complex_data
 
-complex_dtypes = test_pyfftw_numpy_interface.complex_dtypes
-real_dtypes = test_pyfftw_numpy_interface.real_dtypes
+# scipy.fftpack will raise an error for inputs of type float16, so unlike in
+# the numpy interfaces, we cannot validate vs. scipy.fftpack for float16 input
+complex_dtypes = (numpy.complex64, numpy.complex128, numpy.clongdouble)
+real_dtypes = (numpy.float32, numpy.float64, numpy.longdouble)
 
 def numpy_fft_replacement(a, s, axes, overwrite_input, planner_effort,
         threads, auto_align_input, auto_contiguous):


### PR DESCRIPTION
This PR adds a special case for  `numpy.float16` data, causing it to be processed in single rather than double precision.  I think it makes sense to use the nearest available floating point precision in FFTW.  

a simple example:

```python
import numpy as np
from pyfftw.interfaces.numpy_fft import fftn
a = fftn(np.random.randn(32).astype(np.float16))
print(a.dtype)
```
`a` in the example above is `complex64` with this PR vs  `complex128` in current master.

If this seems acceptable, can you please point to where the best place to add a test for this would be?