### PR TITLE
Fix broken build with OpenMP

### DIFF
--- a/pyfftw/interfaces/__init__.py
+++ b/pyfftw/interfaces/__init__.py
@@ -239,10 +239,12 @@ else:
 try:
     import dask.array.fft
     dask.array.fft.fft_wrap
-except ImportError:
+except (ImportError, AttributeError):
     pass
-except AttributeError:
-    del dask
 else:
-    del dask
     from . import dask_fft
+
+try:
+    del dask
+except NameError:
+    pass

--- a/setup.py
+++ b/setup.py
@@ -257,6 +257,9 @@ class EnvironmentSniffer(object):
                 lib_omp = False
                 self.compile_time_env[self.HAVE(d, 'OMP')] = False
 
+            if lib_omp:
+                self.compile_time_env[self.HAVE(d, 'THREADS')] = False
+
             if not lib_omp:
                 # -pthread added for gcc/clang when checking for threads
                 self.linker_flags.append(self.pthread_linker_flag())

--- a/test/test_pyfftw_dask_interface.py
+++ b/test/test_pyfftw_dask_interface.py
@@ -45,7 +45,7 @@ try:
     import dask.array as da
     from dask.array import fft as da_fft
     from dask.array.fft import fft_wrap
-except ImportError:
+except (ImportError, AttributeError):
     da = None
     da_fft = None
 


### PR DESCRIPTION
Apparently HAVE_DOUBLE_THREADS, etc. were never set to either True or False when the OpenMP libraries were found instead.  This PR should fix that.  This was a source of recent build failures as in #192 (see: https://travis-ci.org/pyFFTW/pyFFTW/jobs/276350807#L899) and as mentioned by a user in #197.

I am not sure how this was previously passing on Travis CI, but perhaps the set of FFTW libs that gets installed on Travis has changed in the time since #189 was merged.

@fredRos, do you mind taking a quick look at the proposed change?
