### PR TITLE
update interfaces.scipy_fftpack namespace

### DIFF
--- a/pyfftw/interfaces/scipy_fftpack.py
+++ b/pyfftw/interfaces/scipy_fftpack.py
@@ -60,7 +60,7 @@ from . import numpy_fft
 import numpy
 
 # Complete the namespace (these are not actually used in this module)
-from scipy.fftpack import (dct, idct, diff, tilbert, itilbert,
+from scipy.fftpack import (dct, idct, dst, idst, diff, tilbert, itilbert,
         hilbert, ihilbert, cs_diff, sc_diff, ss_diff, cc_diff,
         shift, fftshift, ifftshift, fftfreq, rfftfreq,
         convolve, _fftpack)
@@ -68,15 +68,13 @@ from scipy.fftpack import (dct, idct, diff, tilbert, itilbert,
 # a next_fast_len specific to pyFFTW is used in place of the scipy.fftpack one
 from ..pyfftw import next_fast_len
 
-try:
-    from scipy.fftpack import dst, idst
-except ImportError:
-    pass
 
-__all__ = ['fft','ifft','fftn','ifftn','rfft','irfft', 'fft2','ifft2',
-        'diff', 'tilbert','itilbert','hilbert','ihilbert', 'sc_diff',
-        'cs_diff','cc_diff','ss_diff', 'shift', 'rfftfreq',
-        'next_fast_len']
+__all__ = ['fft', 'ifft', 'fftn', 'ifftn', 'rfft', 'irfft', 'fft2', 'ifft2',
+           'dct', 'idct', 'dst', 'idst', 'diff', 'tilbert', 'itilbert',
+           'hilbert', 'ihilbert', 'cs_diff', 'sc_diff', 'ss_diff', 'cc_diff',
+           'shift', 'fftshift', 'ifftshift', 'fftfreq', 'rfftfreq', 'convolve',
+           'next_fast_len', ]
+
 
 def fft(x, n=None, axis=-1, overwrite_x=False,
         planner_effort='FFTW_ESTIMATE', threads=1,

--- a/pyfftw/interfaces/scipy_fftpack.py
+++ b/pyfftw/interfaces/scipy_fftpack.py
@@ -75,6 +75,12 @@ __all__ = ['fft', 'ifft', 'fftn', 'ifftn', 'rfft', 'irfft', 'fft2', 'ifft2',
            'shift', 'fftshift', 'ifftshift', 'fftfreq', 'rfftfreq', 'convolve',
            'next_fast_len', ]
 
+try:
+    from scipy.fftpack import dctn, idctn, dstn, idstn
+    __all__ += ['dctn', 'idctn', 'dstn', 'idstn']
+except ImportError:
+    pass
+
 
 def fft(x, n=None, axis=-1, overwrite_x=False,
         planner_effort='FFTW_ESTIMATE', threads=1,


### PR DESCRIPTION
update the `scipy` interface to reflect the current `scipy` minimum version.  For 0.12 as specified in `requirements.txt`, `dst` and `idst` will always be present.  Some other functions such as `fftshift`, `ifftshift` were also missing from `__all__` and have been added.

In the second commit, I add a check for four new n-dimensional routines that are present in current `scipy `master and will be released with `scipy` 1.0