### PR TITLE
[setup, pyx] Build only the parts for which FFTW libraries were found

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,9 @@ install:
   - source activate test-environment
   - python setup.py -v build_ext --inplace
 
-script: python setup.py test
+script:
+  - python setup.py test
+  - travis/partial.sh
 
 before_deploy:
   - rvm default

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,9 @@ Requirements (i.e. what it was designed for)
 --------------------------------------------
 - Python 2.7 or greater (Python 3 is supported)
 - Numpy 1.6
-- FFTW 3.3 or higher (lower versions *may* work)
+- FFTW 3.3 or higher (lower versions *may* work) libraries for single, double,
+  and long double precision in serial and multithreading (pthreads or openMP)
+  versions
 - Cython 0.15 or higher (though the source release on PyPI loses this
   dependency)
 
@@ -99,6 +101,16 @@ After you've run ``setup.py`` with cython available, you then have a
 normal C extension in the ``pyfftw`` directory.
 Further building does not depend on cython (as long as the .c file remains).
 
+During configuration the available FFTW libraries are detected, so pay attention
+to the output when running ``setup.py``. On certain platforms, for example the
+long double precision is not available. pyFFTW still builds fine but will fail
+at runtime if asked to perform a transform involving long double precision.
+
+Regarding multithreading, if both posix and openMP FFTW libs are available, the
+openMP libs are preferred. This preference can be reversed by defining the
+environment variable ``PYFFTW_USE_PTHREADS`` prior to building. If neither
+option is available, pyFFTW works in serial mode only.
+
 For more ways of building and installing, see the
 `distutils documentation <http://docs.python.org/distutils/builtdist.html>`_
 and `setuptools documentation <https://pythonhosted.org/setuptools/>`_.
@@ -109,23 +121,23 @@ Platform specific build info
 Windows
 ~~~~~~~
 
