### PR TITLE
Document the NumPy interface's `hfft` and `ihfft`

### DIFF
--- a/pyfftw/interfaces/numpy_fft.rst
+++ b/pyfftw/interfaces/numpy_fft.rst
@@ -2,4 +2,4 @@
 ==========================
 
 .. automodule:: pyfftw.interfaces.numpy_fft
-   :members: fft, ifft, fft2, ifft2, fftn, ifftn, rfft, irfft, rfft2, irfft2, rfftn, irfftn
+   :members: fft, ifft, fft2, ifft2, fftn, ifftn, rfft, irfft, rfft2, irfft2, rfftn, irfftn, hfft, ihfft


### PR DESCRIPTION
The `hfft` and `ihfft` functions were missing from the documentation of the NumPy interface API. So this make sure they are autodoced and linked to by Sphinx.

Edit: This should also fix some broken links [here]( http://pyfftw.github.io/pyFFTW/pyfftw/interfaces/interfaces.html#numpy-fft ) too. Building it locally confirms this.