### PR TITLE
Update minimum requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ env:
 
 python:
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
+  - 3.6
 
 branches:
     except:

--- a/README.rst
+++ b/README.rst
@@ -48,13 +48,12 @@ index page is `here <http://pypi.python.org/pypi/pyFFTW>`_.
 
 Requirements (i.e. what it was designed for)
 --------------------------------------------
-- Python 2.7 or greater (Python 3 is supported)
-- Numpy 1.6
+- Python 2.7 or 3.4+
+- Numpy 1.10
 - FFTW 3.3 or higher (lower versions *may* work) libraries for single, double,
   and long double precision in serial and multithreading (pthreads or openMP)
-  versions
-- Cython 0.15 or higher (though the source release on PyPI loses this
-  dependency)
+  versions.
+- Cython 0.23 or higher
 
 (install these as much as possible with your preferred package manager).
 

--- a/README.rst
+++ b/README.rst
@@ -23,8 +23,9 @@
 PyFFTW
 ======
 
-pyFFTW is a pythonic wrapper around `FFTW 3 <http://www.fftw.org/>`_, the
-speedy FFT library.  The ultimate aim is to present a unified interface for all the possible transforms that FFTW can perform.
+pyFFTW is a pythonic wrapper around FFTW_ 3, the speedy FFT library.  The
+ultimate aim is to present a unified interface for all the possible transforms
+that FFTW can perform.
 
 Both the complex DFT and the real DFT are supported, as well as on arbitrary
 axes of abitrary shaped and strided arrays, which makes it almost
@@ -38,24 +39,33 @@ Operating FFTW in multithreaded mode is supported.
 pyFFTW implements the numpy and scipy fft interfaces in order for users to
 take advantage of the speed of FFTW with minimal code modifications.
 
-A comprehensive unittest suite can be found with the source on the github
-repository or with the source distribution on PyPI.
+A comprehensive unittest suite can be found with the source on the GitHub_
+repository or with the source distribution on PyPI_.
 
-The documentation can be found on
-`Read the Docs <http://pyfftw.readthedocs.io>`_, the source is
-on `github <https://github.com/pyFFTW/pyFFTW>`_ and the python package
-index page is `here <http://pypi.python.org/pypi/pyFFTW>`_.
+The documentation can be found on `Read the Docs`_, the source is on GitHub_
+and the python package index page (PyPI_).  Issues and questions can be
+raised at the `GitHub Issues`_ page.
 
 Requirements (i.e. what it was designed for)
 --------------------------------------------
-- Python 2.7 or 3.4+
-- Numpy 1.10
-- FFTW 3.3 or higher (lower versions *may* work) libraries for single, double,
+- Python_ 2.7 or >= 3.4
+- Numpy_ >= 1.10.4  (lower versions *may* work)
+- FFTW_ >= 3.3 (lower versions *may* work) libraries for single, double,
   and long double precision in serial and multithreading (pthreads or openMP)
   versions.
-- Cython 0.23 or higher
+- Cython_ >= 0.23 (lower versions *may* work)
 
 (install these as much as possible with your preferred package manager).
+
+In practice, pyFFTW *may* work with older versions of these dependencies, but
+it is not tested against them.
+
+Optional Dependencies
+---------------------
+- Scipy_ >= 0.16
+- Dask_ >= 0.14.2
+
+Scipy and Dask are only required in order to use their respective interfaces.
 
 Installation
 ------------
@@ -69,15 +79,14 @@ or::
 
   easy_install pyfftw
 
-Installers are on the PyPI page for both 32- and 64-bit Windows, which include
+Installers are on the PyPI_ page for both 32- and 64-bit Windows, which include
 all the necessary DLLs.
 
 With FFTW installed, the PyPI release should install fine on Linux and Mac OSX. It doesn't mean it won't work anywhere else, just we don't have any information on it.
 
