### PR TITLE
WIP: support building from conda-forge FFTW packages on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,8 +96,14 @@ def get_package_data():
     package_data = {}
 
     if get_build_platform() in ('win32', 'win-amd64'):
-        package_data['pyfftw'] = [
-            'libfftw3-3.dll', 'libfftw3l-3.dll', 'libfftw3f-3.dll']
+        if 'PYFFTW_WIN_CONDAFORGE' in os.environ:
+            # fftw3.dll, fftw3f.dll will already be on the path (via the
+            # conda environment's \bin subfolder)
+            pass
+        else:
+            # as download from http://www.fftw.org/install/windows.html
+            package_data['pyfftw'] = [
+                'libfftw3-3.dll', 'libfftw3l-3.dll', 'libfftw3f-3.dll']
 
     return package_data
 
@@ -353,7 +359,12 @@ class EnvironmentSniffer(object):
 
         '''
         if get_platform() in ('win32', 'win-amd64'):
-            return 'lib%s-3' % lib
+            if 'PYFFTW_WIN_CONDAFORGE' in os.environ:
+                return '%s' % lib
+            else:
+                # for download from http://www.fftw.org/install/windows.html
+                return 'lib%s-3' % lib
+
         else:
             return lib
 

--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,9 @@ def get_library_dirs():
         library_dirs.append(os.path.join(os.getcwd(), 'pyfftw'))
         library_dirs.append(os.path.join(sys.prefix, 'bin'))
 
+    if 'PYFFTW_LIB_DIR' in os.environ:
+        library_dirs.append(os.environ['PYFFTW_LIB_DIR'])
+
     library_dirs.append(os.path.join(sys.prefix, 'lib'))
     if get_build_platform().startswith('freebsd'):
         library_dirs.append('/usr/local/lib')


### PR DESCRIPTION
This PR adds two environment variables that allow the assumed library path and filenames to be modified to work with conda-forge's FFTW packages on Windows.  The existing Windows installation behavior is unmodified when these environment variables are not defined.

1.  Unlike the pre-built binaries from fftw.org, the conda-forge libraries have names like `fftw3f.dll` rather than `libfftw3f-3.dll`.  This naming convention can be selected by defining `PYFFTW_WIN_CONDAFORGE`.  

2. `PYFFTW_LIB_DIR` should be set to the folder containing `fftw3.lib` and `fftw3f.lib`.  For conda-forge this is the `lib` subfolder of the environment.

3.  On conda, the dll files will already be on the path (via the `\bin` subfolder of the environment), so they do not need to be included in `package_data`.  

**Note:** conda-forge's Windows build does not include long-double support, so the build will only complete once this PR is combined with the proposed changes from #189.