### PR TITLE
fix build-time fftw library detection for compatibility with conda-forge

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,9 @@ def get_include_dirs():
                     numpy.get_include(),
                     os.path.join(sys.prefix, 'include')]
 
+    if 'PYFFTW_INCLUDE' in os.environ:
+        include_dirs.append(os.environ['PYFFTW_INCLUDE'])
+
     if get_build_platform() in ('win32', 'win-amd64'):
         include_dirs.append(os.path.join(os.getcwd(), 'include', 'win'))
 

--- a/setup.py
+++ b/setup.py
@@ -599,7 +599,10 @@ class custom_build_ext(build_ext):
 
         libraries = sniffer.libraries or None
         if self.libraries is not None:
-            libraries += self.libraries
+            if libraries is None:
+                libraries = self.libraries
+            else:
+                libraries += self.libraries
         self.compiler.libraries.extend(libraries)
 
         library_dirs = sniffer.library_dirs


### PR DESCRIPTION
I was trying out the proposed changes from pyFFTW/pyFFTW#177 with the pyFFTW recipe from conda-forge. I had to make a couple of small tweaks for everything to work properly.

The first commit here just defines an environment variable, `PYFFTW_USE_PTHREADS`, so that the user could select a preference for pthreads in the event that both the OpenMP and pthreads variants are available. This part was not necessary for getting the conda-forge recipe to work, but I think it is a good idea to allow user control of which threading library to use.

The conda-forge FFTW packages currently don't build the OpenMP variant. I found that the pthreads variant did not get detected properly, because the sniffer would fail to compile the threading example unless the `-pthread` argument was passed to gcc. When I ran this on my linux system without conda build the `-pthread` flag seemed to get automatically added somehow, but this was not the case when I ran it via conda build. This might be due to differences in gcc compiler versions, but I'm not sure. The second commit in this PR explicitly adds the -pthread argument when needed. When I tested the conda recipe on OS X, clang prints a message saying the the -pthread flag was ignored, but the threading libraries do still get detected properly.

The third commit here fixes an issue I encountered on OS X where the library list is empty (due to no `-lm` needed on OS X) while the sniffer library list was not. Prior to this tweak, there was an attempt to add a list to None which gave an error.