-Windows development builds are also automatically uploaded to
-`bintray <https://bintray.com/hgomersall/generic/PyFFTW-development-builds/view>`_
-as wheels (which are built against numpy 1.9), from where they can be
-downloaded and installed with something like::
+Windows development builds are also automatically uploaded to bintray_ as
+wheels (which are built against numpy 1.9), from where they can be downloaded
+and installed with something like::
 
   pip install pyFFTW-0.10.0.dev0+79ec589-cp35-none-win_amd64.whl
 
@@ -112,7 +121,7 @@ option is available, pyFFTW works in serial mode only.
 
 For more ways of building and installing, see the
 `distutils documentation <http://docs.python.org/distutils/builtdist.html>`_
-and `setuptools documentation <https://pythonhosted.org/setuptools/>`_.
+and `setuptools documentation <https://setuptools.readthedocs.io>`_.
 
 Platform specific build info
 ----------------------------
@@ -155,13 +164,8 @@ Now install pyfftw from pip::
 
   pip install pyfftw
 
-Notes: `pkgin <http://saveosx.org>`_ fftw package does not contain the long or
-float implementations of fftw and so pyFFTW can only perform double-precision
-transforms.
-
-It has been suggested that `macports <http://www.macports.org/>`_ might also
-work fine. You should then replace the LD environmental variables above with the
-right ones.
+It has been suggested that macports_ might also work fine. You should then
+replace the LD environmental variables above with the right ones.
 
 - DYLD - path for libfftw3.dylib etc - ``find /usr -name libfftw3.dylib``
 - LDFLAGS - path for fftw3.h - ``find /usr -name fftw3.h``
