### PR TITLE
Configure RTD

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -16,7 +16,7 @@ import sys, os
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath('.'))
+#sys.path.insert(0, os.path.abspath('.'))
 
 # -- General configuration -----------------------------------------------------
 

--- a/conf.py
+++ b/conf.py
@@ -51,7 +51,7 @@ copyright = u'2016, Henry Gomersall'
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-from setup import VERSION as pyfftw_version
+from pyfftw.version import version as pyfftw_version
 # The short X.Y version.
 version = pyfftw_version
 # The full version, including alpha/beta/rc tags.

--- a/environment_doc.yml
+++ b/environment_doc.yml
@@ -1,0 +1,13 @@
+name: pyfftw_doc_env
+
+channels:
+  - conda-forge
+
+dependencies:
+  - cython
+  - fftw
+  - numpy
+  - python
+  - scipy
+  - dask
+  - sphinx

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,4 @@
+conda:
+  file: environment_doc.yml
+python:
+  setup_py_install: true

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,18 @@ ISRELEASED = True
 
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
+
+if os.environ.get("READTHEDOCS") == "True":
+    try:
+        environ = os.environb
+    except AttributeError:
+        environ = os.environ
+
+    environ[b"CC"] = b"x86_64-linux-gnu-gcc"
+    environ[b"LD"] = b"x86_64-linux-gnu-ld"
+    environ[b"AR"] = b"x86_64-linux-gnu-ar"
+
+
 def get_package_data():
     from pkg_resources import get_build_platform
 


### PR DESCRIPTION
Builds the docs for pyFFTW on ReadTheDocs. Requires a hack to fix use the same toolchain that ReadTheDocs uses. Also relies on PR ( https://github.com/pyFFTW/pyFFTW/pull/162 ) to set some reasonable search paths for use with `conda` packages and PR ( https://github.com/pyFFTW/pyFFTW/pull/164 ) to fix some things with the Sphinx configuration.

ref: http://jakirkhampyfftw.readthedocs.io/en/config_rtd/index.html
ref: https://readthedocs.org/projects/jakirkhampyfftw/builds/5245737

cc @hgomersall @grlee77