### PR TITLE
DOC: add next_fast_len to the interfaces docs too

### DIFF
--- a/docs/source/pyfftw/interfaces/scipy_fftpack.rst
+++ b/docs/source/pyfftw/interfaces/scipy_fftpack.rst
@@ -2,4 +2,4 @@
 ==============================
 
 .. automodule:: pyfftw.interfaces.scipy_fftpack
-   :members: fft, ifft, fftn, ifftn, rfft, irfft, fft2, ifft2
+   :members: fft, ifft, fftn, ifftn, rfft, irfft, fft2, ifft2, next_fast_len

--- a/pyfftw/interfaces/__init__.py
+++ b/pyfftw/interfaces/__init__.py
@@ -127,6 +127,7 @@ being taken along that axes as many times as the axis occurs.
 * :func:`pyfftw.interfaces.scipy_fftpack.ifftn`
 * :func:`pyfftw.interfaces.scipy_fftpack.rfft`
 * :func:`pyfftw.interfaces.scipy_fftpack.irfft`
+* :func:`pyfftw.interfaces.scipy_fftpack.next_fast_len`
 
 :mod:`~pyfftw.interfaces.dask_fft`
 """""""""""""""""""""""""""""""""""


### PR DESCRIPTION
This PR edits the docs to get the recently added `next_fast_len` to also show up under the `scipy.fftpack` interfaces section.  Users would likely look for it there as its purpose matches the function of the same name in scipy's fftpack.

prior to this PR, it is currently only visible under `Utility Functions` in the PyFFTW core section.

p.s. do you want to configure the Labels in this repo to also have a label for "documentation"?  I didn't see one in the dropdown list at the right.

