### PR TITLE
BLD: no conda package for numpy1.9 on Python3.6 so bump to 1.10.4

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
         CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
         # The miniconda installations are put in pyfftw_miniconda
         PYTHON_HOME: "C:\\pyfftw_miniconda"
+        NP_BUILD_DEP: "1.9"
 
     pypi_username:
         secure: qFSpEDsIOj6gzynjuHTX5A==
@@ -48,10 +49,12 @@ environment:
         - PYTHON_HOME: "C:\\Miniconda36"
           PYTHON_ARCH: "32"
           PYTHON_VERSION: "3.6"
+          NP_BUILD_DEP: "1.11"
 
         - PYTHON_HOME: "C:\\Miniconda36-x64"
           PYTHON_ARCH: "64"
           PYTHON_VERSION: "3.6"
+          NP_BUILD_DEP: "1.11"
 
 
 install:
@@ -65,7 +68,7 @@ install:
 
     - "conda config --set always_yes yes --set changeps1 no"
     - "conda update -q conda"
-    - "conda create -q -n build_env python=%PYTHON_VERSION% numpy=1.9 scipy cython dask setuptools"
+    - "conda create -q -n build_env python=%PYTHON_VERSION% numpy=%NP_BUILD_DEP% scipy cython dask setuptools"
     - "activate build_env"
     - "%CMD_IN_ENV% python setup.py bdist_wheel"
     - "%CMD_IN_ENV% python setup.py build_ext --inplace"


### PR DESCRIPTION
bump NumPy up to 1.10 on Appveyor so a conda package will exist for Python 3.6

Note:  as implemented this changes all versions to build against 1.10, but could be modified to keep the rest at 1.9 if that is preferred.