### PR TITLE
Use org URLs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@
 
 .. |travis_ci| image:: https://travis-ci.org/pyFFTW/pyFFTW.svg?branch=master
    :align: middle
-   :target: https://travis-ci.org/hgomersall/pyFFTW
+   :target: https://travis-ci.org/pyFFTW/pyFFTW
 
 .. |appveyor_ci| image:: https://ci.appveyor.com/api/projects/status/uf854abck4x1qsjj/branch/master?svg=true
    :align: middle

--- a/index.rst
+++ b/index.rst
@@ -31,7 +31,7 @@ are included through :mod:`pyfftw.interfaces` that make using :mod:`pyfftw`
 almost equivalent to :mod:`numpy.fft` or :mod:`scipy.fftpack`.
 
 
-The source can be found in `github <https://github.com/hgomersall/pyFFTW>`_ and
+The source can be found in `github <https://github.com/pyFFTW/pyFFTW>`_ and
 its page in the python package index is `here
 <http://pypi.python.org/pypi/pyFFTW>`_.
 

--- a/setup.py
+++ b/setup.py
@@ -216,7 +216,7 @@ This should probably work for OSX, though I've not tried it.
 Numpy is a dependency for both.
 
 The documentation can be found
-`here <http://hgomersall.github.com/pyFFTW/>`_, and the source
+`here <http://pyFFTW.github.io/pyFFTW/>`_, and the source
 is on `github <https://github.com/pyFFTW/pyFFTW>`_.
 '''
 
@@ -460,7 +460,7 @@ def setup_package():
         'description': (
             'A pythonic wrapper around FFTW, the FFT library, presenting a '
             'unified interface for all the supported transforms.'),
-        'url': 'http://hgomersall.github.com/pyFFTW/',
+        'url': 'http://pyFFTW.github.io/pyFFTW/',
         'long_description': long_description,
         'classifiers': [
             'Programming Language :: Python',

--- a/setup.py
+++ b/setup.py
@@ -216,7 +216,7 @@ This should probably work for OSX, though I've not tried it.
 Numpy is a dependency for both.
 
 The documentation can be found
-`here <http://pyFFTW.github.io/pyFFTW/>`_, and the source
+`here <http://hgomersall.github.com/pyFFTW/>`_, and the source
 is on `github <https://github.com/pyFFTW/pyFFTW>`_.
 '''
 
@@ -460,7 +460,7 @@ def setup_package():
         'description': (
             'A pythonic wrapper around FFTW, the FFT library, presenting a '
             'unified interface for all the supported transforms.'),
-        'url': 'http://pyFFTW.github.io/pyFFTW/',
+        'url': 'http://hgomersall.github.com/pyFFTW/',
         'long_description': long_description,
         'classifiers': [
             'Programming Language :: Python',

--- a/setup.py
+++ b/setup.py
@@ -216,8 +216,8 @@ This should probably work for OSX, though I've not tried it.
 Numpy is a dependency for both.
 
 The documentation can be found
-`here <http://hgomersall.github.com/pyFFTW/>`_, and the source
-is on `github <https://github.com/hgomersall/pyFFTW>`_.
+`here <http://pyFFTW.github.io/pyFFTW/>`_, and the source
+is on `github <https://github.com/pyFFTW/pyFFTW>`_.
 '''
 
 class custom_build_ext(build_ext):
@@ -460,7 +460,7 @@ def setup_package():
         'description': (
             'A pythonic wrapper around FFTW, the FFT library, presenting a '
             'unified interface for all the supported transforms.'),
-        'url': 'http://hgomersall.github.com/pyFFTW/',
+        'url': 'http://pyFFTW.github.io/pyFFTW/',
         'long_description': long_description,
         'classifiers': [
             'Programming Language :: Python',


### PR DESCRIPTION
Fixes https://github.com/pyFFTW/pyFFTW/issues/146

Tries to update URLs that can be updated to point to the org. Went through and checked to make sure they are correct, but wouldn't mind a second check from someone else.

ATM it seems there is no AppVeyor project for the org. So that URL was not changed.