### PR TITLE
Disable norm as a keyword argument in Dask test

### DIFF
--- a/test/test_pyfftw_dask_interface.py
+++ b/test/test_pyfftw_dask_interface.py
@@ -559,6 +559,7 @@ class InterfacesDaskFFTTestFFT(unittest.TestCase):
 
 class InterfacesDaskFFTTestIFFT(InterfacesDaskFFTTestFFT):
     func = 'ifft'
+    has_norm_kwarg = False
 
 class InterfacesDaskFFTTestRFFT(InterfacesDaskFFTTestFFT):
     func = 'rfft'


### PR DESCRIPTION
Add another `has_norm_kwarg` to another test of the Dask FFT interface as it the Dask functions do not accept the `norm` keyword argument.