### PR TITLE
Fix test suite on machines without any SIMD instruction sets

### DIFF
--- a/test/test_pyfftw_builders.py
+++ b/test/test_pyfftw_builders.py
@@ -36,6 +36,7 @@ from pyfftw import builders, empty_aligned, byte_align, FFTW
 from pyfftw.builders import _utils as utils
 from .test_pyfftw_base import run_test_suites
 from ._get_default_args import get_default_args
+from pyfftw.pyfftw import _valid_simd_alignments
 
 import unittest
 import numpy
@@ -442,22 +443,23 @@ class BuildersTestFFT(unittest.TestCase):
 
                 # Now for the contiguous case (for both
                 # FFTW and _FFTWWrapper)
-                _kwargs['auto_contiguous'] = True
-                FFTW_object = getattr(builders, self.func)(
+                if len(_valid_simd_alignments) > 0:
+                    _kwargs['auto_contiguous'] = True
+                    FFTW_object = getattr(builders, self.func)(
                         input_array, s1, **_kwargs)
 
-                internal_input_array = FFTW_object.input_array
-                flags = internal_input_array.flags
-                self.assertTrue(flags['C_CONTIGUOUS'] or
-                    flags['F_CONTIGUOUS'])
+                    internal_input_array = FFTW_object.input_array
+                    flags = internal_input_array.flags
+                    self.assertTrue(flags['C_CONTIGUOUS'] or
+                                    flags['F_CONTIGUOUS'])
 
-                FFTW_object = getattr(builders, self.func)(
+                    FFTW_object = getattr(builders, self.func)(
                         input_array, s2, **_kwargs)
 
-                internal_input_array = FFTW_object.input_array
-                flags = internal_input_array.flags
-                # as above
-                self.assertTrue(flags['C_CONTIGUOUS'])
+                    internal_input_array = FFTW_object.input_array
+                    flags = internal_input_array.flags
+                    # as above
+                    self.assertTrue(flags['C_CONTIGUOUS'])
 
 
     def test_auto_align_input(self):

--- a/test/test_pyfftw_class_misc.py
+++ b/test/test_pyfftw_class_misc.py
@@ -35,6 +35,7 @@
 from pyfftw import (
         FFTW, empty_aligned, is_byte_aligned, simd_alignment)
 import pyfftw
+from pyfftw.pyfftw import _valid_simd_alignments
 
 from .test_pyfftw_base import run_test_suites
 
@@ -68,8 +69,9 @@ class FFTWMiscTest(unittest.TestCase):
     def test_aligned_flag(self):
         '''Test to see if the aligned flag is correct
         '''
-        fft = FFTW(self.input_array, self.output_array)
-        self.assertTrue(fft.simd_aligned)
+        if len(_valid_simd_alignments) > 0:
+            fft = FFTW(self.input_array, self.output_array)
+            self.assertTrue(fft.simd_aligned)
 
         fft = FFTW(self.input_array, self.output_array,
                 flags=('FFTW_UNALIGNED',))
@@ -79,11 +81,16 @@ class FFTWMiscTest(unittest.TestCase):
     def test_flags(self):
         '''Test to see if the flags are correct
         '''
-        fft = FFTW(self.input_array, self.output_array)
-        self.assertEqual(fft.flags, ('FFTW_MEASURE',))
+        if len(_valid_simd_alignments) > 0:
+            fft = FFTW(self.input_array, self.output_array)
+            self.assertEqual(fft.flags, ('FFTW_MEASURE',))
+        else:
+            # FFTW_UNALIGNED is automatically appended when SIMD isn't detected
+            fft = FFTW(self.input_array, self.output_array)
+            self.assertEqual(fft.flags, ('FFTW_MEASURE', 'FFTW_UNALIGNED'))
 
         fft = FFTW(self.input_array, self.output_array,
-                flags=('FFTW_DESTROY_INPUT', 'FFTW_UNALIGNED'))
+                   flags=('FFTW_DESTROY_INPUT', 'FFTW_UNALIGNED'))
         self.assertEqual(fft.flags, ('FFTW_DESTROY_INPUT', 'FFTW_UNALIGNED'))
 
         # Test an implicit flag

--- a/test/test_pyfftw_complex.py
+++ b/test/test_pyfftw_complex.py
@@ -290,8 +290,9 @@ class Complex64FFTW1DTest(object):
         fft, ifft = self.run_validate_fft(a, b, axes,
                 create_array_copies=False)
 
-        self.assertTrue(fft.input_alignment == 16)
-        self.assertTrue(fft.output_alignment == 16)
+        if 'FFTW_UNALIGNED' not in fft.flags:
+            self.assertTrue(fft.input_alignment == 16)
+            self.assertTrue(fft.output_alignment == 16)
 
         a[:] = a_orig
         fft, ifft = self.run_validate_fft(a, b_, axes,

--- a/test/test_pyfftw_utils.py
+++ b/test/test_pyfftw_utils.py
@@ -76,18 +76,19 @@ class UtilsTest(unittest.TestCase):
 
         return
 
-    @unittest.skipIf('Linux' not in platform.system(),
-            'Skipping as we only have it set up for Linux at present.')
+    @unittest.skipIf(
+        'Linux' not in platform.system(),
+        'Skipping as we only have it set up for Linux at present.')
     def test_get_alignment(self):
         cpus_info = get_cpus_info()
-
         for each_cpu in cpus_info:
-            if 'avx' in each_cpu['flags']:
+            flags = each_cpu.get('flags', [])
+            if 'avx' in flags:
                 self.assertTrue(pyfftw.simd_alignment == 32)
-            elif 'sse' in each_cpu['flags']:
+            elif 'sse' in flags:
                 self.assertTrue(pyfftw.simd_alignment == 16)
             else:
-                self.assertTrue(pyfftw.simd_alignment == 1)
+                self.assertTrue(pyfftw.simd_alignment == 4)
 
 
 class NextFastLenTest(unittest.TestCase):


### PR DESCRIPTION
This is an attempt to address the ARM test failures reported by @ghisvail in #128.  We currently only support SSE and AVX SIMD variants.  If neither is found, a few tests related to SIMD auto-alignment are skipped.