-To build for windows from source, download the fftw dlls for your system
-and the header file from `here <http://www.fftw.org/install/windows.html>`_
-(they're in a zip file) and place them in the pyfftw
-directory. The files are ``libfftw3-3.dll``, ``libfftw3l-3.dll``,
-``libfftw3f-3.dll``. If you're using a version of FFTW other than 3.3, it may
-be necessary to copy ``fftw3.h`` into ``include\win``.
+To build for windows from source, download the fftw dlls for your system and the
+header file from `here <http://www.fftw.org/install/windows.html>`_ (they're in
+a zip file) and place them in the pyfftw directory. The files are
+``libfftw3-3.dll``, ``libfftw3l-3.dll``, ``libfftw3f-3.dll``. These libs use
+pthreads for multithreading. If you're using a version of FFTW other than 3.3,
+it may be necessary to copy ``fftw3.h`` into ``include\win``.
 
 The builds on PyPI use mingw for the 32-bit release and the Windows SDK
 C++ compiler for the 64-bit release. The scripts should handle this
 automatically. If you want to compile for 64-bit Windows, you have to use
 the MS Visual C++ compiler. Set up your environment as described
 `here <https://github.com/cython/cython/wiki/CythonExtensionsOnWindows>`_ and then
-run `setup.py` with the version of python you wish to target and a suitable
+run ``setup.py`` with the version of python you wish to target and a suitable
 build command.
 
 For using the MS Visual C++ compiler, you'll need to create a set of
-suitable `.lib` files as described on the
+suitable ``.lib`` files as described on the
 `FFTW page <http://www.fftw.org/install/windows.html>`_.
 
 Mac OSX
@@ -144,8 +156,9 @@ Now install pyfftw from pip::
 
   pip install pyfftw
 
-Notes: `pkgin <http://saveosx.org>`_ fftw package does not contain the long
-or float implementations of fftw and so installation will fail.
+Notes: `pkgin <http://saveosx.org>`_ fftw package does not contain the long or
+float implementations of fftw and so pyFFTW can only perform double-precision
+transforms.
 
 It has been suggested that `macports <http://www.macports.org/>`_ might also
 work fine. You should then replace the LD environmental variables above with the
@@ -163,7 +176,7 @@ Install FFTW from ports tree or ``pkg``:
     - math/fftw3-float
     - math/fftw3-long
 
-Please install all of them.
+Please install all of them, if possible.
 
 Contributions
 -------------

--- a/pyfftw/__init__.py
+++ b/pyfftw/__init__.py
@@ -26,6 +26,7 @@ from .pyfftw import (
         ones_aligned,
         zeros_aligned,
         next_fast_len,
+        supported_types,
 )
 
 from . import builders

--- a/pyfftw/__init__.py
+++ b/pyfftw/__init__.py
@@ -30,6 +30,7 @@ from .pyfftw import (
         _supported_nptypes_complex,
         _supported_nptypes_real,
         _all_types_human_readable,
+        _all_types_np
 )
 
 from . import builders

--- a/pyfftw/__init__.py
+++ b/pyfftw/__init__.py
@@ -26,7 +26,10 @@ from .pyfftw import (
         ones_aligned,
         zeros_aligned,
         next_fast_len,
-        supported_types,
+        _supported_types,
+        _supported_nptypes_complex,
+        _supported_nptypes_real,
+        _all_types_human_readable,
 )
 
 from . import builders

--- a/pyfftw/interfaces/numpy_fft.py
+++ b/pyfftw/interfaces/numpy_fft.py
@@ -39,13 +39,15 @@ of :mod:`numpy.fft`, but those functions that are not included here are imported
 directly from :mod:`numpy.fft`.
 
 
-It is notable that unlike :mod:`numpy.fftpack`, these functions will
-generally return an output array with the same precision as the input
-array, and the transform that is chosen is chosen based on the precision
-of the input array. That is, if the input array is 32-bit floating point,
-then the transform will be 32-bit floating point and so will the returned
-array. Half precision input will be converted to single precision.  Otherwise,
-if any type conversion is required, the default will be double precision.
+It is notable that unlike :mod:`numpy.fftpack`, these functions will generally
+return an output array with the same precision as the input array, and the
+transform that is chosen is chosen based on the precision of the input array.
+That is, if the input array is 32-bit floating point, then the transform will
+be 32-bit floating point and so will the returned array. Half precision input
+will be converted to single precision. Otherwise, if any type conversion is
+required, the default will be double precision. If pyFFTW was not built with
+support for double precision, the default is long double precision. If that is not
+available, it defaults to single precision.
 
 One known caveat is that repeated axes are handled differently to
 :mod:`numpy.fft`; axes that are repeated in the axes argument are considered

--- a/pyfftw/pyfftw.pyx
+++ b/pyfftw/pyfftw.pyx
@@ -55,6 +55,12 @@ _all_types_human_readable = {
     'ld': 'long double',
 }
 
+_all_types_np = {
+    np.dtype(np.float32): '32',
+    np.dtype(np.float64): '64',
+    np.dtype(np.longdouble): 'ld'
+}
+
 # the types supported in this build
 _supported_types = []
 _supported_nptypes_complex = []

--- a/pyfftw/pyfftw.pyx
+++ b/pyfftw/pyfftw.pyx
@@ -114,6 +114,14 @@ cdef object plan_lock = threading.Lock()
 #     Planners
 #     ========
 #
+cdef void* _fftw_plan_null(
+            int rank, fftw_iodim *dims,
+            int howmany_rank, fftw_iodim *howmany_dims,
+            void *_in, void *_out,
+            int sign, unsigned flags):
+
+    raise RuntimeError("Undefined planner. This is a bug")
+
 # Complex double precision
 IF HAVE_DOUBLE:
     cdef void* _fftw_plan_guru_dft(
@@ -228,6 +236,11 @@ IF HAVE_LONG:
 #    Executors
 #    =========
 #
+
+cdef void _fftw_execute_null(void *_plan, void *_in, void *_out):
+
+    raise RuntimeError("Undefined executor. This is a bug")
+
 IF HAVE_DOUBLE:
     # Complex double precision
     cdef void _fftw_execute_dft(void *_plan, void *_in, void *_out) nogil:
@@ -288,6 +301,10 @@ IF HAVE_LONG:
 #    Destroyers
 #    ==========
 #
+cdef void _fftw_destroy_null(void *plan):
+
+    raise RuntimeError("Undefined destroy. This is a bug")
+
 IF HAVE_DOUBLE:
     # Double precision
     cdef void _fftw_destroy_plan(void *_plan):
@@ -314,7 +331,7 @@ cdef fftw_generic_plan_guru planners[9]
 
 cdef fftw_generic_plan_guru * _build_planner_list():
     for i in range(9):
-        planners[i] = NULL
+        planners[i] = <fftw_generic_plan_guru>&_fftw_plan_null
 
     IF HAVE_DOUBLE:
         planners[0] = <fftw_generic_plan_guru>&_fftw_plan_guru_dft
@@ -334,7 +351,7 @@ cdef fftw_generic_execute executors[9]
 
 cdef fftw_generic_execute * _build_executor_list():
     for i in range(9):
-        executors[i] = NULL
+        executors[i] = <fftw_generic_execute>&_fftw_execute_null
 
     IF HAVE_DOUBLE:
         executors[0] = <fftw_generic_execute>&_fftw_execute_dft
@@ -354,7 +371,7 @@ cdef fftw_generic_destroy_plan destroyers[3]
 
 cdef fftw_generic_destroy_plan * _build_destroyer_list():
     for i in range(3):
-        destroyers[i] = NULL
+        destroyers[i] = <fftw_generic_destroy_plan>&_fftw_destroy_null
 
     IF HAVE_DOUBLE:
         destroyers[0] = <fftw_generic_destroy_plan>&_fftw_destroy_plan
@@ -366,13 +383,14 @@ cdef fftw_generic_destroy_plan * _build_destroyer_list():
 # nthreads plan setters table
 cdef fftw_generic_plan_with_nthreads nthreads_plan_setters[3]
 
-cdef void _fftw_plan_with_nthreads_dummy(int n): pass
+cdef void _fftw_plan_with_nthreads_null(int n):
+
+    raise RuntimeError("Undefined plan with nthreads. This is a bug")
 
 cdef fftw_generic_plan_with_nthreads * _build_nthreads_plan_setters_list():
     for i in range(3):
         nthreads_plan_setters[i] = (
-            <fftw_generic_plan_with_nthreads>&_fftw_plan_with_nthreads_dummy)
-
+            <fftw_generic_plan_with_nthreads>&_fftw_plan_with_nthreads_null)
     IF HAVE_DOUBLE_MULTITHREADING:
         nthreads_plan_setters[0] = (
             <fftw_generic_plan_with_nthreads>&fftw_plan_with_nthreads)
@@ -386,9 +404,14 @@ cdef fftw_generic_plan_with_nthreads * _build_nthreads_plan_setters_list():
 # Set planner timelimits
 cdef fftw_generic_set_timelimit set_timelimit_funcs[3]
 
+cdef void _fftw_generic_set_timelimit_null(void *plan):
+
+    raise RuntimeError("Undefined set timelimit. This is a bug")
+
 cdef fftw_generic_set_timelimit * _build_set_timelimit_funcs_list():
     for i in range(3):
-        set_timelimit_funcs[i] = NULL
+        set_timelimit_funcs[i] = (
+            <fftw_generic_set_timelimit>&_fftw_generic_set_timelimit_null)
 
     IF HAVE_DOUBLE:
         set_timelimit_funcs[0] = (

--- a/pyfftw/pyfftw.pyx
+++ b/pyfftw/pyfftw.pyx
@@ -46,25 +46,32 @@ include 'utils.pxi'
 cdef extern from *:
     int Py_AtExit(void (*callback)())
 
-# the total number of supported types pyfftw is build for
+# the total number of types pyfftw can support
 cdef int _n_types = 3
 cdef object _all_types = ['32', '64', 'ld']
-
-# the types supported in this build
-supported_types = []
-IF HAVE_DOUBLE:
-    supported_types.append('64')
-IF HAVE_SINGLE:
-    supported_types.append('32')
-IF HAVE_LONG:
-    supported_types.append('ld')
-
-cdef object _all_types_human_readable
 _all_types_human_readable = {
     '32': 'single',
     '64': 'double',
     'ld': 'long double',
 }
+
+# the types supported in this build
+_supported_types = []
+_supported_nptypes_complex = []
+_supported_nptypes_real = []
+
+IF HAVE_SINGLE:
+    _supported_types.append('32')
+    _supported_nptypes_complex.append(np.complex64)
+    _supported_nptypes_real.append(np.float32)
+IF HAVE_DOUBLE:
+    _supported_types.append('64')
+    _supported_nptypes_complex.append(np.complex128)
+    _supported_nptypes_real.append(np.float64)
+IF HAVE_LONG:
+    _supported_types.append('ld')
+    _supported_nptypes_complex.append(np.clongdouble)
+    _supported_nptypes_real.append(np.longdouble)
 
 cdef object directions
 directions = {'FFTW_FORWARD': FFTW_FORWARD,

--- a/pyfftw/pyfftw.pyx
+++ b/pyfftw/pyfftw.pyx
@@ -46,6 +46,19 @@ include 'utils.pxi'
 cdef extern from *:
     int Py_AtExit(void (*callback)())
 
+# the total number of supported types pyfftw is build for
+cdef int _n_types = 3
+cdef object _all_types = ['32', '64', 'ld']
+
+# the types supported in this build
+cdef object supported_types = []
+IF HAVE_DOUBLE:
+    supported_types.append('64')
+IF HAVE_SINGLE:
+    supported_types.append('32')
+IF HAVE_LONG:
+    supported_types.append('ld')
+
 cdef object directions
 directions = {'FFTW_FORWARD': FFTW_FORWARD,
         'FFTW_BACKWARD': FFTW_BACKWARD}
@@ -82,254 +95,287 @@ cdef object plan_lock = threading.Lock()
 #     ========
 #
 # Complex double precision
-cdef void* _fftw_plan_guru_dft(
-            int rank, fftw_iodim *dims,
-            int howmany_rank, fftw_iodim *howmany_dims,
-            void *_in, void *_out,
-            int sign, unsigned flags) nogil:
+IF HAVE_DOUBLE:
+    cdef void* _fftw_plan_guru_dft(
+                int rank, fftw_iodim *dims,
+                int howmany_rank, fftw_iodim *howmany_dims,
+                void *_in, void *_out,
+                int sign, unsigned flags) nogil:
 
-    return <void *>fftw_plan_guru_dft(rank, dims,
-            howmany_rank, howmany_dims,
-            <cdouble *>_in, <cdouble *>_out,
-            sign, flags)
+        return <void *>fftw_plan_guru_dft(rank, dims,
+                howmany_rank, howmany_dims,
+                <cdouble *>_in, <cdouble *>_out,
+                sign, flags)
 
-# Complex single precision
-cdef void* _fftwf_plan_guru_dft(
-            int rank, fftw_iodim *dims,
-            int howmany_rank, fftw_iodim *howmany_dims,
-            void *_in, void *_out,
-            int sign, unsigned flags) nogil:
+    # real to complex double precision
+    cdef void* _fftw_plan_guru_dft_r2c(
+                int rank, fftw_iodim *dims,
+                int howmany_rank, fftw_iodim *howmany_dims,
+                void *_in, void *_out,
+                int sign, unsigned flags) nogil:
 
-    return <void *>fftwf_plan_guru_dft(rank, dims,
-            howmany_rank, howmany_dims,
-            <cfloat *>_in, <cfloat *>_out,
-            sign, flags)
+        return <void *>fftw_plan_guru_dft_r2c(rank, dims,
+                howmany_rank, howmany_dims,
+                <double *>_in, <cdouble *>_out,
+                flags)
 
-# Complex long double precision
-cdef void* _fftwl_plan_guru_dft(
-            int rank, fftw_iodim *dims,
-            int howmany_rank, fftw_iodim *howmany_dims,
-            void *_in, void *_out,
-            int sign, unsigned flags) nogil:
+    # complex to real double precision
+    cdef void* _fftw_plan_guru_dft_c2r(
+                int rank, fftw_iodim *dims,
+                int howmany_rank, fftw_iodim *howmany_dims,
+                void *_in, void *_out,
+                int sign, unsigned flags) nogil:
 
-    return <void *>fftwl_plan_guru_dft(rank, dims,
-            howmany_rank, howmany_dims,
-            <clongdouble *>_in, <clongdouble *>_out,
-            sign, flags)
+        return <void *>fftw_plan_guru_dft_c2r(rank, dims,
+                howmany_rank, howmany_dims,
+                <cdouble *>_in, <double *>_out,
+                flags)
 
-# real to complex double precision
-cdef void* _fftw_plan_guru_dft_r2c(
-            int rank, fftw_iodim *dims,
-            int howmany_rank, fftw_iodim *howmany_dims,
-            void *_in, void *_out,
-            int sign, unsigned flags) nogil:
+IF HAVE_SINGLE:
+    # Complex single precision
+    cdef void* _fftwf_plan_guru_dft(
+                int rank, fftw_iodim *dims,
+                int howmany_rank, fftw_iodim *howmany_dims,
+                void *_in, void *_out,
+                int sign, unsigned flags) nogil:
 
-    return <void *>fftw_plan_guru_dft_r2c(rank, dims,
-            howmany_rank, howmany_dims,
-            <double *>_in, <cdouble *>_out,
-            flags)
+        return <void *>fftwf_plan_guru_dft(rank, dims,
+                howmany_rank, howmany_dims,
+                <cfloat *>_in, <cfloat *>_out,
+                sign, flags)
 
-# real to complex single precision
-cdef void* _fftwf_plan_guru_dft_r2c(
-            int rank, fftw_iodim *dims,
-            int howmany_rank, fftw_iodim *howmany_dims,
-            void *_in, void *_out,
-            int sign, unsigned flags) nogil:
+    # real to complex single precision
+    cdef void* _fftwf_plan_guru_dft_r2c(
+                int rank, fftw_iodim *dims,
+                int howmany_rank, fftw_iodim *howmany_dims,
+                void *_in, void *_out,
+                int sign, unsigned flags) nogil:
 
-    return <void *>fftwf_plan_guru_dft_r2c(rank, dims,
-            howmany_rank, howmany_dims,
-            <float *>_in, <cfloat *>_out,
-            flags)
+        return <void *>fftwf_plan_guru_dft_r2c(rank, dims,
+                howmany_rank, howmany_dims,
+                <float *>_in, <cfloat *>_out,
+                flags)
 
-# real to complex long double precision
-cdef void* _fftwl_plan_guru_dft_r2c(
-            int rank, fftw_iodim *dims,
-            int howmany_rank, fftw_iodim *howmany_dims,
-            void *_in, void *_out,
-            int sign, unsigned flags) nogil:
+    # complex to real single precision
+    cdef void* _fftwf_plan_guru_dft_c2r(
+                int rank, fftw_iodim *dims,
+                int howmany_rank, fftw_iodim *howmany_dims,
+                void *_in, void *_out,
+                int sign, unsigned flags) nogil:
 
-    return <void *>fftwl_plan_guru_dft_r2c(rank, dims,
-            howmany_rank, howmany_dims,
-            <long double *>_in, <clongdouble *>_out,
-            flags)
+        return <void *>fftwf_plan_guru_dft_c2r(rank, dims,
+                howmany_rank, howmany_dims,
+                <cfloat *>_in, <float *>_out,
+                flags)
 
-# complex to real double precision
-cdef void* _fftw_plan_guru_dft_c2r(
-            int rank, fftw_iodim *dims,
-            int howmany_rank, fftw_iodim *howmany_dims,
-            void *_in, void *_out,
-            int sign, unsigned flags) nogil:
+IF HAVE_LONG:
+    # Complex long double precision
+    cdef void* _fftwl_plan_guru_dft(
+                int rank, fftw_iodim *dims,
+                int howmany_rank, fftw_iodim *howmany_dims,
+                void *_in, void *_out,
+                int sign, unsigned flags) nogil:
 
-    return <void *>fftw_plan_guru_dft_c2r(rank, dims,
-            howmany_rank, howmany_dims,
-            <cdouble *>_in, <double *>_out,
-            flags)
+        return <void *>fftwl_plan_guru_dft(rank, dims,
+                howmany_rank, howmany_dims,
+                <clongdouble *>_in, <clongdouble *>_out,
+                sign, flags)
 
-# complex to real single precision
-cdef void* _fftwf_plan_guru_dft_c2r(
-            int rank, fftw_iodim *dims,
-            int howmany_rank, fftw_iodim *howmany_dims,
-            void *_in, void *_out,
-            int sign, unsigned flags) nogil:
+    # real to complex long double precision
+    cdef void* _fftwl_plan_guru_dft_r2c(
+                int rank, fftw_iodim *dims,
+                int howmany_rank, fftw_iodim *howmany_dims,
+                void *_in, void *_out,
+                int sign, unsigned flags) nogil:
 
-    return <void *>fftwf_plan_guru_dft_c2r(rank, dims,
-            howmany_rank, howmany_dims,
-            <cfloat *>_in, <float *>_out,
-            flags)
+        return <void *>fftwl_plan_guru_dft_r2c(rank, dims,
+                howmany_rank, howmany_dims,
+                <long double *>_in, <clongdouble *>_out,
+                flags)
 
-# complex to real long double precision
-cdef void* _fftwl_plan_guru_dft_c2r(
-            int rank, fftw_iodim *dims,
-            int howmany_rank, fftw_iodim *howmany_dims,
-            void *_in, void *_out,
-            int sign, unsigned flags) nogil:
+    # complex to real long double precision
+    cdef void* _fftwl_plan_guru_dft_c2r(
+                int rank, fftw_iodim *dims,
+                int howmany_rank, fftw_iodim *howmany_dims,
+                void *_in, void *_out,
+                int sign, unsigned flags) nogil:
 
-    return <void *>fftwl_plan_guru_dft_c2r(rank, dims,
-            howmany_rank, howmany_dims,
-            <clongdouble *>_in, <long double *>_out,
-            flags)
+        return <void *>fftwl_plan_guru_dft_c2r(rank, dims,
+                howmany_rank, howmany_dims,
+                <clongdouble *>_in, <long double *>_out,
+                flags)
 
 #    Executors
 #    =========
 #
-# Complex double precision
-cdef void _fftw_execute_dft(void *_plan, void *_in, void *_out) nogil:
+IF HAVE_DOUBLE:
+    # Complex double precision
+    cdef void _fftw_execute_dft(void *_plan, void *_in, void *_out) nogil:
 
-    fftw_execute_dft(<fftw_plan>_plan,
-            <cdouble *>_in, <cdouble *>_out)
+        fftw_execute_dft(<fftw_plan>_plan,
+                <cdouble *>_in, <cdouble *>_out)
 
-# Complex single precision
-cdef void _fftwf_execute_dft(void *_plan, void *_in, void *_out) nogil:
+    # real to complex double precision
+    cdef void _fftw_execute_dft_r2c(void *_plan, void *_in, void *_out) nogil:
 
-    fftwf_execute_dft(<fftwf_plan>_plan,
-            <cfloat *>_in, <cfloat *>_out)
+        fftw_execute_dft_r2c(<fftw_plan>_plan,
+                <double *>_in, <cdouble *>_out)
 
-# Complex long double precision
-cdef void _fftwl_execute_dft(void *_plan, void *_in, void *_out) nogil:
+    # complex to real double precision
+    cdef void _fftw_execute_dft_c2r(void *_plan, void *_in, void *_out) nogil:
 
-    fftwl_execute_dft(<fftwl_plan>_plan,
-            <clongdouble *>_in, <clongdouble *>_out)
+        fftw_execute_dft_c2r(<fftw_plan>_plan,
+                <cdouble *>_in, <double *>_out)
 
-# real to complex double precision
-cdef void _fftw_execute_dft_r2c(void *_plan, void *_in, void *_out) nogil:
+IF HAVE_SINGLE:
+    # Complex single precision
+    cdef void _fftwf_execute_dft(void *_plan, void *_in, void *_out) nogil:
 
-    fftw_execute_dft_r2c(<fftw_plan>_plan,
-            <double *>_in, <cdouble *>_out)
+        fftwf_execute_dft(<fftwf_plan>_plan,
+                <cfloat *>_in, <cfloat *>_out)
 
-# real to complex single precision
-cdef void _fftwf_execute_dft_r2c(void *_plan, void *_in, void *_out) nogil:
+    # real to complex single precision
+    cdef void _fftwf_execute_dft_r2c(void *_plan, void *_in, void *_out) nogil:
 
-    fftwf_execute_dft_r2c(<fftwf_plan>_plan,
-            <float *>_in, <cfloat *>_out)
+        fftwf_execute_dft_r2c(<fftwf_plan>_plan,
+                <float *>_in, <cfloat *>_out)
 
-# real to complex long double precision
-cdef void _fftwl_execute_dft_r2c(void *_plan, void *_in, void *_out) nogil:
+    # complex to real single precision
+    cdef void _fftwf_execute_dft_c2r(void *_plan, void *_in, void *_out) nogil:
 
-    fftwl_execute_dft_r2c(<fftwl_plan>_plan,
-            <long double *>_in, <clongdouble *>_out)
+        fftwf_execute_dft_c2r(<fftwf_plan>_plan,
+                <cfloat *>_in, <float *>_out)
 
-# complex to real double precision
-cdef void _fftw_execute_dft_c2r(void *_plan, void *_in, void *_out) nogil:
+IF HAVE_LONG:
+    # Complex long double precision
+    cdef void _fftwl_execute_dft(void *_plan, void *_in, void *_out) nogil:
 
-    fftw_execute_dft_c2r(<fftw_plan>_plan,
-            <cdouble *>_in, <double *>_out)
+        fftwl_execute_dft(<fftwl_plan>_plan,
+                <clongdouble *>_in, <clongdouble *>_out)
 
-# complex to real single precision
-cdef void _fftwf_execute_dft_c2r(void *_plan, void *_in, void *_out) nogil:
+    # real to complex long double precision
+    cdef void _fftwl_execute_dft_r2c(void *_plan, void *_in, void *_out) nogil:
 
-    fftwf_execute_dft_c2r(<fftwf_plan>_plan,
-            <cfloat *>_in, <float *>_out)
+        fftwl_execute_dft_r2c(<fftwl_plan>_plan,
+                <long double *>_in, <clongdouble *>_out)
 
-# complex to real long double precision
-cdef void _fftwl_execute_dft_c2r(void *_plan, void *_in, void *_out) nogil:
+    # complex to real long double precision
+    cdef void _fftwl_execute_dft_c2r(void *_plan, void *_in, void *_out) nogil:
 
-    fftwl_execute_dft_c2r(<fftwl_plan>_plan,
-            <clongdouble *>_in, <long double *>_out)
+        fftwl_execute_dft_c2r(<fftwl_plan>_plan,
+                <clongdouble *>_in, <long double *>_out)
 
 #    Destroyers
 #    ==========
 #
-# Double precision
-cdef void _fftw_destroy_plan(void *_plan):
+IF HAVE_DOUBLE:
+    # Double precision
+    cdef void _fftw_destroy_plan(void *_plan):
 
-    fftw_destroy_plan(<fftw_plan>_plan)
+        fftw_destroy_plan(<fftw_plan>_plan)
 
-# Single precision
-cdef void _fftwf_destroy_plan(void *_plan):
+IF HAVE_SINGLE:
+    # Single precision
+    cdef void _fftwf_destroy_plan(void *_plan):
 
-    fftwf_destroy_plan(<fftwf_plan>_plan)
+        fftwf_destroy_plan(<fftwf_plan>_plan)
 
-# Long double precision
-cdef void _fftwl_destroy_plan(void *_plan):
+IF HAVE_LONG:
+    # Long double precision
+    cdef void _fftwl_destroy_plan(void *_plan):
 
-    fftwl_destroy_plan(<fftwl_plan>_plan)
-
+        fftwl_destroy_plan(<fftwl_plan>_plan)
 
 # Function lookup tables
 # ======================
 
-# Planner table (of side the number of planners).
+# Planner table (of size the number of planners).
 cdef fftw_generic_plan_guru planners[9]
 
 cdef fftw_generic_plan_guru * _build_planner_list():
+    for i in range(9):
+        planners[i] = NULL
 
-    planners[0] = <fftw_generic_plan_guru>&_fftw_plan_guru_dft
-    planners[1] = <fftw_generic_plan_guru>&_fftwf_plan_guru_dft
-    planners[2] = <fftw_generic_plan_guru>&_fftwl_plan_guru_dft
-    planners[3] = <fftw_generic_plan_guru>&_fftw_plan_guru_dft_r2c
-    planners[4] = <fftw_generic_plan_guru>&_fftwf_plan_guru_dft_r2c
-    planners[5] = <fftw_generic_plan_guru>&_fftwl_plan_guru_dft_r2c
-    planners[6] = <fftw_generic_plan_guru>&_fftw_plan_guru_dft_c2r
-    planners[7] = <fftw_generic_plan_guru>&_fftwf_plan_guru_dft_c2r
-    planners[8] = <fftw_generic_plan_guru>&_fftwl_plan_guru_dft_c2r
+    IF HAVE_DOUBLE:
+        planners[0] = <fftw_generic_plan_guru>&_fftw_plan_guru_dft
+        planners[3] = <fftw_generic_plan_guru>&_fftw_plan_guru_dft_r2c
+        planners[6] = <fftw_generic_plan_guru>&_fftw_plan_guru_dft_c2r
+    IF HAVE_SINGLE:
+        planners[1] = <fftw_generic_plan_guru>&_fftwf_plan_guru_dft
+        planners[4] = <fftw_generic_plan_guru>&_fftwf_plan_guru_dft_r2c
+        planners[7] = <fftw_generic_plan_guru>&_fftwf_plan_guru_dft_c2r
+    IF HAVE_LONG:
+        planners[2] = <fftw_generic_plan_guru>&_fftwl_plan_guru_dft
+        planners[5] = <fftw_generic_plan_guru>&_fftwl_plan_guru_dft_r2c
+        planners[8] = <fftw_generic_plan_guru>&_fftwl_plan_guru_dft_c2r
 
 # Executor table (of size the number of executors)
 cdef fftw_generic_execute executors[9]
 
 cdef fftw_generic_execute * _build_executor_list():
+    for i in range(9):
+        executors[i] = NULL
 
-    executors[0] = <fftw_generic_execute>&_fftw_execute_dft
-    executors[1] = <fftw_generic_execute>&_fftwf_execute_dft
-    executors[2] = <fftw_generic_execute>&_fftwl_execute_dft
-    executors[3] = <fftw_generic_execute>&_fftw_execute_dft_r2c
-    executors[4] = <fftw_generic_execute>&_fftwf_execute_dft_r2c
-    executors[5] = <fftw_generic_execute>&_fftwl_execute_dft_r2c
-    executors[6] = <fftw_generic_execute>&_fftw_execute_dft_c2r
-    executors[7] = <fftw_generic_execute>&_fftwf_execute_dft_c2r
-    executors[8] = <fftw_generic_execute>&_fftwl_execute_dft_c2r
+    IF HAVE_DOUBLE:
+        executors[0] = <fftw_generic_execute>&_fftw_execute_dft
+        executors[3] = <fftw_generic_execute>&_fftw_execute_dft_r2c
+        executors[6] = <fftw_generic_execute>&_fftw_execute_dft_c2r
+    IF HAVE_SINGLE:
+        executors[1] = <fftw_generic_execute>&_fftwf_execute_dft
+        executors[4] = <fftw_generic_execute>&_fftwf_execute_dft_r2c
+        executors[7] = <fftw_generic_execute>&_fftwf_execute_dft_c2r
+    IF HAVE_LONG:
+        executors[2] = <fftw_generic_execute>&_fftwl_execute_dft
+        executors[5] = <fftw_generic_execute>&_fftwl_execute_dft_r2c
+        executors[8] = <fftw_generic_execute>&_fftwl_execute_dft_c2r
 
 # Destroyer table (of size the number of destroyers)
 cdef fftw_generic_destroy_plan destroyers[3]
 
 cdef fftw_generic_destroy_plan * _build_destroyer_list():
+    for i in range(3):
+        destroyers[i] = NULL
 
-    destroyers[0] = <fftw_generic_destroy_plan>&_fftw_destroy_plan
-    destroyers[1] = <fftw_generic_destroy_plan>&_fftwf_destroy_plan
-    destroyers[2] = <fftw_generic_destroy_plan>&_fftwl_destroy_plan
-
+    IF HAVE_DOUBLE:
+        destroyers[0] = <fftw_generic_destroy_plan>&_fftw_destroy_plan
+    IF HAVE_SINGLE:
+        destroyers[1] = <fftw_generic_destroy_plan>&_fftwf_destroy_plan
+    IF HAVE_LONG:
+        destroyers[2] = <fftw_generic_destroy_plan>&_fftwl_destroy_plan
 
 # nthreads plan setters table
 cdef fftw_generic_plan_with_nthreads nthreads_plan_setters[3]
 
 cdef fftw_generic_plan_with_nthreads * _build_nthreads_plan_setters_list():
-    nthreads_plan_setters[0] = (
+    for i in range(3):
+        nthreads_plan_setters[i] = NULL
+
+    IF HAVE_DOUBLE:
+        nthreads_plan_setters[0] = (
             <fftw_generic_plan_with_nthreads>&fftw_plan_with_nthreads)
-    nthreads_plan_setters[1] = (
+    IF HAVE_SINGLE:
+        nthreads_plan_setters[1] = (
             <fftw_generic_plan_with_nthreads>&fftwf_plan_with_nthreads)
-    nthreads_plan_setters[2] = (
+    IF HAVE_LONG:
+        nthreads_plan_setters[2] = (
             <fftw_generic_plan_with_nthreads>&fftwl_plan_with_nthreads)
 
 # Set planner timelimits
 cdef fftw_generic_set_timelimit set_timelimit_funcs[3]
 
 cdef fftw_generic_set_timelimit * _build_set_timelimit_funcs_list():
-    set_timelimit_funcs[0] = (
-            <fftw_generic_set_timelimit>&fftw_set_timelimit)
-    set_timelimit_funcs[1] = (
-            <fftw_generic_set_timelimit>&fftwf_set_timelimit)
-    set_timelimit_funcs[2] = (
-            <fftw_generic_set_timelimit>&fftwl_set_timelimit)
+    for i in range(3):
+        set_timelimit_funcs[i] = NULL
 
+    IF HAVE_DOUBLE:
+        set_timelimit_funcs[0] = (
+            <fftw_generic_set_timelimit>&fftw_set_timelimit)
+    IF HAVE_SINGLE:
+        set_timelimit_funcs[1] = (
+            <fftw_generic_set_timelimit>&fftwf_set_timelimit)
+    IF HAVE_LONG:
+        set_timelimit_funcs[2] = (
+            <fftw_generic_set_timelimit>&fftwl_set_timelimit)
 
 # Data validators table
 cdef validator validators[2]
@@ -450,12 +496,22 @@ fftw_schemes = {
         (np.dtype('complex128'), np.dtype('float64')): ('c2r', '64'),
         (np.dtype('complex64'), np.dtype('float32')): ('c2r', '32')}
 
+cdef object fftw_default_output
+fftw_default_output = {
+    np.dtype('float32'): np.dtype('complex64'),
+    np.dtype('float64'): np.dtype('complex128'),
+    np.dtype('complex64'): np.dtype('complex64'),
+    np.dtype('complex128'): np.dtype('complex128')}
+
 if np.dtype('longdouble') != np.dtype('float64'):
     fftw_schemes.update({
         (np.dtype('clongdouble'), np.dtype('clongdouble')): ('c2c', 'ld'),
         (np.dtype('longdouble'), np.dtype('clongdouble')): ('r2c', 'ld'),
         (np.dtype('clongdouble'), np.dtype('longdouble')): ('c2r', 'ld')})
 
+    fftw_default_output.update({
+        np.dtype('longdouble'): np.dtype('clongdouble'),
+        np.dtype('clongdouble'): np.dtype('clongdouble')})
 
 cdef object scheme_directions
 scheme_directions = {
@@ -473,32 +529,71 @@ scheme_directions = {
 # reported on some systems when this is set to None. It seems
 # sufficiently trivial to use -1 in place of None, especially given
 # that scheme_functions is an internal cdef object.
-cdef object scheme_functions
-scheme_functions = {
+cdef object _scheme_functions = {}
+IF HAVE_DOUBLE:
+    _scheme_functions.update({
     ('c2c', '64'): {'planner': 0, 'executor':0, 'generic_precision':0,
-        'validator': -1, 'fft_shape_lookup': -1},
-    ('c2c', '32'): {'planner':1, 'executor':1, 'generic_precision':1,
-        'validator': -1, 'fft_shape_lookup': -1},
-    ('c2c', 'ld'): {'planner':2, 'executor':2, 'generic_precision':2,
         'validator': -1, 'fft_shape_lookup': -1},
     ('r2c', '64'): {'planner':3, 'executor':3, 'generic_precision':0,
         'validator': 0,
         'fft_shape_lookup': _lookup_shape_r2c_arrays},
+    ('c2r', '64'): {'planner':6, 'executor':6, 'generic_precision':0,
+        'validator': 1,
+        'fft_shape_lookup': _lookup_shape_c2r_arrays}})
+IF HAVE_SINGLE:
+    _scheme_functions.update({
+    ('c2c', '32'): {'planner':1, 'executor':1, 'generic_precision':1,
+        'validator': -1, 'fft_shape_lookup': -1},
     ('r2c', '32'): {'planner':4, 'executor':4, 'generic_precision':1,
         'validator': 0,
         'fft_shape_lookup': _lookup_shape_r2c_arrays},
+    ('c2r', '32'): {'planner':7, 'executor':7, 'generic_precision':1,
+        'validator': 1,
+        'fft_shape_lookup': _lookup_shape_c2r_arrays}})
+IF HAVE_LONG:
+    _scheme_functions.update({
+    ('c2c', 'ld'): {'planner':2, 'executor':2, 'generic_precision':2,
+        'validator': -1, 'fft_shape_lookup': -1},
     ('r2c', 'ld'): {'planner':5, 'executor':5, 'generic_precision':2,
         'validator': 0,
         'fft_shape_lookup': _lookup_shape_r2c_arrays},
-    ('c2r', '64'): {'planner':6, 'executor':6, 'generic_precision':0,
-        'validator': 1,
-        'fft_shape_lookup': _lookup_shape_c2r_arrays},
-    ('c2r', '32'): {'planner':7, 'executor':7, 'generic_precision':1,
-        'validator': 1,
-        'fft_shape_lookup': _lookup_shape_c2r_arrays},
     ('c2r', 'ld'): {'planner':8, 'executor':8, 'generic_precision':2,
         'validator': 1,
-        'fft_shape_lookup': _lookup_shape_c2r_arrays}}
+        'fft_shape_lookup': _lookup_shape_c2r_arrays}})
+
+def scheme_functions(scheme):
+    try:
+        return _scheme_functions[scheme]
+    except KeyError:
+        msg = "The scheme '%s' is not supported." % str(scheme)
+        if scheme[1] in _all_types:
+            msg += "\nRebuild pyfftw with support for the data type '%s'!" % scheme[1]
+        raise NotImplementedError(msg)
+
+# Set the cleanup routine
+cdef void _cleanup():
+    # TODO tight coupling with non-MPI code
+    # TODO mpi_cleanup() includes serial clean up
+    IF HAVE_MPI:
+        IF HAVE_DOUBLE_MPI:
+            fftw_mpi_cleanup()
+        IF HAVE_SINGLE_MPI:
+            fftwf_mpi_cleanup()
+        IF HAVE_LONG_MPI:
+            fftwl_mpi_cleanup()
+
+    IF HAVE_DOUBLE:
+        fftw_cleanup()
+    IF HAVE_SINGLE:
+        fftwf_cleanup()
+    IF HAVE_LONG:
+        fftwl_cleanup()
+    IF HAVE_DOUBLE_THREADS:
+        fftw_cleanup_threads()
+    IF HAVE_SINGLE_THREADS:
+        fftwf_cleanup_threads()
+    IF HAVE_LONG_THREADS:
+        fftwl_cleanup_threads()
 
 # Initialize the module
 
@@ -510,18 +605,12 @@ _build_nthreads_plan_setters_list()
 _build_validators_list()
 _build_set_timelimit_funcs_list()
 
-fftw_init_threads()
-fftwf_init_threads()
-fftwl_init_threads()
-
-# Set the cleanup routine
-cdef void _cleanup():
-    fftw_cleanup()
-    fftwf_cleanup()
-    fftwl_cleanup()
-    fftw_cleanup_threads()
-    fftwf_cleanup_threads()
-    fftwl_cleanup_threads()
+IF HAVE_DOUBLE_THREADS:
+    fftw_init_threads()
+IF HAVE_SINGLE_THREADS:
+    fftwf_init_threads()
+IF HAVE_LONG_THREADS:
+    fftwl_init_threads()
 
 Py_AtExit(_cleanup)
 
@@ -642,6 +731,7 @@ cdef class FFTW:
     cdef bint _simd_allowed
     cdef int _input_array_alignment
     cdef int _output_array_alignment
+    cdef bint _use_threads
 
     cdef object _input_item_strides
     cdef object _input_strides
@@ -884,7 +974,7 @@ cdef class FFTW:
         self._input_dtype = input_dtype
         self._output_dtype = output_dtype
 
-        functions = scheme_functions[scheme]
+        functions = scheme_functions(scheme)
 
         self._fftw_planner = planners[functions['planner']]
         self._fftw_execute = executors[functions['executor']]
@@ -1105,6 +1195,9 @@ cdef class FFTW:
             self._howmany_dims[i]._is = input_strides_array[self._not_axes[i]]
             self._howmany_dims[i]._os = output_strides_array[self._not_axes[i]]
 
+        # parallel execution
+        self._use_threads = (threads > 1)
+
         ## Point at which FFTW calls are made
         ## (and none should be made before this)
         self._nthreads_plan_setter(threads)
@@ -1202,7 +1295,7 @@ cdef class FFTW:
           * ``'FFTW_WISDOM_ONLY'`` is supported.
             This tells FFTW to raise an error if no plan for this transform
             and data type is already in the wisdom. It thus provides a method
-            to determine whether planning would require additional effor or the
+            to determine whether planning would require additional effort or the
             cached wisdom can be used. This flag should be combined with the
             various planning-effort flags (``'FFTW_ESTIMATE'``,
             ``'FFTW_MEASURE'``, etc.); if so, then an error will be raised if
@@ -1223,7 +1316,9 @@ cdef class FFTW:
           Note that only the flags documented here are supported.
 
         * ``threads`` tells the wrapper how many threads to use
-          when invoking FFTW, with a default of 1.
+          when invoking FFTW, with a default of 1. If the number
+          of threads is greater than 1, then the GIL is released
+          by necessity.
 
         * ``planning_timelimit`` is a floating point number that
           indicates to the underlying FFTW planner the maximum number of
@@ -1678,48 +1773,60 @@ def export_wisdom():
     argument to :func:`~pyfftw.import_wisdom`.
     '''
 
-    cdef bytes py_wisdom
-    cdef bytes py_wisdomf
-    cdef bytes py_wisdoml
+    cdef:
+        # can't directly initialize `bytes` with ''
+        const char* empty = ''
+        bytes py_wisdom  = empty
+        bytes py_wisdomf = empty
+        bytes py_wisdoml = empty
 
-    cdef int counter = 0
-    cdef int counterf = 0
-    cdef int counterl = 0
+        # default init to zero
+        cdef int counter  = 0
+        cdef int counterf = 0
+        cdef int counterl = 0
 
-    fftw_export_wisdom(&count_char, <void *>&counter)
-    fftwf_export_wisdom(&count_char, <void *>&counterf)
-    fftwl_export_wisdom(&count_char, <void *>&counterl)
+        char* c_wisdom  = NULL
+        char* c_wisdomf = NULL
+        char* c_wisdoml = NULL
 
-    cdef char* c_wisdom = <char *>malloc(sizeof(char)*(counter + 1))
-    cdef char* c_wisdomf = <char *>malloc(sizeof(char)*(counterf + 1))
-    cdef char* c_wisdoml = <char *>malloc(sizeof(char)*(counterl + 1))
-
-    if c_wisdom == NULL or c_wisdomf == NULL or c_wisdoml == NULL:
-        raise MemoryError
-
-    # Set the pointers to the string pointers
-    cdef intptr_t c_wisdom_ptr = <intptr_t>c_wisdom
-    cdef intptr_t c_wisdomf_ptr = <intptr_t>c_wisdomf
-    cdef intptr_t c_wisdoml_ptr = <intptr_t>c_wisdoml
-
-    fftw_export_wisdom(&write_char_to_string, <void *>&c_wisdom_ptr)
-    fftwf_export_wisdom(&write_char_to_string, <void *>&c_wisdomf_ptr)
-    fftwl_export_wisdom(&write_char_to_string, <void *>&c_wisdoml_ptr)
-
-    # Write the last byte as the null byte
-    c_wisdom[counter] = 0
-    c_wisdomf[counterf] = 0
-    c_wisdoml[counterl] = 0
-
-    try:
-        py_wisdom = c_wisdom
-        py_wisdomf = c_wisdomf
-        py_wisdoml = c_wisdoml
-
-    finally:
-        free(c_wisdom)
-        free(c_wisdomf)
-        free(c_wisdoml)
+    IF HAVE_DOUBLE:
+        fftw_export_wisdom(&count_char, <void *>&counter)
+        c_wisdom = <char *>malloc(sizeof(char)*(counter + 1))
+        if c_wisdom == NULL:
+            raise MemoryError
+        # Set the pointers to the string pointers
+        cdef intptr_t c_wisdom_ptr = <intptr_t>c_wisdom
+        fftw_export_wisdom(&write_char_to_string, <void *>&c_wisdom_ptr)
+        # Write the last byte as the null byte
+        c_wisdom[counter] = 0
+        try:
+            py_wisdom = c_wisdom
+        finally:
+            free(c_wisdom)
+    IF HAVE_SINGLE:
+        fftwf_export_wisdom(&count_char, <void *>&counterf)
+        c_wisdomf = <char *>malloc(sizeof(char)*(counterf + 1))
+        if c_wisdomf == NULL:
+            raise MemoryError
+        cdef intptr_t c_wisdomf_ptr = <intptr_t>c_wisdomf
+        fftwf_export_wisdom(&write_char_to_string, <void *>&c_wisdomf_ptr)
+        c_wisdomf[counterf] = 0
+        try:
+            py_wisdomf = c_wisdomf
+        finally:
+            free(c_wisdomf)
+    IF HAVE_LONG:
+        fftwl_export_wisdom(&count_char, <void *>&counterl)
+        c_wisdoml = <char *>malloc(sizeof(char)*(counterl + 1))
+        if c_wisdoml == NULL:
+            raise MemoryError
+        cdef intptr_t c_wisdoml_ptr = <intptr_t>c_wisdoml
+        fftwl_export_wisdom(&write_char_to_string, <void *>&c_wisdoml_ptr)
+        c_wisdoml[counterl] = 0
+        try:
+            py_wisdoml = c_wisdoml
+        finally:
+            free(c_wisdoml)
 
     return (py_wisdom, py_wisdomf, py_wisdoml)
 
@@ -1742,14 +1849,21 @@ def import_wisdom(wisdom):
     and long double, in that order).
     '''
 
-    cdef char* c_wisdom = wisdom[0]
-    cdef char* c_wisdomf = wisdom[1]
-    cdef char* c_wisdoml = wisdom[2]
+    cdef:
+        char* c_wisdom = wisdom[0]
+        char* c_wisdomf = wisdom[1]
+        char* c_wisdoml = wisdom[2]
 
-    cdef bint success = fftw_import_wisdom_from_string(c_wisdom)
-    cdef bint successf = fftwf_import_wisdom_from_string(c_wisdomf)
-    cdef bint successl = fftwl_import_wisdom_from_string(c_wisdoml)
+        bint success  = False
+        bint successf = False
+        bint successl = False
 
+    IF HAVE_DOUBLE:
+        success = fftw_import_wisdom_from_string(c_wisdom)
+    IF HAVE_SINGLE:
+        successf = fftwf_import_wisdom_from_string(c_wisdomf)
+    IF HAVE_LONG:
+        successl = fftwl_import_wisdom_from_string(c_wisdoml)
     return (success, successf, successl)
 
 #def export_wisdom_to_files(
@@ -1844,6 +1958,9 @@ def forget_wisdom():
 
     Forget all the accumulated wisdom.
     '''
-    fftw_forget_wisdom()
-    fftwf_forget_wisdom()
-    fftwl_forget_wisdom()
+    IF HAVE_DOUBLE:
+        fftw_forget_wisdom()
+    IF HAVE_SINGLE:
+        fftwf_forget_wisdom()
+    IF HAVE_LONG:
+        fftwl_forget_wisdom()

--- a/pyfftw/pyfftw.pyx
+++ b/pyfftw/pyfftw.pyx
@@ -572,9 +572,9 @@ IF HAVE_LONG:
         'fft_shape_lookup': _lookup_shape_c2r_arrays}})
 
 def scheme_functions(scheme):
-    try:
+    if scheme in _scheme_functions:
         return _scheme_functions[scheme]
-    except KeyError:
+    else:
         msg = "The scheme '%s' is not supported." % str(scheme)
         if scheme[1] in _all_types:
             msg += "\nRebuild pyfftw with support for %s precision!" % \

--- a/pyfftw/pyfftw.pyx
+++ b/pyfftw/pyfftw.pyx
@@ -584,22 +584,12 @@ def scheme_functions(scheme):
     else:
         msg = "The scheme '%s' is not supported." % str(scheme)
         if scheme[1] in _all_types:
-            msg += "\nRebuild pyfftw with support for %s precision!" % \
+            msg += "\nRebuild pyFFTW with support for %s precision!" % \
                    _all_types_human_readable[scheme[1]]
         raise NotImplementedError(msg)
 
 # Set the cleanup routine
 cdef void _cleanup():
-    # TODO tight coupling with non-MPI code
-    # TODO mpi_cleanup() includes serial clean up
-    IF HAVE_MPI:
-        IF HAVE_DOUBLE_MPI:
-            fftw_mpi_cleanup()
-        IF HAVE_SINGLE_MPI:
-            fftwf_mpi_cleanup()
-        IF HAVE_LONG_MPI:
-            fftwl_mpi_cleanup()
-
     IF HAVE_DOUBLE:
         fftw_cleanup()
     IF HAVE_SINGLE:

--- a/pyfftw/pyfftw.pyx
+++ b/pyfftw/pyfftw.pyx
@@ -1780,13 +1780,14 @@ def export_wisdom():
 
     Return the FFTW wisdom as a tuple of strings.
 
-    The first string in the tuple is the string for the double
-    precision wisdom. The second string in the tuple is the string
-    for the single precision wisdom. The third string in the tuple
-    is the string for the long double precision wisdom.
+    The first string in the tuple is the string for the double precision
+    wisdom, the second is for single precision, and the third for long double
+    precision. If any of the precisions is not supported in the build, the
+    string is empty.
 
-    The tuple that is returned from this function can be used as the
-    argument to :func:`~pyfftw.import_wisdom`.
+    The tuple that is returned from this function can be used as the argument
+    to :func:`~pyfftw.import_wisdom`.
+
     '''
 
     cdef:
@@ -1805,6 +1806,9 @@ def export_wisdom():
         char* c_wisdomf = NULL
         char* c_wisdoml = NULL
 
+    # count the length of the string and extract it manually rather than using
+    # `fftw_export_wisdom_to_string` to avoid calling `free` on the string
+    # potentially allocated by a different C library; see #3
     IF HAVE_DOUBLE:
         fftw_export_wisdom(&count_char, <void *>&counter)
         c_wisdom = <char *>malloc(sizeof(char)*(counter + 1))

--- a/setup.py
+++ b/setup.py
@@ -314,7 +314,7 @@ class EnvironmentSniffer(object):
         if not have_fftw:
             raise LinkError("Could not find any of the FFTW libraries")
 
-        log.info('Discovered FFTW with')
+        log.info('Build pyFFTW with support for FFTW with')
         for d in data_types:
             if not self.compile_time_env[self.HAVE(d)]:
                 continue

--- a/setup.py
+++ b/setup.py
@@ -226,9 +226,9 @@ class EnvironmentSniffer(object):
     def search_dependencies(self):
 
         # lib_checks = {}
-        data_types = ['DOUBLE', 'SINGLE', 'LONG', 'QUAD']
+        data_types = ['DOUBLE', 'SINGLE', 'LONG']
         data_types_short = ['', 'f', 'l', 'q']
-        lib_types = ['', 'PTHREADS', 'OMP']
+        lib_types = ['', 'THREADS', 'OMP']
         functions = ['plan_dft', 'init_threads', 'init_threads']
         if self.support_mpi:
             lib_types.append('MPI')
@@ -252,7 +252,7 @@ class EnvironmentSniffer(object):
                 if lib_omp:
                     self.add_library(lib_omp)
                     # manually set flag because it won't be checked below
-                    self.compile_time_env[self.HAVE(d, 'PTHREADS')] = False
+                    self.compile_time_env[self.HAVE(d, 'THREADS')] = False
                 else:
                     self.linker_flags.pop()
             else:
@@ -265,7 +265,7 @@ class EnvironmentSniffer(object):
             if not lib_omp:
                 # -pthread added for gcc/clang when checking for threads
                 self.linker_flags.append(self.pthread_linker_flag())
-                lib_pthread = self.check('PTHREADS', 'init_threads', d, s,
+                lib_pthread = self.check('THREADS', 'init_threads', d, s,
                                          basic_lib)
                 if lib_pthread:
                     self.add_library(lib_pthread)
@@ -277,10 +277,10 @@ class EnvironmentSniffer(object):
             # and MPI are not supported in the releases
             if get_platform() in ('win32', 'win-amd64'):
                 if basic_lib:
-                    self.compile_time_env[self.HAVE(d, 'PTHREADS')] = True
+                    self.compile_time_env[self.HAVE(d, 'THREADS')] = True
 
             # check whatever multithreading is available
-            self.compile_time_env[self.HAVE(d, 'THREADS')] = self.compile_time_env[self.HAVE(d, 'OMP')] or self.compile_time_env[self.HAVE(d, 'PTHREADS')]
+            self.compile_time_env[self.HAVE(d, 'MULTITHREADING')] = self.compile_time_env[self.HAVE(d, 'OMP')] or self.compile_time_env[self.HAVE(d, 'THREADS')]
 
             # check MPI only if headers were found
             self.add_library(self.check('MPI', 'mpi_init', d, s, basic_lib and self.support_mpi))
@@ -311,7 +311,7 @@ class EnvironmentSniffer(object):
             s = d.lower() + ' precision'
             if self.compile_time_env[self.HAVE(d, 'OMP')]:
                 s += ' + openMP'
-            elif self.compile_time_env[self.HAVE(d, 'PTHREADS')]:
+            elif self.compile_time_env[self.HAVE(d, 'THREADS')]:
                 s += ' + pthreads'
             if self.compile_time_env[self.HAVE(d, 'MPI')]:
                 s += ' + MPI'
@@ -703,9 +703,8 @@ class QuickTestCommand(Command):
         ]
 
         import subprocess
-        errno = subprocess.call([sys.executable, '-m',
+        subprocess.check_call([sys.executable, '-m',
                                  'unittest'] + quick_test_cases)
-        raise SystemExit(errno)
 
 
 cmdclass = {'test': TestCommand,

--- a/setup.py
+++ b/setup.py
@@ -227,7 +227,7 @@ class EnvironmentSniffer(object):
 
         # lib_checks = {}
         data_types = ['DOUBLE', 'SINGLE', 'LONG']
-        data_types_short = ['', 'f', 'l', 'q']
+        data_types_short = ['', 'f', 'l']
         lib_types = ['', 'THREADS', 'OMP']
         functions = ['plan_dft', 'init_threads', 'init_threads']
         if self.support_mpi:
@@ -293,6 +293,16 @@ class EnvironmentSniffer(object):
                     found_mpi_types.append(d)
         else:
             self.compile_time_env['HAVE_MPI'] = False
+
+        # Pretend FFTW precision not available, regardless if it was found or
+        # not. Useful for testing that pyfftw still works without requiring all
+        # precisions
+        if 'PYFFTW_IGNORE_SINGLE' in os.environ:
+            self.compile_time_env['HAVE_SINGLE'] = False
+        if 'PYFFTW_IGNORE_DOUBLE' in os.environ:
+            self.compile_time_env['HAVE_DOUBLE'] = False
+        if 'PYFFTW_IGNORE_LONG' in os.environ:
+            self.compile_time_env['HAVE_LONG'] = False
 
         log.debug(repr(self.compile_time_env))
 

--- a/test/test_pyfftw_base.py
+++ b/test/test_pyfftw_base.py
@@ -48,6 +48,11 @@ def miss(*xs):
     skip = not all(x in _supported_types for x in xs)
     return (skip, msg)
 
+def require(self, *xs):
+    skip, msg = miss(*xs)
+    if skip:
+        self.skipTest(msg)
+
 class FFTWBaseTest(unittest.TestCase):
 
     def reference_fftn(self, a, axes):
@@ -63,9 +68,7 @@ class FFTWBaseTest(unittest.TestCase):
 
     def setUp(self):
 
-        skip, msg = miss('32')
-        if skip:
-            self.skipTest(msg)
+        require(self, '32')
 
         self.input_dtype = numpy.complex64
         self.output_dtype = numpy.complex64

--- a/test/test_pyfftw_base.py
+++ b/test/test_pyfftw_base.py
@@ -32,12 +32,21 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
-from pyfftw import FFTW
+from pyfftw import FFTW, _supported_types, _all_types_human_readable
 import numpy
 import struct
 from timeit import Timer
 
 import unittest
+
+def miss(*xs):
+    '''Skip test if the precisions in the iterable `xs` are not available.'''
+    msg = 'Requires %s' % _all_types_human_readable[xs[0]]
+    for x in xs[1:]:
+        msg += ' and %s' % _all_types_human_readable[x]
+    msg += ' precision.'
+    skip = not all(x in _supported_types for x in xs)
+    return (skip, msg)
 
 class FFTWBaseTest(unittest.TestCase):
 
@@ -53,6 +62,10 @@ class FFTWBaseTest(unittest.TestCase):
             self.assertRaisesRegex = self.assertRaisesRegexp
 
     def setUp(self):
+
+        skip, msg = miss('32')
+        if skip:
+            self.skipTest(msg)
 
         self.input_dtype = numpy.complex64
         self.output_dtype = numpy.complex64

--- a/test/test_pyfftw_builders.py
+++ b/test/test_pyfftw_builders.py
@@ -33,6 +33,7 @@
 #
 
 from pyfftw import builders, empty_aligned, byte_align, FFTW
+from pyfftw import _supported_nptypes_complex, _supported_nptypes_real
 from pyfftw.builders import _utils as utils
 from .test_pyfftw_base import run_test_suites
 from ._get_default_args import get_default_args
@@ -46,8 +47,8 @@ import copy
 import warnings
 warnings.filterwarnings('always')
 
-complex_dtypes = (numpy.complex64, numpy.complex128, numpy.clongdouble)
-real_dtypes = (numpy.float32, numpy.float64, numpy.longdouble)
+complex_dtypes = _supported_nptypes_complex
+real_dtypes = _supported_nptypes_real
 
 def make_complex_data(shape, dtype):
     ar, ai = numpy.random.randn(2, *shape).astype(dtype)

--- a/test/test_pyfftw_builders.py
+++ b/test/test_pyfftw_builders.py
@@ -35,7 +35,7 @@
 from pyfftw import builders, empty_aligned, byte_align, FFTW
 from pyfftw import _supported_nptypes_complex, _supported_nptypes_real
 from pyfftw.builders import _utils as utils
-from .test_pyfftw_base import run_test_suites
+from .test_pyfftw_base import run_test_suites, require
 from ._get_default_args import get_default_args
 
 import unittest
@@ -799,6 +799,8 @@ class BuildersTestFFTWWrapper(unittest.TestCase):
             self.assertRaisesRegex = self.assertRaisesRegexp
 
     def setUp(self):
+
+        require(self, '64')
 
         self.input_array_slicer = [slice(None), slice(256)]
         self.FFTW_array_slicer = [slice(128), slice(None)]

--- a/test/test_pyfftw_call.py
+++ b/test/test_pyfftw_call.py
@@ -36,10 +36,11 @@
 from pyfftw import (
         FFTW, empty_aligned, byte_align)
 
-from .test_pyfftw_base import run_test_suites, miss
+from .test_pyfftw_base import run_test_suites, miss, require
 import numpy
 import unittest
 
+@unittest.skipIf(*miss('64'))
 class FFTWCallTest(unittest.TestCase):
 
     def __init__(self, *args, **kwargs):

--- a/test/test_pyfftw_call.py
+++ b/test/test_pyfftw_call.py
@@ -36,7 +36,7 @@
 from pyfftw import (
         FFTW, empty_aligned, byte_align)
 
-from .test_pyfftw_base import run_test_suites
+from .test_pyfftw_base import run_test_suites, miss
 import numpy
 import unittest
 
@@ -205,6 +205,8 @@ class FFTWCallTest(unittest.TestCase):
                 *(),
                 **{'input_array':invalid_array})
 
+
+    @unittest.skipIf(*miss('32'))
     def test_call_with_auto_input_alignment(self):
         '''Test the class call with a keyword input update.
         '''
@@ -389,6 +391,7 @@ class FFTWCallTest(unittest.TestCase):
         # Scaling is performed by default
         self.assertTrue(numpy.allclose(self.input_array, _input_array))
 
+    @unittest.skipIf(*miss('32', '64'))
     def test_call_with_normalisation_precision(self):
         '''The normalisation should use a double precision scaling.
         '''

--- a/test/test_pyfftw_class_misc.py
+++ b/test/test_pyfftw_class_misc.py
@@ -36,7 +36,7 @@ from pyfftw import (
         FFTW, empty_aligned, is_byte_aligned, simd_alignment)
 import pyfftw
 
-from .test_pyfftw_base import run_test_suites
+from .test_pyfftw_base import run_test_suites, miss, require
 
 import unittest
 import numpy
@@ -56,6 +56,7 @@ class FFTWMiscTest(unittest.TestCase):
 
 
     def setUp(self):
+        require(self, '64')
 
         self.input_array = empty_aligned((256, 512), dtype='complex128', n=16)
         self.output_array = empty_aligned((256, 512), dtype='complex128', n=16)
@@ -76,6 +77,7 @@ class FFTWMiscTest(unittest.TestCase):
 
         self.assertFalse(fft.simd_aligned)
 
+    @unittest.skipIf(*miss('32'))
     def test_flags(self):
         '''Test to see if the flags are correct
         '''
@@ -105,6 +107,7 @@ class FFTWMiscTest(unittest.TestCase):
         fft = FFTW(u_input_array, u_output_array)
         self.assertEqual(fft.flags, ('FFTW_MEASURE', 'FFTW_UNALIGNED'))
 
+    @unittest.skipIf(*miss('32'))
     def test_differing_aligned_arrays_update(self):
         '''Test to see if the alignment code is working as expected
         '''
@@ -288,6 +291,7 @@ class FFTWMiscTest(unittest.TestCase):
 
         self.assertEqual(new_fft.output_shape, new_output_array.shape)
 
+    @unittest.skipIf(*miss('32'))
     def test_input_dtype(self):
         '''Test to see if the input_dtype property returns the correct thing
         '''
@@ -300,6 +304,7 @@ class FFTWMiscTest(unittest.TestCase):
 
         self.assertEqual(new_fft.input_dtype, new_input_array.dtype)
 
+    @unittest.skipIf(*miss('32'))
     def test_output_dtype(self):
         '''Test to see if the output_dtype property returns the correct thing
         '''

--- a/test/test_pyfftw_complex.py
+++ b/test/test_pyfftw_complex.py
@@ -41,7 +41,7 @@ import time
 
 import unittest
 
-from .test_pyfftw_base import FFTWBaseTest, run_test_suites
+from .test_pyfftw_base import FFTWBaseTest, run_test_suites, miss
 
 # We make this 1D case not inherit from FFTWBaseTest.
 # It needs to be combined with FFTWBaseTest to work.
@@ -666,7 +666,6 @@ class Complex64FFTW1DTest(object):
         with self.assertRaisesRegex(IndexError, 'Invalid axes'):
                 FFTW(a, b, axes, direction=self.direction)
 
-
 class Complex64FFTWTest(Complex64FFTW1DTest, FFTWBaseTest):
 
     def test_2d(self):
@@ -736,11 +735,10 @@ class Complex64FFTWTest(Complex64FFTW1DTest, FFTWBaseTest):
 
         self.run_validate_fft(a_sliced, b_sliced, axes, create_array_copies=False)
 
-
+@unittest.skipIf(*miss('64'))
 class Complex128FFTWTest(Complex64FFTWTest):
 
     def setUp(self):
-
         self.input_dtype = numpy.complex128
         self.output_dtype = numpy.complex128
         self.np_fft_comparison = numpy.fft.fft
@@ -748,6 +746,7 @@ class Complex128FFTWTest(Complex64FFTWTest):
         self.direction = 'FFTW_FORWARD'
         return
 
+@unittest.skipIf(*miss('ld'))
 class ComplexLongDoubleFFTWTest(Complex64FFTWTest):
 
     def setUp(self):

--- a/test/test_pyfftw_dask_interface.py
+++ b/test/test_pyfftw_dask_interface.py
@@ -35,6 +35,7 @@
 from pyfftw import interfaces
 
 from .test_pyfftw_base import run_test_suites
+from .test_pyfftw_numpy_interface import complex_dtypes, real_dtypes
 from ._get_default_args import get_default_args
 
 from distutils.version import LooseVersion
@@ -52,9 +53,6 @@ except (ImportError, AttributeError):
 import warnings
 import copy
 warnings.filterwarnings('always')
-
-complex_dtypes = (numpy.complex64, numpy.complex64, numpy.complex128, numpy.clongdouble)
-real_dtypes = (numpy.float16, numpy.float32, numpy.float64, numpy.longdouble)
 
 def make_complex_data(shape, dtype):
     ar, ai = dtype(numpy.random.randn(2, *shape))

--- a/test/test_pyfftw_interfaces_cache.py
+++ b/test/test_pyfftw_interfaces_cache.py
@@ -39,7 +39,7 @@ from pyfftw import interfaces, builders
 import numpy
 
 import unittest
-from .test_pyfftw_base import run_test_suites
+from .test_pyfftw_base import run_test_suites, miss
 from .test_pyfftw_numpy_interface import InterfacesNumpyFFTTestFFT
 
 import threading
@@ -64,6 +64,7 @@ def _check_n_cache_threads_running():
 
     return cache_threads
 
+@unittest.skipIf(*miss('64'))
 class InterfacesNumpyFFTCacheTestFFT(InterfacesNumpyFFTTestFFT):
     test_shapes = (
             ((100,), {}),
@@ -87,6 +88,7 @@ class InterfacesNumpyFFTCacheTestFFT(InterfacesNumpyFFTTestFFT):
         # Turn it off to finish
         interfaces.cache.disable()
 
+@unittest.skipIf(*miss('64'))
 class CacheSpecificInterfacesUtils(unittest.TestCase):
 
     def test_slow_lookup_no_race_condition(self):
@@ -221,6 +223,7 @@ class CacheTest(unittest.TestCase):
         time.sleep(0.2)
         self.assertTrue(_check_n_cache_threads_running() == 0)
 
+    @unittest.skipIf(*miss('64'))
     def test_insert_and_lookup_item(self):
         _cache = interfaces.cache._Cache()
 
@@ -232,6 +235,7 @@ class CacheTest(unittest.TestCase):
 
         self.assertIs(_cache.lookup(key), obj)
 
+    @unittest.skipIf(*miss('64'))
     def test_invalid_lookup(self):
         _cache = interfaces.cache._Cache()
 
@@ -264,6 +268,7 @@ class CacheTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             _cache.set_keepalive_time([])
 
+    @unittest.skipIf(*miss('64'))
     def test_contains(self):
         _cache = interfaces.cache._Cache()
 
@@ -276,6 +281,7 @@ class CacheTest(unittest.TestCase):
         self.assertTrue(key in _cache)
         self.assertFalse('Not a key' in _cache)
 
+    @unittest.skipIf(*miss('64'))
     def test_objects_removed_after_keepalive(self):
         _cache = interfaces.cache._Cache()
 

--- a/test/test_pyfftw_multithreaded.py
+++ b/test/test_pyfftw_multithreaded.py
@@ -36,7 +36,7 @@ from pyfftw import FFTW
 import numpy
 from timeit import Timer
 
-from .test_pyfftw_base import run_test_suites
+from .test_pyfftw_base import run_test_suites, miss
 
 import unittest
 
@@ -72,6 +72,7 @@ class Complex64MultiThreadedTest(FFTWBaseTest):
     def test_25_threads(self):
         self.run_multithreaded_test(25)
 
+@unittest.skipIf(*miss('64'))
 class Complex128MultiThreadedTest(Complex64MultiThreadedTest):
 
     def setUp(self):
@@ -81,6 +82,7 @@ class Complex128MultiThreadedTest(Complex64MultiThreadedTest):
         self.np_fft_comparison = numpy.fft.fft
         return
 
+@unittest.skipIf(*miss('ld'))
 class ComplexLongDoubleMultiThreadedTest(Complex64MultiThreadedTest):
 
     def setUp(self):

--- a/test/test_pyfftw_numpy_interface.py
+++ b/test/test_pyfftw_numpy_interface.py
@@ -276,7 +276,7 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
             except NotImplementedError as e:
                 # check if exception due to missing precision
                 msg = repr(e)
-                if 'Rebuild pyfftw with support for' in msg:
+                if 'Rebuild pyFFTW with support for' in msg:
                     self.skipTest(msg)
                 else:
                     raise

--- a/test/test_pyfftw_numpy_interface.py
+++ b/test/test_pyfftw_numpy_interface.py
@@ -229,14 +229,6 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
 
         np_input_array = numpy.asarray(input_array)
 
-        # TODO why are long double inputs copied to double precision?
-        # if np_input_array.dtype == 'clongdouble':
-        #     np_input_array = numpy.complex128(input_array)
-
-        # elif np_input_array.dtype == 'longdouble':
-        #     np_input_array = numpy.float64(input_array)
-
-
         with warnings.catch_warnings(record=True) as w:
             # We catch the warnings so as to pick up on when
             # a complex array is turned into a real array

--- a/test/test_pyfftw_numpy_interface.py
+++ b/test/test_pyfftw_numpy_interface.py
@@ -62,9 +62,6 @@ if 'ld' in _supported_types:
     complex_dtypes.append(numpy.clongdouble)
     real_dtypes.append(numpy.longdouble)
 
-# complex_dtypes = (numpy.complex64, numpy.complex64, numpy.complex128, numpy.clongdouble)
-# real_dtypes = (numpy.float16, numpy.float32, numpy.float64, numpy.longdouble)
-
 def make_complex_data(shape, dtype):
     ar, ai = dtype(numpy.random.randn(2, *shape))
     return ar + 1j*ai

--- a/test/test_pyfftw_numpy_interface.py
+++ b/test/test_pyfftw_numpy_interface.py
@@ -270,9 +270,16 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
                         msg='Interface exception raised. ' +
                         'Testing for: ' + repr(e))
                 return
-
-            output_array = getattr(self.test_interface, self.func)(
-                    copy_func(input_array), s, **kwargs)
+            try:
+                output_array = getattr(self.test_interface, self.func)(
+                                    copy_func(input_array), s, **kwargs)
+            except NotImplementedError as e:
+                # check if exception due to missing precision
+                msg = repr(e)
+                if 'Rebuild pyfftw with support for' in msg:
+                    self.skipTest(msg)
+                else:
+                    raise
 
             if (functions[self.func] == 'r2c'):
                 if numpy.iscomplexobj(input_array):

--- a/test/test_pyfftw_numpy_interface.py
+++ b/test/test_pyfftw_numpy_interface.py
@@ -32,7 +32,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
-from pyfftw import interfaces
+from pyfftw import interfaces, _supported_types
 
 from .test_pyfftw_base import run_test_suites
 from ._get_default_args import get_default_args
@@ -50,8 +50,20 @@ if LooseVersion(numpy.version.version) <= LooseVersion('1.6.2'):
     from ._cook_nd_args import _cook_nd_args
     numpy.fft.fftpack._cook_nd_args = _cook_nd_args
 
-complex_dtypes = (numpy.complex64, numpy.complex64, numpy.complex128, numpy.clongdouble)
-real_dtypes = (numpy.float16, numpy.float32, numpy.float64, numpy.longdouble)
+complex_dtypes = []
+real_dtypes = []
+if '32' in _supported_types:
+    complex_dtypes.extend([numpy.complex64]*2)
+    real_dtypes.extend([numpy.float16, numpy.float32])
+if '64' in _supported_types:
+    complex_dtypes.append(numpy.complex128)
+    real_dtypes.append(numpy.float64)
+if 'ld' in _supported_types:
+    complex_dtypes.append(numpy.clongdouble)
+    real_dtypes.append(numpy.longdouble)
+
+# complex_dtypes = (numpy.complex64, numpy.complex64, numpy.complex128, numpy.clongdouble)
+# real_dtypes = (numpy.float16, numpy.float32, numpy.float64, numpy.longdouble)
 
 def make_complex_data(shape, dtype):
     ar, ai = dtype(numpy.random.randn(2, *shape))

--- a/test/test_pyfftw_partial.py
+++ b/test/test_pyfftw_partial.py
@@ -1,0 +1,59 @@
+# Copyright 2017 Knowledge Economy Developments Ltd
+#
+# Henry Gomersall
+# heng@kedevelopments.co.uk
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+from pyfftw import (
+    FFTW, empty_aligned,
+    _all_types_human_readable, _supported_types
+    )
+import numpy as np
+import unittest
+
+class FFTWPartialTest(unittest.TestCase):
+
+    def test_failure(self):
+        for dtype, npdtype in zip(['32', '64', 'ld'], [np.complex64, np.complex128, np.clongdouble]):
+            if dtype not in _supported_types:
+                a = empty_aligned((1,1024), npdtype, n=16)
+                b = empty_aligned(a.shape, dtype=a.dtype, n=16)
+                with self.assertRaisesRegex(NotImplementedError, "Rebuild pyFFTW with support for %s precision!" % _all_types_human_readable[dtype]):
+                    FFTW(a,b)
+
+test_cases = (
+        FFTWPartialTest,)
+
+test_set = None
+
+if __name__ == '__main__':
+
+    run_test_suites(test_cases, test_set)

--- a/test/test_pyfftw_partial.py
+++ b/test/test_pyfftw_partial.py
@@ -2,6 +2,8 @@
 #
 # Henry Gomersall
 # heng@kedevelopments.co.uk
+# Frederik Beaujean
+# Frederik.Beaujean@lmu.de
 #
 # All rights reserved.
 #
@@ -53,8 +55,12 @@ class FFTWPartialTest(unittest.TestCase):
             if dtype not in _supported_types:
                 a = empty_aligned((1,1024), npdtype, n=16)
                 b = empty_aligned(a.shape, dtype=a.dtype, n=16)
-                with self.assertRaisesRegex(NotImplementedError, "Rebuild pyFFTW with support for %s precision!" % _all_types_human_readable[dtype]):
+                msg = "Rebuild pyFFTW with support for %s precision!" % _all_types_human_readable[dtype]
+                with self.assertRaisesRegex(NotImplementedError, msg):
                     FFTW(a,b)
+
+    def test_conversion(self):
+        # If double precision not supported, the builder should convert to single precision
 
 test_cases = (
         FFTWPartialTest,)

--- a/test/test_pyfftw_partial.py
+++ b/test/test_pyfftw_partial.py
@@ -41,6 +41,13 @@ import unittest
 
 class FFTWPartialTest(unittest.TestCase):
 
+    def __init__(self, *args, **kwargs):
+
+        super(FFTWPartialTest, self).__init__(*args, **kwargs)
+
+        if not hasattr(self, 'assertRaisesRegex'):
+            self.assertRaisesRegex = self.assertRaisesRegexp
+
     def test_failure(self):
         for dtype, npdtype in zip(['32', '64', 'ld'], [np.complex64, np.complex128, np.clongdouble]):
             if dtype not in _supported_types:

--- a/test/test_pyfftw_real_backward.py
+++ b/test/test_pyfftw_real_backward.py
@@ -38,7 +38,7 @@ import numpy
 from timeit import Timer
 import time
 
-from .test_pyfftw_base import run_test_suites
+from .test_pyfftw_base import run_test_suites, miss, require
 
 import unittest
 
@@ -47,6 +47,7 @@ from .test_pyfftw_complex import Complex64FFTWTest
 class RealBackwardDoubleFFTWTest(Complex64FFTWTest):
 
     def setUp(self):
+        require(self, '64')
 
         self.input_dtype = numpy.complex128
         self.output_dtype = numpy.float64
@@ -306,6 +307,7 @@ class RealBackwardDoubleFFTWTest(Complex64FFTWTest):
         super(RealBackwardDoubleFFTWTest,
                 self).test_non_monotonic_increasing_axes()
 
+@unittest.skipIf(*miss('32'))
 class RealBackwardSingleFFTWTest(RealBackwardDoubleFFTWTest):
 
     def setUp(self):
@@ -316,6 +318,7 @@ class RealBackwardSingleFFTWTest(RealBackwardDoubleFFTWTest):
 
         self.direction = 'FFTW_BACKWARD'
 
+@unittest.skipIf(*miss('ld'))
 class RealBackwardLongDoubleFFTWTest(RealBackwardDoubleFFTWTest):
 
     def setUp(self):

--- a/test/test_pyfftw_real_forward.py
+++ b/test/test_pyfftw_real_forward.py
@@ -36,7 +36,7 @@ from pyfftw import FFTW
 import numpy
 from timeit import Timer
 
-from .test_pyfftw_base import run_test_suites
+from .test_pyfftw_base import run_test_suites, miss, require
 
 import unittest
 
@@ -45,6 +45,7 @@ from .test_pyfftw_complex import Complex64FFTWTest
 class RealForwardDoubleFFTWTest(Complex64FFTWTest):
 
     def setUp(self):
+        require(self, '64')
 
         self.input_dtype = numpy.float64
         self.output_dtype = numpy.complex128
@@ -114,6 +115,7 @@ class RealForwardDoubleFFTWTest(Complex64FFTWTest):
 
         self.run_validate_fft(a_sliced, b_sliced, axes, create_array_copies=False)
 
+@unittest.skipIf(*miss('32'))
 class RealForwardSingleFFTWTest(RealForwardDoubleFFTWTest):
 
     def setUp(self):
@@ -124,6 +126,7 @@ class RealForwardSingleFFTWTest(RealForwardDoubleFFTWTest):
 
         self.direction = 'FFTW_FORWARD'
 
+@unittest.skipIf(*miss('ld'))
 class RealForwardLongDoubleFFTWTest(RealForwardDoubleFFTWTest):
 
     def setUp(self):

--- a/test/test_pyfftw_scipy_interface.py
+++ b/test/test_pyfftw_scipy_interface.py
@@ -79,8 +79,8 @@ make_complex_data = test_pyfftw_numpy_interface.make_complex_data
 if scipy.__version__ < '0.19':
     # Older scipy will raise an error for inputs of type float16, so we
     # cannot validate transforms with float16 input vs. scipy.fftpack
-    complex_dtypes = _supported_nptypes_complex
-    real_dtypes = _supported_nptypes_real
+    complex_dtypes = pyfftw._supported_nptypes_complex
+    real_dtypes = pyfftw._supported_nptypes_real
 else:
     # reuse all dtypes from numpy tests (including float16)
     complex_dtypes = test_pyfftw_numpy_interface.complex_dtypes

--- a/test/test_pyfftw_scipy_interface.py
+++ b/test/test_pyfftw_scipy_interface.py
@@ -48,7 +48,7 @@ else:
     scipy_missing = False
 
 import unittest
-from .test_pyfftw_base import run_test_suites
+from .test_pyfftw_base import run_test_suites, miss
 from . import test_pyfftw_numpy_interface
 
 '''pyfftw.interfaces.scipy_fftpack just wraps pyfftw.interfaces.numpy_fft.
@@ -103,6 +103,7 @@ class InterfacesScipyFFTPackTestSimple(unittest.TestCase):
     ''' A really simple test suite to check simple implementation.
     '''
 
+    @unittest.skipIf(*miss('64'))
     def test_scipy_overwrite(self):
 
         new_style_scipy_fftn = False

--- a/test/test_pyfftw_scipy_interface.py
+++ b/test/test_pyfftw_scipy_interface.py
@@ -86,6 +86,10 @@ else:
     complex_dtypes = test_pyfftw_numpy_interface.complex_dtypes
     real_dtypes = test_pyfftw_numpy_interface.real_dtypes
 
+# Remove long double because scipy explicitly doesn't support it
+complex_dtypes = [x for x in complex_dtypes if x != numpy.clongdouble]
+real_dtypes = [x for x in real_dtypes if x != numpy.longdouble]
+
 def numpy_fft_replacement(a, s, axes, overwrite_input, planner_effort,
         threads, auto_align_input, auto_contiguous):
 

--- a/test/test_pyfftw_scipy_interface.py
+++ b/test/test_pyfftw_scipy_interface.py
@@ -79,8 +79,8 @@ make_complex_data = test_pyfftw_numpy_interface.make_complex_data
 if scipy.__version__ < '0.19':
     # Older scipy will raise an error for inputs of type float16, so we
     # cannot validate transforms with float16 input vs. scipy.fftpack
-    complex_dtypes = (numpy.complex64, numpy.complex128, numpy.clongdouble)
-    real_dtypes = (numpy.float32, numpy.float64, numpy.longdouble)
+    complex_dtypes = _supported_nptypes_complex
+    real_dtypes = _supported_nptypes_real
 else:
     # reuse all dtypes from numpy tests (including float16)
     complex_dtypes = test_pyfftw_numpy_interface.complex_dtypes

--- a/test/test_pyfftw_wisdom.py
+++ b/test/test_pyfftw_wisdom.py
@@ -57,7 +57,7 @@ class FFTWWisdomTest(unittest.TestCase):
     def compare_single(self, prec, before, after):
         # skip over unsupported data types where wisdom is the empty string
         if  prec in _supported_types:
-            print(prec, ": before", before, "after", after)
+            print(prec, ": before", before, "\nafter", after)
             self.assertNotEqual(before, after)
         else:
             self.assertEqual(before, b'')
@@ -98,9 +98,50 @@ class FFTWWisdomTest(unittest.TestCase):
 
         self.assertEqual(success, tuple([x in _supported_types for x in ['64', '32', 'ld']]))
 
+class FFTWWisdomTestMaster(unittest.TestCase):
+
+    def generate_wisdom(self):
+        for each_dtype in (numpy.complex128, numpy.complex64,
+                numpy.clongdouble):
+
+            a = empty_aligned((1,1024), each_dtype, n=16)
+            b = empty_aligned(a.shape, dtype=a.dtype, n=16)
+            fft = FFTW(a,b)
+
+
+    def test_export(self):
+
+        forget_wisdom()
+
+        before_wisdom = export_wisdom()
+
+        self.generate_wisdom()
+
+        after_wisdom = export_wisdom()
+
+        for n in range(0,2):
+            self.assertNotEqual(before_wisdom[n], after_wisdom[n])
+
+    def test_import(self):
+
+        forget_wisdom()
+
+        self.generate_wisdom()
+
+        after_wisdom = export_wisdom()
+
+        forget_wisdom()
+        before_wisdom = export_wisdom()
+
+        success = import_wisdom(after_wisdom)
+
+        for n in range(0,2):
+            self.assertNotEqual(before_wisdom[n], after_wisdom[n])
+
+        self.assertEqual(success, (True, True, True))
 
 test_cases = (
-        FFTWWisdomTest,)
+        FFTWWisdomTest, FFTWWisdomTestMaster)
 
 test_set = None
 

--- a/test/test_pyfftw_wisdom.py
+++ b/test/test_pyfftw_wisdom.py
@@ -34,7 +34,8 @@
 
 from pyfftw import (
         FFTW, empty_aligned,
-        export_wisdom, import_wisdom, forget_wisdom, _supported_nptypes_complex)
+        export_wisdom, import_wisdom, forget_wisdom,
+        _supported_types, _supported_nptypes_complex)
 
 from .test_pyfftw_base import run_test_suites
 
@@ -53,6 +54,21 @@ class FFTWWisdomTest(unittest.TestCase):
             fft = FFTW(a,b)
 
 
+    def compare_single(self, supported, before, after):
+        # skip over unsupported data types where wisdom is the empty string
+        if supported:
+            self.assertNotEqual(before, after)
+        else:
+            self.assertEqual(before, b'')
+            self.assertEqual(before, after)
+
+
+    def compare(self, before, after):
+        self.compare_single('64' in _supported_types, before[0], after[0])
+        self.compare_single('32' in _supported_types, before[1], after[1])
+        self.compare_single('ld' in _supported_types, before[2], after[2])
+
+
     def test_export(self):
 
         forget_wisdom()
@@ -63,8 +79,7 @@ class FFTWWisdomTest(unittest.TestCase):
 
         after_wisdom = export_wisdom()
 
-        for n, _ in enumerate(_supported_nptypes_complex):
-            self.assertNotEqual(before_wisdom[n], after_wisdom[n])
+        self.compare(before_wisdom, after_wisdom)
 
     def test_import(self):
 
@@ -79,8 +94,7 @@ class FFTWWisdomTest(unittest.TestCase):
 
         success = import_wisdom(after_wisdom)
 
-        for n, _ in enumerate(_supported_nptypes_complex):
-            self.assertNotEqual(before_wisdom[n], after_wisdom[n])
+        self.compare(before_wisdom, after_wisdom)
 
         self.assertEqual(success, (True, True, True))
 

--- a/test/test_pyfftw_wisdom.py
+++ b/test/test_pyfftw_wisdom.py
@@ -48,9 +48,9 @@ class FFTWWisdomTest(unittest.TestCase):
 
     def generate_wisdom(self):
         for each_dtype in _supported_nptypes_complex:
-
-            a = empty_aligned((1,1024), each_dtype, n=16)
-            b = empty_aligned(a.shape, dtype=a.dtype, n=16)
+            n = 16
+            a = empty_aligned((1,1024), each_dtype, n=n)
+            b = empty_aligned(a.shape, dtype=a.dtype, n=n)
             fft = FFTW(a,b)
 
 

--- a/test/test_pyfftw_wisdom.py
+++ b/test/test_pyfftw_wisdom.py
@@ -64,9 +64,8 @@ class FFTWWisdomTest(unittest.TestCase):
 
 
     def compare(self, before, after):
-        self.compare_single('64' in _supported_types, before[0], after[0])
-        self.compare_single('32' in _supported_types, before[1], after[1])
-        self.compare_single('ld' in _supported_types, before[2], after[2])
+        for prec, ind in zip(['64', '32', 'ld'], [0,1,2]):
+            self.compare_single(prec in _supported_types, before[ind], after[ind])
 
 
     def test_export(self):
@@ -96,7 +95,7 @@ class FFTWWisdomTest(unittest.TestCase):
 
         self.compare(before_wisdom, after_wisdom)
 
-        self.assertEqual(success, (True, True, True))
+        self.assertEqual(success, tuple([x in _supported_types for x in ['64', '32', 'ld']]))
 
 
 test_cases = (

--- a/test/test_pyfftw_wisdom.py
+++ b/test/test_pyfftw_wisdom.py
@@ -63,7 +63,7 @@ class FFTWWisdomTest(unittest.TestCase):
 
         after_wisdom = export_wisdom()
 
-        for n in range(0,2):
+        for n, _ in enumerate(_supported_nptypes_complex):
             self.assertNotEqual(before_wisdom[n], after_wisdom[n])
 
     def test_import(self):
@@ -79,7 +79,7 @@ class FFTWWisdomTest(unittest.TestCase):
 
         success = import_wisdom(after_wisdom)
 
-        for n in range(0,2):
+        for n, _ in enumerate(_supported_nptypes_complex):
             self.assertNotEqual(before_wisdom[n], after_wisdom[n])
 
         self.assertEqual(success, (True, True, True))

--- a/test/test_pyfftw_wisdom.py
+++ b/test/test_pyfftw_wisdom.py
@@ -54,9 +54,10 @@ class FFTWWisdomTest(unittest.TestCase):
             fft = FFTW(a,b)
 
 
-    def compare_single(self, supported, before, after):
+    def compare_single(self, prec, before, after):
         # skip over unsupported data types where wisdom is the empty string
-        if supported:
+        if  prec in _supported_types:
+            print(prec, ": before", before, "after", after)
             self.assertNotEqual(before, after)
         else:
             self.assertEqual(before, b'')
@@ -65,7 +66,7 @@ class FFTWWisdomTest(unittest.TestCase):
 
     def compare(self, before, after):
         for prec, ind in zip(['64', '32', 'ld'], [0,1,2]):
-            self.compare_single(prec in _supported_types, before[ind], after[ind])
+            self.compare_single(prec, before[ind], after[ind])
 
 
     def test_export(self):

--- a/test/test_pyfftw_wisdom.py
+++ b/test/test_pyfftw_wisdom.py
@@ -34,7 +34,7 @@
 
 from pyfftw import (
         FFTW, empty_aligned,
-        export_wisdom, import_wisdom, forget_wisdom)
+        export_wisdom, import_wisdom, forget_wisdom, _supported_nptypes_complex)
 
 from .test_pyfftw_base import run_test_suites
 
@@ -46,8 +46,7 @@ import unittest
 class FFTWWisdomTest(unittest.TestCase):
 
     def generate_wisdom(self):
-        for each_dtype in (numpy.complex128, numpy.complex64,
-                numpy.clongdouble):
+        for each_dtype in _supported_nptypes_complex:
 
             a = empty_aligned((1,1024), each_dtype, n=16)
             b = empty_aligned(a.shape, dtype=a.dtype, n=16)

--- a/travis/partial.sh
+++ b/travis/partial.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# build pyfftw while ignoring one precision, then run tests.
+
+# fail if any command below fails
+set -e
+
+# move relative to directory of this script
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $DIR/..
+
+for v in PYFFTW_IGNORE_DOUBLE PYFFTW_IGNORE_SINGLE PYFFTW_IGNORE_LONG
+do
+    # declare variable based on the value of `v`
+    declare "${v}"=1
+    export "${v}"
+    # test shouldn't fail because pyfftw.c is not there yet
+    rm pyfftw/pyfftw.c || true
+    python setup.py build_ext -i
+    python setup.py test
+    unset "${v}"
+done


### PR DESCRIPTION
After #177 and #185 have been merged, it remains to use available information on available libs during build time and during run time to run only available tests. 

This is work in progress and should not be merged yet but I want to open the PR so you can have a look at what's coming.

The essential steps

- [x] build with cython compile time `IF HAVE_DOUBLE`. Fixes long-standing issues #27 and #70
- [x] skip tests for unavailable FFTW libs. Fixes #127