### PR TITLE
extend the norm argument as implemented in the numpy interface to the builders

### DIFF
--- a/docs/source/pyfftw/pyfftw.rst
+++ b/docs/source/pyfftw/pyfftw.rst
@@ -38,6 +38,10 @@ FFTW Class
 
    .. autoattribute:: pyfftw.FFTW.axes
 
+   .. autoattribute:: pyfftw.FFTW.ortho
+
+   .. autoattribute:: pyfftw.FFTW.normalise_idft
+
    .. automethod:: pyfftw.FFTW.__call__
 
    .. automethod:: pyfftw.FFTW.update_arrays

--- a/pyfftw/builders/builders.py
+++ b/pyfftw/builders/builders.py
@@ -256,7 +256,8 @@ The exceptions raised by each of these functions are as per their
 equivalents in :mod:`numpy.fft`, or as documented above.
 '''
 
-from ._utils import _precook_1d_args, _Xfftn
+from ._utils import _precook_1d_args, _Xfftn, _norm_args
+
 
 __all__ = ['fft','ifft', 'fft2', 'ifft2', 'fftn',
            'ifftn', 'rfft', 'irfft', 'rfft2', 'irfft2', 'rfftn',
@@ -266,7 +267,7 @@ __all__ = ['fft','ifft', 'fft2', 'ifft2', 'fftn',
 def fft(a, n=None, axis=-1, overwrite_input=False,
         planner_effort='FFTW_MEASURE', threads=1,
         auto_align_input=True, auto_contiguous=True,
-        avoid_copy=False):
+        avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a 1D FFT.
 
     The first three arguments are as per :func:`numpy.fft.fft`;
@@ -280,12 +281,12 @@ def fft(a, n=None, axis=-1, overwrite_input=False,
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
-            avoid_copy, inverse, real)
+            avoid_copy, inverse, real, **_norm_args(norm))
 
 def ifft(a, n=None, axis=-1, overwrite_input=False,
         planner_effort='FFTW_MEASURE', threads=1,
         auto_align_input=True, auto_contiguous=True,
-        avoid_copy=False):
+        avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a 1D
     inverse FFT.
 
@@ -301,13 +302,13 @@ def ifft(a, n=None, axis=-1, overwrite_input=False,
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
-            avoid_copy, inverse, real)
+            avoid_copy, inverse, real, **_norm_args(norm))
 
 
 def fft2(a, s=None, axes=(-2,-1), overwrite_input=False,
         planner_effort='FFTW_MEASURE', threads=1,
         auto_align_input=True, auto_contiguous=True,
-        avoid_copy=False):
+        avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a 2D FFT.
 
     The first three arguments are as per :func:`numpy.fft.fft2`;
@@ -321,12 +322,12 @@ def fft2(a, s=None, axes=(-2,-1), overwrite_input=False,
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
-            avoid_copy, inverse, real)
+            avoid_copy, inverse, real, **_norm_args(norm))
 
 def ifft2(a, s=None, axes=(-2,-1), overwrite_input=False,
         planner_effort='FFTW_MEASURE', threads=1,
         auto_align_input=True, auto_contiguous=True,
-        avoid_copy=False):
+        avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a
     2D inverse FFT.
 
@@ -341,13 +342,13 @@ def ifft2(a, s=None, axes=(-2,-1), overwrite_input=False,
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
-            avoid_copy, inverse, real)
+            avoid_copy, inverse, real, **_norm_args(norm))
 
 
 def fftn(a, s=None, axes=None, overwrite_input=False,
         planner_effort='FFTW_MEASURE', threads=1,
         auto_align_input=True, auto_contiguous=True,
-        avoid_copy=False):
+        avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a n-D FFT.
 
     The first three arguments are as per :func:`numpy.fft.fftn`;
@@ -361,12 +362,12 @@ def fftn(a, s=None, axes=None, overwrite_input=False,
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
-            avoid_copy, inverse, real)
+            avoid_copy, inverse, real, **_norm_args(norm))
 
 def ifftn(a, s=None, axes=None, overwrite_input=False,
         planner_effort='FFTW_MEASURE', threads=1,
         auto_align_input=True, auto_contiguous=True,
-        avoid_copy=False):
+        avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing an n-D
     inverse FFT.
 
@@ -381,12 +382,12 @@ def ifftn(a, s=None, axes=None, overwrite_input=False,
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
-            avoid_copy, inverse, real)
+            avoid_copy, inverse, real, **_norm_args(norm))
 
 def rfft(a, n=None, axis=-1, overwrite_input=False,
         planner_effort='FFTW_MEASURE', threads=1,
         auto_align_input=True, auto_contiguous=True,
-        avoid_copy=False):
+        avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a 1D
     real FFT.
 
@@ -403,12 +404,12 @@ def rfft(a, n=None, axis=-1, overwrite_input=False,
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
-            avoid_copy, inverse, real)
+            avoid_copy, inverse, real, **_norm_args(norm))
 
 def irfft(a, n=None, axis=-1, overwrite_input=False,
         planner_effort='FFTW_MEASURE', threads=1,
         auto_align_input=True, auto_contiguous=True,
-        avoid_copy=False):
+        avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a 1D
     real inverse FFT.
 
@@ -425,12 +426,12 @@ def irfft(a, n=None, axis=-1, overwrite_input=False,
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
-            avoid_copy, inverse, real)
+            avoid_copy, inverse, real, **_norm_args(norm))
 
 def rfft2(a, s=None, axes=(-2,-1), overwrite_input=False,
         planner_effort='FFTW_MEASURE', threads=1,
         auto_align_input=True, auto_contiguous=True,
-        avoid_copy=False):
+        avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a 2D
     real FFT.
 
@@ -444,12 +445,12 @@ def rfft2(a, s=None, axes=(-2,-1), overwrite_input=False,
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
-            avoid_copy, inverse, real)
+            avoid_copy, inverse, real, **_norm_args(norm))
 
 def irfft2(a, s=None, axes=(-2,-1),
         planner_effort='FFTW_MEASURE', threads=1,
         auto_align_input=True, auto_contiguous=True,
-        avoid_copy=False):
+        avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a 2D
     real inverse FFT.
 
@@ -466,13 +467,13 @@ def irfft2(a, s=None, axes=(-2,-1),
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
-            avoid_copy, inverse, real)
+            avoid_copy, inverse, real, **_norm_args(norm))
 
 
 def rfftn(a, s=None, axes=None, overwrite_input=False,
         planner_effort='FFTW_MEASURE', threads=1,
         auto_align_input=True, auto_contiguous=True,
-        avoid_copy=False):
+        avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing an n-D
     real FFT.
 
@@ -487,13 +488,13 @@ def rfftn(a, s=None, axes=None, overwrite_input=False,
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
-            avoid_copy, inverse, real)
+            avoid_copy, inverse, real, **_norm_args(norm))
 
 
 def irfftn(a, s=None, axes=None,
         planner_effort='FFTW_MEASURE', threads=1,
         auto_align_input=True, auto_contiguous=True,
-        avoid_copy=False):
+        avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing an n-D
     real inverse FFT.
 
@@ -510,4 +511,4 @@ def irfftn(a, s=None, axes=None,
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
-            avoid_copy, inverse, real)
+            avoid_copy, inverse, real, **_norm_args(norm))

--- a/pyfftw/builders/builders.py
+++ b/pyfftw/builders/builders.py
@@ -94,6 +94,13 @@ not necessarily the case that the internal array *is* the input array.
 The actual internal input array can always be retrieved with
 :attr:`pyfftw.FFTW.input_array`.
 
+The behaviour of the ``norm`` option in all builder routines matches that of
+the corresponding numpy functions.  In short, if ``norm`` is ``None``, then the
+output from the forward DFT is unscaled and the inverse DFT is scaled by 1/N,
+where N is the product of the lengths of input array on which the FFT is taken.
+If ``norm == 'ortho'``, then the output of both forward and inverse DFT
+operations are scaled by 1/sqrt(N).
+
 **Example:**
 
 .. doctest::

--- a/pyfftw/interfaces/_utils.py
+++ b/pyfftw/interfaces/_utils.py
@@ -46,6 +46,7 @@ import pyfftw
 import numpy
 from . import cache
 
+
 def _Xfftn(a, s, axes, overwrite_input, planner_effort,
         threads, auto_align_input, auto_contiguous,
         calling_func, normalise_idft=True, ortho=False):

--- a/pyfftw/interfaces/numpy_fft.py
+++ b/pyfftw/interfaces/numpy_fft.py
@@ -58,6 +58,7 @@ which this may not be true.
 '''
 
 from ._utils import _Xfftn
