### PR TITLE
Fix sphinx configuration

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -16,7 +16,7 @@ import sys, os
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath('.'))
+#sys.path.insert(0, os.path.abspath('.'))
 
 # -- General configuration -----------------------------------------------------
 

--- a/conf.py
+++ b/conf.py
@@ -51,7 +51,7 @@ copyright = u'2016, Henry Gomersall'
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-from setup import VERSION as pyfftw_version
+from pyfftw.version import version as pyfftw_version
 # The short X.Y version.
 version = pyfftw_version
 # The full version, including alpha/beta/rc tags.


### PR DESCRIPTION
Fixes a couple of things with the configuration file that came up while trying to get ReadTheDocs working.

First it stops adding the current working directory to the path. This ends up resulting in some confusion for Sphinx (with or without ReadTheDocs) in terms of where to import things from. By dropping this path manipulation, Sphinx simply tries to import `pyfftw` the standard way. So if it was installed in `site-packages`, this will import it from there. Also it works just as well with development installs. Regardless it ensures it is importing only the fully built `pyfftw` and not the unbuilt source, which causes problems.

Second it gets the version information from `pyfftw.version`, which should exist in the fully built `pyfftw` instead of resorting to using the `setup.py` file. Importing the latter could have all sorts of weird, unintended side effects. The same problems are not true of `pyfftw.version`. Thus it works just as well and is cleaner.