### PR TITLE
add rfftfreq to the numpy interfaces

### DIFF
--- a/pyfftw/interfaces/numpy_fft.py
+++ b/pyfftw/interfaces/numpy_fft.py
@@ -62,11 +62,19 @@ from ..builders._utils import _norm_args, _unitary
 
 # Complete the namespace (these are not actually used in this module)
 from numpy.fft import fftfreq, fftshift, ifftshift
+
 import numpy
 
-__all__ = ['fft','ifft', 'fft2', 'ifft2', 'fftn', 'ifftn',
+__all__ = ['fft', 'ifft', 'fft2', 'ifft2', 'fftn', 'ifftn',
            'rfft', 'irfft', 'rfft2', 'irfft2', 'rfftn', 'irfftn',
            'hfft', 'ihfft', 'fftfreq', 'fftshift', 'ifftshift']
+
+try:
+    # rfftfreq was added to the namespace in numpy 1.8
+    from numpy.fft import rfftfreq
+    __all__ += ['rfftfreq', ]
+except ImportError:
+    pass
 
 
 def fft(a, n=None, axis=-1, norm=None, overwrite_input=False,

--- a/test/test_pyfftw_numpy_interface.py
+++ b/test/test_pyfftw_numpy_interface.py
@@ -123,6 +123,10 @@ functions = {
 
 acquired_names = ('fftfreq', 'fftshift', 'ifftshift')
 
+if LooseVersion(numpy.version.version) >= LooseVersion('1.8'):
+    acquired_names += ('rfftfreq', )
+
+
 class InterfacesNumpyFFTTestModule(unittest.TestCase):
     ''' A really simple test suite to check the module works as expected.
     '''


### PR DESCRIPTION
As pointed out in #206,  `rfftfreq` is missing from our `numpy` interfaces.  This PR adds it (just a re-export of numpy's function).

`rfftfreq` appears to have been introduced in `numpy` 1.8.  I have made the code here compatible with older `numpy` as well, but if we are indeed bumping our minimum supported version to 1.10 as proposed in #204 the error/version checking is not strictly necessary. 

closes #206