+from ..builders._utils import _norm_args, _unitary
 
 # Complete the namespace (these are not actually used in this module)
 from numpy.fft import fftfreq, fftshift, ifftshift
@@ -67,22 +68,6 @@ __all__ = ['fft','ifft', 'fft2', 'ifft2', 'fftn', 'ifftn',
            'rfft', 'irfft', 'rfft2', 'irfft2', 'rfftn', 'irfftn',
            'hfft', 'ihfft', 'fftfreq', 'fftshift', 'ifftshift']
 
-def _unitary(norm):
-    """_unitary() utility copied from numpy"""
-    if norm not in (None, "ortho"):
-        raise ValueError("Invalid norm value %s, should be None or \"ortho\"."
-                         % norm)
-    return norm is not None
-
-def _norm_args(norm):
-    """ pass the proper normalization-related keyword arguments. """
-    if _unitary(norm):
-        ortho = True
-        normalise_idft = False
-    else:
-        ortho = False
-        normalise_idft = True
-    return dict(normalise_idft=normalise_idft, ortho=ortho)
 
 def fft(a, n=None, axis=-1, norm=None, overwrite_input=False,
         planner_effort='FFTW_ESTIMATE', threads=1,
@@ -95,12 +80,6 @@ def fft(a, n=None, axis=-1, norm=None, overwrite_input=False,
     '''
 
     calling_func = 'fft'
-    if _unitary(norm):
-        ortho = True
-        normalise_idft = False
-    else:
-        ortho = False
-        normalise_idft = True
 
     return _Xfftn(a, n, axis, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,

--- a/pyfftw/pyfftw.pyx
+++ b/pyfftw/pyfftw.pyx
@@ -833,7 +833,7 @@ cdef class FFTW:
     def __cinit__(self, input_array, output_array, axes=(-1,),
                   direction='FFTW_FORWARD', flags=('FFTW_MEASURE',),
                   unsigned int threads=1, planning_timelimit=None,
-                  normalise_idft=True, ortho=False,
+                  bint normalise_idft=True, bint ortho=False,
                   *args, **kwargs):
 
         # Initialise the pointers that need to be freed

--- a/pyfftw/pyfftw.pyx
+++ b/pyfftw/pyfftw.pyx
@@ -815,8 +815,7 @@ cdef class FFTW:
 
     def _get_normalise_idft(self):
         '''
-        If normalise_idft, the inverse transform is scaled by 1/N.
-        N is the product of the shape along the transformed axes.
+        If ``normalise_idft=True``, the inverse transform is scaled by 1/N.
         '''
         return self._normalise_idft
 
@@ -824,7 +823,7 @@ cdef class FFTW:
 
     def _get_ortho(self):
         '''
-        If ortho both the forward and inverse transforms are scaled by
+        If ``ortho=True`` both the forward and inverse transforms are scaled by
         1/sqrt(N).
         '''
         return self._ortho

--- a/pyfftw/pyfftw.pyx
+++ b/pyfftw/pyfftw.pyx
@@ -848,7 +848,7 @@ cdef class FFTW:
         self._normalise_idft = normalise_idft
         self._ortho = ortho
         if self._ortho and self._normalise_idft:
-            raise ValueError('Incompatible normalization options: '
+            raise ValueError('Invalid options: '
                 'ortho and normalise_idft cannot both be True.')
 
         flags = list(flags)

--- a/pyfftw/pyfftw.pyx
+++ b/pyfftw/pyfftw.pyx
@@ -665,6 +665,10 @@ cdef class FFTW:
     cdef int64_t *_not_axes
 
     cdef int64_t _N
+
+    cdef bint _normalise_idft
+    cdef bint _ortho
+
     def _get_N(self):
         '''
         The product of the lengths of the DFT over all DFT axes.
@@ -809,9 +813,28 @@ cdef class FFTW:
 
     axes = property(_get_axes)
 
+    def _get_normalise_idft(self):
+        '''
+        If normalise_idft, the inverse transform is scaled by 1/N.
+        N is the product of the shape along the transformed axes.
+        '''
+        return self._normalise_idft
+
+    normalise_idft = property(_get_normalise_idft)
+
+    def _get_ortho(self):
+        '''
+        If ortho both the forward and inverse transforms are scaled by
+        1/sqrt(N).
+        '''
+        return self._ortho
+
+    ortho = property(_get_ortho)
+
     def __cinit__(self, input_array, output_array, axes=(-1,),
                   direction='FFTW_FORWARD', flags=('FFTW_MEASURE',),
                   unsigned int threads=1, planning_timelimit=None,
+                  normalise_idft=True, ortho=False,
                   *args, **kwargs):
 
         # Initialise the pointers that need to be freed
@@ -821,6 +844,12 @@ cdef class FFTW:
 
         self._axes = NULL
         self._not_axes = NULL
+
+        self._normalise_idft = normalise_idft
+        self._ortho = ortho
+        if self._ortho and self._normalise_idft:
+            raise ValueError('Incompatible normalization options: '
+                'ortho and normalise_idft cannot both be True.')
 
         flags = list(flags)
 
@@ -1114,7 +1143,8 @@ cdef class FFTW:
 
     def __init__(self, input_array, output_array, axes=(-1,),
             direction='FFTW_FORWARD', flags=('FFTW_MEASURE',),
-            int threads=1, planning_timelimit=None):
+            int threads=1, planning_timelimit=None,
+            normalise_idft=True, ortho=False):
         '''
         **Arguments**:
 
@@ -1319,7 +1349,6 @@ cdef class FFTW:
         transform (which :class:`pyfftw.FFTW` will handle for you when
         accessed through :meth:`~pyfftw.FFTW.__call__`).
         '''
-        pass
 
     def __dealloc__(self):
 
@@ -1339,7 +1368,7 @@ cdef class FFTW:
             free(self._howmany_dims)
 
     def __call__(self, input_array=None, output_array=None,
-            normalise_idft=True, ortho=False):
+            normalise_idft=None, ortho=None):
         '''__call__(input_array=None, output_array=None, normalise_idft=True,
                     ortho=False)
 
@@ -1407,6 +1436,11 @@ cdef class FFTW:
         need the data to persist longer than a subsequent call, you should
         copy the returned array.
         '''