@@ -191,7 +195,7 @@ See some of my philosophy on testing in development `here
 If you want to argue with the philosophy, there is probably a good place to
 do it.
 
-New contributions should adhere to pep-8, but this is only weakly enforced
+New contributions should adhere to `PEP 8`_, but this is only weakly enforced
 (there is loads of legacy stuff that breaks it, and things like a single
 trailing whitespace is not a big deal).
 
@@ -202,3 +206,17 @@ where I can with any conceptual issues.
 
 I suggest reading the issues already open in order that you know where things
 might be heading, or what others are working on.
+
+.. _Python: https://python.org
+.. _FFTW: https://www.fftw.org
+.. _NumPy: https://www.numpy.org
+.. _Cython: https://cython.org
+.. _SciPy: https://www.scipy.org
+.. _Dask: https://dask.pydata.org
+.. _GitHub: https://github.com/PyFFTW/PyFFTW
+.. _GitHub Issues: https://github.com/PyFFTW/PyFFTW/issues
+.. _PyPI: https://pypi.python.org
+.. _Read the Docs: https://pyfftw.readthedocs.io
+.. _bintray: https://bintray.com/hgomersall/generic/PyFFTW-development-builds/view
+.. _PEP 8: https://www.python.org/dev/peps/pep-0008
+.. _macports:  https://www.macports.org

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,10 @@ environment:
         CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
         # The miniconda installations are put in pyfftw_miniconda
         PYTHON_HOME: "C:\\pyfftw_miniconda"
-        NP_BUILD_DEP: "1.9"
+        NP_BUILD_DEP: "1.10"
+        SP_BUILD_DEP: "0.16"
+        CYTHON_BUILD_DEP: "0.23"
+        EXTRA_CONDA_ARGS: ""
 
     pypi_username:
         secure: qFSpEDsIOj6gzynjuHTX5A==
@@ -30,11 +33,11 @@ environment:
           PYTHON_ARCH: "64"
           PYTHON_VERSION: "2.7"
 
-        - PYTHON_HOME: "C:\\Miniconda3"
+        - PYTHON_HOME: "C:\\Miniconda34"
           PYTHON_ARCH: "32"
           PYTHON_VERSION: "3.4"
 
-        - PYTHON_HOME: "C:\\Miniconda3-x64"
+        - PYTHON_HOME: "C:\\Miniconda34-x64"
           PYTHON_ARCH: "64"
           PYTHON_VERSION: "3.4"
 
@@ -46,15 +49,14 @@ environment:
           PYTHON_ARCH: "64"
           PYTHON_VERSION: "3.5"
 
-        - PYTHON_HOME: "C:\\Miniconda36"
-          PYTHON_ARCH: "32"
-          PYTHON_VERSION: "3.6"
-          NP_BUILD_DEP: "1.11"
-
+        # skipping 32-bit with Python 3.6: no 32-bit numpy with OpenBLAS
         - PYTHON_HOME: "C:\\Miniconda36-x64"
           PYTHON_ARCH: "64"
           PYTHON_VERSION: "3.6"
-          NP_BUILD_DEP: "1.11"
+          NP_BUILD_DEP: "1.14"
+          SP_BUILD_DEP: "1.1"
+          CYTHON_BUILD_DEP: "0.28"
+          EXTRA_CONDA_ARGS: "-c conda-forge blas=*=openblas"  # needed for non-MKL numpy/scipy
 
 install:
     # Get and configure the FFTW libs
@@ -67,7 +69,7 @@ install:
 
     - "conda config --set always_yes yes --set changeps1 no"
     - "conda update -q conda"
-    - "conda create -q -n build_env python=%PYTHON_VERSION% numpy=%NP_BUILD_DEP% scipy cython dask setuptools"
+    - "conda create -q -n build_env %EXTRA_CONDA_ARGS% python=%PYTHON_VERSION% numpy=%NP_BUILD_DEP% scipy=%SP_BUILD_DEP% cython=%CYTHON_BUILD_DEP% dask setuptools"
     - "activate build_env"
     - "%CMD_IN_ENV% python setup.py -v bdist_wheel"
     - "%CMD_IN_ENV% python setup.py -v build_ext --inplace"

--- a/pyfftw/interfaces/__init__.py
+++ b/pyfftw/interfaces/__init__.py
@@ -236,17 +236,12 @@ else:
     del scipy
     from . import scipy_fftpack
 
-from distutils.version import StrictVersion
-import numpy
 
 fft_wrap = None
-if StrictVersion(numpy.__version__) >= StrictVersion("1.10.0"):
-    try:
-        from dask.array.fft import fft_wrap
-    except ImportError:
-        pass
-del StrictVersion
-del numpy
+try:
+    from dask.array.fft import fft_wrap
+except ImportError:
+    pass
 
 if fft_wrap:
     from . import dask_fft

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cython
-numpy>=1.6
-scipy>=0.12.0
+cython>=0.23
+numpy>=1.10
+scipy>=0.16.0
 dask[array]>=0.15.0

--- a/setup.py
+++ b/setup.py
@@ -742,7 +742,7 @@ def setup_package():
 
     # Figure out whether to add ``*_requires = ['numpy']``.
     build_requires = []
-    numpy_requirement = 'numpy>=1.6, <2.0'
+    numpy_requirement = 'numpy>=1.10, <2.0'
     try:
         import numpy
     except ImportError:


### PR DESCRIPTION
All minimum versions selected here are at least 2 years old.

Our current `setup.py` seemed to already be enforcing Cython >=0.23, so that is what I went with elsewhere as well.

The choice of scipy 0.16 is somewhat arbitrary.  I just selected a version that is a bit more than 2 years old at this point.

Numpy 1.10 corresponds to a version where automatic casting of inputs to the `numpy.fft.*` functions to double precision was implemented.  We could potentially drop our own manual casting of the inputs to double within the numpy interface tests after this PR is merged.

Python 3.3 was being tested on Travis only.  I have removed it and added 3.6 there instead.  Appveyor was already using 3.4, 3.5 and 3.6, but I have tried to make sure that some test cases get run with the minimum required versions and then have 3.6 using more recent versions.  

~The new `pyproject.toml` is for [PEP 518](https://www.python.org/dev/peps/pep-0518/) support which has been [implemented in pip](https://github.com/pypa/pip/pull/4144).  I based this off of the one currently in scipy, with the minimum numpy bumped up to 1.10 to match our new minimum requirement.  Basically you want as old of a numpy as possible for a given python version to take advantage of ABI backwards compatibility (see much discussion: [here](https://github.com/pypa/pip/issues/4582#issuecomment-315037686)).~
**edit**: pip is not quite ready yet for pyproject.toml.  Can be added at some point in the future via #226