### PR TITLE
Check system prefix for headers and libraries

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,8 @@ def get_include_dirs():
 
     include_dirs = [os.path.join(os.getcwd(), 'include'),
                     os.path.join(os.getcwd(), 'pyfftw'),
-                    numpy.get_include()]
+                    numpy.get_include(),
+                    os.path.join(sys.prefix, 'include')]
 
     if get_build_platform() in ('win32', 'win-amd64'):
         include_dirs.append(os.path.join(os.getcwd(), 'include', 'win'))
@@ -114,7 +115,9 @@ def get_library_dirs():
     library_dirs = []
     if get_build_platform() in ('win32', 'win-amd64'):
         library_dirs.append(os.path.join(os.getcwd(), 'pyfftw'))
+        library_dirs.append(os.path.join(sys.prefix, 'bin'))
 
+    library_dirs.append(os.path.join(sys.prefix, 'lib'))
     if get_build_platform().startswith('freebsd'):
         library_dirs.append('/usr/local/lib')
 


### PR DESCRIPTION
Uses `sys.prefix` as a root search path for headers and libraries. This is where `conda` stores everything relative to. So it should simplify building `conda` packages or building in a `conda` environment with other build tools (e.g. `pip`).

cc @grlee77