+
+        if ortho is None:
+            ortho = self._ortho
+        if normalise_idft is None:
+            normalise_idft = self._normalise_idft
 
         if ortho and normalise_idft:
             raise ValueError('Invalid options: ortho and normalise_idft cannot'

--- a/test/test_pyfftw_class_misc.py
+++ b/test/test_pyfftw_class_misc.py
@@ -342,6 +342,31 @@ class FFTWMiscTest(unittest.TestCase):
         new_fft = FFTW(self.input_array, self.output_array, axes=(0,))
         self.assertEqual(new_fft.axes, (0,))
 
+    def test_ortho_property(self):
+        '''ortho property defaults to False
+        '''
+        self.assertEqual(self.fft.ortho, False)
+
+        newfft = FFTW(self.input_array, self.output_array, ortho=True,
+                      normalise_idft=False)
+        self.assertEqual(newfft.ortho, True)
+
+    def test_normalise_idft_property(self):
+        '''normalise_idft property defaults to True
+        '''
+        self.assertEqual(self.fft.normalise_idft, True)
+
+        newfft = FFTW(self.input_array, self.output_array,
+                      normalise_idft=False)
+        self.assertEqual(newfft.normalise_idft, False)
+
+    def test_invalid_normalisation(self):
+        # both ortho and normalise_idft cannot be True
+        self.assertRaisesRegex(
+            ValueError, 'Invalid options: ortho',
+            FFTW, self.input_array, self.output_array,
+            direction='FFTW_BACKWARD', ortho=True, normalise_idft=True)
+
 test_cases = (
         FFTWMiscTest,)
 


### PR DESCRIPTION
This allows the FFTW builders to all take either `norm=None` (matches the current behaviour) or `norm='ortho'`in exactly the same way as the numpy interfaces.

In implementing, this two of the arguments from the `__call__` method of the core FFTW class were also added to the `__cinit__` method.  These are the `ortho` and `normalise_idft` arguments related to normalisation.  This allows the default normalisation to be set at the time of class initialization, but this choice can still be overridden by passing explicit values to the `__call__` method if desired.

The private convenience functions for normalisation argument handling ( `_norm_args` and `_unitary`) were moved from `pyfftw.interfaces.numpy_fft.py` to `pyfftw.builders._utils.py` as they are now used by both the builder and numpy interface routines.
