### PR TITLE
simple fix to overflow in empty_aligned() (on Windows machine)

### DIFF
--- a/pyfftw/utils.pxi
+++ b/pyfftw/utils.pxi
@@ -182,6 +182,8 @@ cpdef empty_aligned(shape, dtype='float64', order='C', n=None):
     determine alignment. The rest of the arguments are as per
     :func:`numpy.empty`.
     '''
+    cdef long long array_length
+
     if n is None:
         n = _simd_alignment
 


### PR DESCRIPTION
The previous codes (even with the explicit multiplication in lines 196 to 198 in utils.pxi) still depend on the machine default which causes pyFFTW on Windows machine to throw overflow error. It fixes the problem to specify the type of variable `array_length`.