### PR TITLE
 include documentation in the source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -17,9 +17,6 @@ recursive-include docs *
 # Exclude built docs
 prune docs/_build
 
-# exclude Cython-generated source files
-exclude pyfftw/pyfftw.c
-
 # exclude built libraries, swap files, etc.
 prune build
 prune */__pycache__

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,6 +9,19 @@ include pyfftw/utils.pxi
 include test/*.py
 include conf.py
 include index.rst
-recursive-include pyfftw *.rst
-recursive-include sphinx *.rst
 recursive-include include *.h
+
+# All documentation
+recursive-include docs *
+
+# Exclude built docs
+prune docs/_build
+
+# exclude Cython-generated source files
+exclude pyfftw/pyfftw.c
+
+# exclude built libraries, swap files, etc.
+prune build
+prune */__pycache__
+global-exclude *.py[cod] *.so *.dll *.dylib
+global-exclude *~ *.bak *.swp


### PR DESCRIPTION
Updates MANIFEST.in so the docs will get properly included in the sdist.

~~While I was there, I also addressed #31 (exclude cython-generated files from the source distribution)~~

closes #32
closes #86
