### PR TITLE
configure the number of threads via an environment variable

### DIFF
--- a/pyfftw/__init__.py
+++ b/pyfftw/__init__.py
@@ -15,10 +15,10 @@ import os
 
 # All planners and interfaces default to single threaded unless otherwise
 # specified via PYFFTW_NUM_THREADS.
-default_num_threads = int(os.environ.get('PYFFTW_NUM_THREADS', 1))
-if default_num_threads <= 0:
+_default_num_threads = int(os.environ.get('PYFFTW_NUM_THREADS', 1))
+if _default_num_threads <= 0:
     import multiprocessing
-    default_num_threads = multiprocessing.cpu_count()
+    _default_num_threads = multiprocessing.cpu_count()
 
 from .pyfftw import (
         FFTW,

--- a/pyfftw/__init__.py
+++ b/pyfftw/__init__.py
@@ -11,6 +11,15 @@ library <http://www.fftw.org/>`_. However, users may find it easier to
 use the helper routines provided in :mod:`pyfftw.builders`.
 '''
 
+import os
+
+# All planners and interfaces default to single threaded unless otherwise
+# specified via PYFFTW_NUM_THREADS.
+default_num_threads = int(os.environ.get('PYFFTW_NUM_THREADS', 1))
+if default_num_threads <= 0:
+    import multiprocessing
+    default_num_threads = multiprocessing.cpu_count()
+
 from .pyfftw import (
         FFTW,
         export_wisdom,

--- a/pyfftw/builders/builders.py
+++ b/pyfftw/builders/builders.py
@@ -264,7 +264,7 @@ equivalents in :mod:`numpy.fft`, or as documented above.
 '''
 
 from ._utils import _precook_1d_args, _Xfftn, _norm_args
-
+from .. import default_num_threads
 
 __all__ = ['fft','ifft', 'fft2', 'ifft2', 'fftn',
            'ifftn', 'rfft', 'irfft', 'rfft2', 'irfft2', 'rfftn',
@@ -272,7 +272,7 @@ __all__ = ['fft','ifft', 'fft2', 'ifft2', 'fftn',
 
 
 def fft(a, n=None, axis=-1, overwrite_input=False,
-        planner_effort='FFTW_MEASURE', threads=1,
+        planner_effort='FFTW_MEASURE', threads=default_num_threads,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a 1D FFT.
@@ -291,7 +291,7 @@ def fft(a, n=None, axis=-1, overwrite_input=False,
             avoid_copy, inverse, real, **_norm_args(norm))
 
 def ifft(a, n=None, axis=-1, overwrite_input=False,
-        planner_effort='FFTW_MEASURE', threads=1,
+        planner_effort='FFTW_MEASURE', threads=default_num_threads,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a 1D
@@ -313,7 +313,7 @@ def ifft(a, n=None, axis=-1, overwrite_input=False,
 
 
 def fft2(a, s=None, axes=(-2,-1), overwrite_input=False,
-        planner_effort='FFTW_MEASURE', threads=1,
+        planner_effort='FFTW_MEASURE', threads=default_num_threads,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a 2D FFT.
@@ -332,7 +332,7 @@ def fft2(a, s=None, axes=(-2,-1), overwrite_input=False,
             avoid_copy, inverse, real, **_norm_args(norm))
 
 def ifft2(a, s=None, axes=(-2,-1), overwrite_input=False,
-        planner_effort='FFTW_MEASURE', threads=1,
+        planner_effort='FFTW_MEASURE', threads=default_num_threads,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a
@@ -353,7 +353,7 @@ def ifft2(a, s=None, axes=(-2,-1), overwrite_input=False,
 
 
 def fftn(a, s=None, axes=None, overwrite_input=False,
-        planner_effort='FFTW_MEASURE', threads=1,
+        planner_effort='FFTW_MEASURE', threads=default_num_threads,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a n-D FFT.
@@ -372,7 +372,7 @@ def fftn(a, s=None, axes=None, overwrite_input=False,
             avoid_copy, inverse, real, **_norm_args(norm))
 
 def ifftn(a, s=None, axes=None, overwrite_input=False,
-        planner_effort='FFTW_MEASURE', threads=1,
+        planner_effort='FFTW_MEASURE', threads=default_num_threads,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing an n-D
@@ -392,7 +392,7 @@ def ifftn(a, s=None, axes=None, overwrite_input=False,
             avoid_copy, inverse, real, **_norm_args(norm))
 
 def rfft(a, n=None, axis=-1, overwrite_input=False,
-        planner_effort='FFTW_MEASURE', threads=1,
+        planner_effort='FFTW_MEASURE', threads=default_num_threads,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a 1D
@@ -414,7 +414,7 @@ def rfft(a, n=None, axis=-1, overwrite_input=False,
             avoid_copy, inverse, real, **_norm_args(norm))
 
 def irfft(a, n=None, axis=-1, overwrite_input=False,
-        planner_effort='FFTW_MEASURE', threads=1,
+        planner_effort='FFTW_MEASURE', threads=default_num_threads,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a 1D
@@ -436,7 +436,7 @@ def irfft(a, n=None, axis=-1, overwrite_input=False,
             avoid_copy, inverse, real, **_norm_args(norm))
 
 def rfft2(a, s=None, axes=(-2,-1), overwrite_input=False,
-        planner_effort='FFTW_MEASURE', threads=1,
+        planner_effort='FFTW_MEASURE', threads=default_num_threads,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a 2D
@@ -455,7 +455,7 @@ def rfft2(a, s=None, axes=(-2,-1), overwrite_input=False,
             avoid_copy, inverse, real, **_norm_args(norm))
 
 def irfft2(a, s=None, axes=(-2,-1),
-        planner_effort='FFTW_MEASURE', threads=1,
+        planner_effort='FFTW_MEASURE', threads=default_num_threads,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a 2D
@@ -478,7 +478,7 @@ def irfft2(a, s=None, axes=(-2,-1),
 
 
 def rfftn(a, s=None, axes=None, overwrite_input=False,
-        planner_effort='FFTW_MEASURE', threads=1,
+        planner_effort='FFTW_MEASURE', threads=default_num_threads,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing an n-D
@@ -499,7 +499,7 @@ def rfftn(a, s=None, axes=None, overwrite_input=False,
 
 
 def irfftn(a, s=None, axes=None,
-        planner_effort='FFTW_MEASURE', threads=1,
+        planner_effort='FFTW_MEASURE', threads=default_num_threads,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing an n-D

--- a/pyfftw/builders/builders.py
+++ b/pyfftw/builders/builders.py
@@ -264,7 +264,7 @@ equivalents in :mod:`numpy.fft`, or as documented above.
 '''
 
 from ._utils import _precook_1d_args, _Xfftn, _norm_args
-from .. import default_num_threads
+from .. import _default_num_threads
 
 __all__ = ['fft','ifft', 'fft2', 'ifft2', 'fftn',
            'ifftn', 'rfft', 'irfft', 'rfft2', 'irfft2', 'rfftn',
@@ -272,7 +272,7 @@ __all__ = ['fft','ifft', 'fft2', 'ifft2', 'fftn',
 
 
 def fft(a, n=None, axis=-1, overwrite_input=False,
-        planner_effort='FFTW_MEASURE', threads=default_num_threads,
+        planner_effort='FFTW_MEASURE', threads=_default_num_threads,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a 1D FFT.
@@ -291,7 +291,7 @@ def fft(a, n=None, axis=-1, overwrite_input=False,
             avoid_copy, inverse, real, **_norm_args(norm))
 
 def ifft(a, n=None, axis=-1, overwrite_input=False,
-        planner_effort='FFTW_MEASURE', threads=default_num_threads,
+        planner_effort='FFTW_MEASURE', threads=_default_num_threads,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a 1D
@@ -313,7 +313,7 @@ def ifft(a, n=None, axis=-1, overwrite_input=False,
 
 
 def fft2(a, s=None, axes=(-2,-1), overwrite_input=False,
-        planner_effort='FFTW_MEASURE', threads=default_num_threads,
+        planner_effort='FFTW_MEASURE', threads=_default_num_threads,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a 2D FFT.
@@ -332,7 +332,7 @@ def fft2(a, s=None, axes=(-2,-1), overwrite_input=False,
             avoid_copy, inverse, real, **_norm_args(norm))
 
 def ifft2(a, s=None, axes=(-2,-1), overwrite_input=False,
-        planner_effort='FFTW_MEASURE', threads=default_num_threads,
+        planner_effort='FFTW_MEASURE', threads=_default_num_threads,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a
@@ -353,7 +353,7 @@ def ifft2(a, s=None, axes=(-2,-1), overwrite_input=False,
 
 
 def fftn(a, s=None, axes=None, overwrite_input=False,
-        planner_effort='FFTW_MEASURE', threads=default_num_threads,
+        planner_effort='FFTW_MEASURE', threads=_default_num_threads,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a n-D FFT.
@@ -372,7 +372,7 @@ def fftn(a, s=None, axes=None, overwrite_input=False,
             avoid_copy, inverse, real, **_norm_args(norm))
 
 def ifftn(a, s=None, axes=None, overwrite_input=False,
-        planner_effort='FFTW_MEASURE', threads=default_num_threads,
+        planner_effort='FFTW_MEASURE', threads=_default_num_threads,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing an n-D
@@ -392,7 +392,7 @@ def ifftn(a, s=None, axes=None, overwrite_input=False,
             avoid_copy, inverse, real, **_norm_args(norm))
 
 def rfft(a, n=None, axis=-1, overwrite_input=False,
-        planner_effort='FFTW_MEASURE', threads=default_num_threads,
+        planner_effort='FFTW_MEASURE', threads=_default_num_threads,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a 1D
@@ -414,7 +414,7 @@ def rfft(a, n=None, axis=-1, overwrite_input=False,
             avoid_copy, inverse, real, **_norm_args(norm))
 
 def irfft(a, n=None, axis=-1, overwrite_input=False,
-        planner_effort='FFTW_MEASURE', threads=default_num_threads,
+        planner_effort='FFTW_MEASURE', threads=_default_num_threads,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a 1D
@@ -436,7 +436,7 @@ def irfft(a, n=None, axis=-1, overwrite_input=False,
             avoid_copy, inverse, real, **_norm_args(norm))
 
 def rfft2(a, s=None, axes=(-2,-1), overwrite_input=False,
-        planner_effort='FFTW_MEASURE', threads=default_num_threads,
+        planner_effort='FFTW_MEASURE', threads=_default_num_threads,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a 2D
@@ -455,7 +455,7 @@ def rfft2(a, s=None, axes=(-2,-1), overwrite_input=False,
             avoid_copy, inverse, real, **_norm_args(norm))
 
 def irfft2(a, s=None, axes=(-2,-1),
-        planner_effort='FFTW_MEASURE', threads=default_num_threads,
+        planner_effort='FFTW_MEASURE', threads=_default_num_threads,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a 2D
@@ -478,7 +478,7 @@ def irfft2(a, s=None, axes=(-2,-1),
 
 
 def rfftn(a, s=None, axes=None, overwrite_input=False,
-        planner_effort='FFTW_MEASURE', threads=default_num_threads,
+        planner_effort='FFTW_MEASURE', threads=_default_num_threads,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing an n-D
@@ -499,7 +499,7 @@ def rfftn(a, s=None, axes=None, overwrite_input=False,
 
 
 def irfftn(a, s=None, axes=None,
-        planner_effort='FFTW_MEASURE', threads=default_num_threads,
+        planner_effort='FFTW_MEASURE', threads=_default_num_threads,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing an n-D

--- a/pyfftw/interfaces/numpy_fft.py
+++ b/pyfftw/interfaces/numpy_fft.py
@@ -59,7 +59,7 @@ which this may not be true.
 
 from ._utils import _Xfftn
 from ..builders._utils import _norm_args, _unitary
-from .. import default_num_threads
+from .. import _default_num_threads
 
 # Complete the namespace (these are not actually used in this module)
 from numpy.fft import fftfreq, fftshift, ifftshift
@@ -71,7 +71,7 @@ __all__ = ['fft','ifft', 'fft2', 'ifft2', 'fftn', 'ifftn',
 
 
 def fft(a, n=None, axis=-1, norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
+        planner_effort='FFTW_ESTIMATE', threads=_default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D FFT.
 
@@ -87,7 +87,7 @@ def fft(a, n=None, axis=-1, norm=None, overwrite_input=False,
             calling_func, **_norm_args(norm))
 
 def ifft(a, n=None, axis=-1, norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
+        planner_effort='FFTW_ESTIMATE', threads=_default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D inverse FFT.
 
@@ -103,7 +103,7 @@ def ifft(a, n=None, axis=-1, norm=None, overwrite_input=False,
 
 
 def fft2(a, s=None, axes=(-2,-1), norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
+        planner_effort='FFTW_ESTIMATE', threads=_default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 2D FFT.
 
@@ -118,7 +118,7 @@ def fft2(a, s=None, axes=(-2,-1), norm=None, overwrite_input=False,
             calling_func, **_norm_args(norm))
 
 def ifft2(a, s=None, axes=(-2,-1), norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
+        planner_effort='FFTW_ESTIMATE', threads=_default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 2D inverse FFT.
 
@@ -134,7 +134,7 @@ def ifft2(a, s=None, axes=(-2,-1), norm=None, overwrite_input=False,
 
 
 def fftn(a, s=None, axes=None, norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
+        planner_effort='FFTW_ESTIMATE', threads=_default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform an n-D FFT.
 
@@ -150,7 +150,7 @@ def fftn(a, s=None, axes=None, norm=None, overwrite_input=False,
 
 
 def ifftn(a, s=None, axes=None, norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
+        planner_effort='FFTW_ESTIMATE', threads=_default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform an n-D inverse FFT.
 
@@ -166,7 +166,7 @@ def ifftn(a, s=None, axes=None, norm=None, overwrite_input=False,
 
 
 def rfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
+        planner_effort='FFTW_ESTIMATE', threads=_default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D real FFT.
 
@@ -182,7 +182,7 @@ def rfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
 
 
 def irfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
+        planner_effort='FFTW_ESTIMATE', threads=_default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D real inverse FFT.
 
@@ -198,7 +198,7 @@ def irfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
 
 
 def rfft2(a, s=None, axes=(-2,-1), norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
+        planner_effort='FFTW_ESTIMATE', threads=_default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 2D real FFT.
 
@@ -214,7 +214,7 @@ def rfft2(a, s=None, axes=(-2,-1), norm=None, overwrite_input=False,
 
 
 def irfft2(a, s=None, axes=(-2,-1), norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
+        planner_effort='FFTW_ESTIMATE', threads=_default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 2D real inverse FFT.
 
@@ -230,7 +230,7 @@ def irfft2(a, s=None, axes=(-2,-1), norm=None, overwrite_input=False,
 
 
 def rfftn(a, s=None, axes=None, norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
+        planner_effort='FFTW_ESTIMATE', threads=_default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform an n-D real FFT.
 
@@ -246,7 +246,7 @@ def rfftn(a, s=None, axes=None, norm=None, overwrite_input=False,
 
 
 def irfftn(a, s=None, axes=None, norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
+        planner_effort='FFTW_ESTIMATE', threads=_default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform an n-D real inverse FFT.
 
@@ -262,7 +262,7 @@ def irfftn(a, s=None, axes=None, norm=None, overwrite_input=False,
 
 
 def hfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
-         planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
+         planner_effort='FFTW_ESTIMATE', threads=_default_num_threads,
          auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D FFT of a signal with hermitian symmetry.
     This yields a real output spectrum. See :func:`numpy.fft.hfft`
@@ -299,7 +299,7 @@ def hfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
 
 
 def ihfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
+        planner_effort='FFTW_ESTIMATE', threads=_default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D inverse FFT of a real-spectrum, yielding
     a signal with hermitian symmetry. See :func:`numpy.fft.ihfft`

--- a/pyfftw/interfaces/numpy_fft.py
+++ b/pyfftw/interfaces/numpy_fft.py
@@ -59,6 +59,7 @@ which this may not be true.
 
 from ._utils import _Xfftn
 from ..builders._utils import _norm_args, _unitary
+from .. import default_num_threads
 
 # Complete the namespace (these are not actually used in this module)
 from numpy.fft import fftfreq, fftshift, ifftshift
@@ -70,7 +71,7 @@ __all__ = ['fft','ifft', 'fft2', 'ifft2', 'fftn', 'ifftn',
 
 
 def fft(a, n=None, axis=-1, norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D FFT.
 
@@ -86,7 +87,7 @@ def fft(a, n=None, axis=-1, norm=None, overwrite_input=False,
             calling_func, **_norm_args(norm))
 
 def ifft(a, n=None, axis=-1, norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D inverse FFT.
 
@@ -102,7 +103,7 @@ def ifft(a, n=None, axis=-1, norm=None, overwrite_input=False,
 
 
 def fft2(a, s=None, axes=(-2,-1), norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 2D FFT.
 
@@ -117,7 +118,7 @@ def fft2(a, s=None, axes=(-2,-1), norm=None, overwrite_input=False,
             calling_func, **_norm_args(norm))
 
 def ifft2(a, s=None, axes=(-2,-1), norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 2D inverse FFT.
 
@@ -133,7 +134,7 @@ def ifft2(a, s=None, axes=(-2,-1), norm=None, overwrite_input=False,
 
 
 def fftn(a, s=None, axes=None, norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform an n-D FFT.
 
@@ -149,7 +150,7 @@ def fftn(a, s=None, axes=None, norm=None, overwrite_input=False,
 
 
 def ifftn(a, s=None, axes=None, norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform an n-D inverse FFT.
 
@@ -165,7 +166,7 @@ def ifftn(a, s=None, axes=None, norm=None, overwrite_input=False,
 
 
 def rfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D real FFT.
 
@@ -181,7 +182,7 @@ def rfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
 
 
 def irfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D real inverse FFT.
 
@@ -197,7 +198,7 @@ def irfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
 
 
 def rfft2(a, s=None, axes=(-2,-1), norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 2D real FFT.
 
@@ -213,7 +214,7 @@ def rfft2(a, s=None, axes=(-2,-1), norm=None, overwrite_input=False,
 
 
 def irfft2(a, s=None, axes=(-2,-1), norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 2D real inverse FFT.
 
@@ -229,7 +230,7 @@ def irfft2(a, s=None, axes=(-2,-1), norm=None, overwrite_input=False,
 
 
 def rfftn(a, s=None, axes=None, norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform an n-D real FFT.
 
@@ -245,7 +246,7 @@ def rfftn(a, s=None, axes=None, norm=None, overwrite_input=False,
 
 
 def irfftn(a, s=None, axes=None, norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform an n-D real inverse FFT.
 
@@ -261,7 +262,7 @@ def irfftn(a, s=None, axes=None, norm=None, overwrite_input=False,
 
 
 def hfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
-         planner_effort='FFTW_ESTIMATE', threads=1,
+         planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
          auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D FFT of a signal with hermitian symmetry.
     This yields a real output spectrum. See :func:`numpy.fft.hfft`
@@ -298,7 +299,7 @@ def hfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
 
 
 def ihfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D inverse FFT of a real-spectrum, yielding
     a signal with hermitian symmetry. See :func:`numpy.fft.ihfft`

--- a/pyfftw/interfaces/scipy_fftpack.py
+++ b/pyfftw/interfaces/scipy_fftpack.py
@@ -67,6 +67,7 @@ from scipy.fftpack import (dct, idct, dst, idst, diff, tilbert, itilbert,
 
 # a next_fast_len specific to pyFFTW is used in place of the scipy.fftpack one
 from ..pyfftw import next_fast_len
+from .. import default_num_threads
 
 
 __all__ = ['fft', 'ifft', 'fftn', 'ifftn', 'rfft', 'irfft', 'fft2', 'ifft2',
@@ -83,7 +84,7 @@ except ImportError:
 
 
 def fft(x, n=None, axis=-1, overwrite_x=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D FFT.
 
@@ -95,7 +96,7 @@ def fft(x, n=None, axis=-1, overwrite_x=False,
             threads, auto_align_input, auto_contiguous)
 
 def ifft(x, n=None, axis=-1, overwrite_x=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D inverse FFT.
 
@@ -109,7 +110,7 @@ def ifft(x, n=None, axis=-1, overwrite_x=False,
 
 
 def fft2(x, shape=None, axes=(-2,-1), overwrite_x=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 2D FFT.
 
@@ -123,7 +124,7 @@ def fft2(x, shape=None, axes=(-2,-1), overwrite_x=False,
 
 
 def ifft2(x, shape=None, axes=(-2,-1), overwrite_x=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 2D inverse FFT.
 
@@ -137,7 +138,7 @@ def ifft2(x, shape=None, axes=(-2,-1), overwrite_x=False,
 
 
 def fftn(x, shape=None, axes=None, overwrite_x=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform an n-D FFT.
 
@@ -161,7 +162,7 @@ def fftn(x, shape=None, axes=None, overwrite_x=False,
 
 
 def ifftn(x, shape=None, axes=None, overwrite_x=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform an n-D inverse FFT.
 
@@ -254,7 +255,7 @@ def _irfft_input_to_complex(irfft_input, axis):
 
 
 def rfft(x, n=None, axis=-1, overwrite_x=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D real FFT.
 
@@ -278,7 +279,7 @@ def rfft(x, n=None, axis=-1, overwrite_x=False,
     return _complex_to_rfft_output(complex_output, output_shape, axis)
 
 def irfft(x, n=None, axis=-1, overwrite_x=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D real inverse FFT.
 

--- a/pyfftw/interfaces/scipy_fftpack.py
+++ b/pyfftw/interfaces/scipy_fftpack.py
@@ -67,7 +67,7 @@ from scipy.fftpack import (dct, idct, dst, idst, diff, tilbert, itilbert,
 
 # a next_fast_len specific to pyFFTW is used in place of the scipy.fftpack one
 from ..pyfftw import next_fast_len
-from .. import default_num_threads
+from .. import _default_num_threads
 
 
 __all__ = ['fft', 'ifft', 'fftn', 'ifftn', 'rfft', 'irfft', 'fft2', 'ifft2',
@@ -84,7 +84,7 @@ except ImportError:
 
 
 def fft(x, n=None, axis=-1, overwrite_x=False,
-        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
+        planner_effort='FFTW_ESTIMATE', threads=_default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D FFT.
 
@@ -96,7 +96,7 @@ def fft(x, n=None, axis=-1, overwrite_x=False,
             threads, auto_align_input, auto_contiguous)
 
 def ifft(x, n=None, axis=-1, overwrite_x=False,
-        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
+        planner_effort='FFTW_ESTIMATE', threads=_default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D inverse FFT.
 
@@ -110,7 +110,7 @@ def ifft(x, n=None, axis=-1, overwrite_x=False,
 
 
 def fft2(x, shape=None, axes=(-2,-1), overwrite_x=False,
-        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
+        planner_effort='FFTW_ESTIMATE', threads=_default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 2D FFT.
 
@@ -124,7 +124,7 @@ def fft2(x, shape=None, axes=(-2,-1), overwrite_x=False,
 
 
 def ifft2(x, shape=None, axes=(-2,-1), overwrite_x=False,
-        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
+        planner_effort='FFTW_ESTIMATE', threads=_default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 2D inverse FFT.
 
@@ -138,7 +138,7 @@ def ifft2(x, shape=None, axes=(-2,-1), overwrite_x=False,
 
 
 def fftn(x, shape=None, axes=None, overwrite_x=False,
-        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
+        planner_effort='FFTW_ESTIMATE', threads=_default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform an n-D FFT.
 
@@ -162,7 +162,7 @@ def fftn(x, shape=None, axes=None, overwrite_x=False,
 
 
 def ifftn(x, shape=None, axes=None, overwrite_x=False,
-        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
+        planner_effort='FFTW_ESTIMATE', threads=_default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform an n-D inverse FFT.
 
@@ -255,7 +255,7 @@ def _irfft_input_to_complex(irfft_input, axis):
 
 
 def rfft(x, n=None, axis=-1, overwrite_x=False,
-        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
+        planner_effort='FFTW_ESTIMATE', threads=_default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D real FFT.
 
@@ -279,7 +279,7 @@ def rfft(x, n=None, axis=-1, overwrite_x=False,
     return _complex_to_rfft_output(complex_output, output_shape, axis)
 
 def irfft(x, n=None, axis=-1, overwrite_x=False,
-        planner_effort='FFTW_ESTIMATE', threads=default_num_threads,
+        planner_effort='FFTW_ESTIMATE', threads=_default_num_threads,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D real inverse FFT.
 


### PR DESCRIPTION
Currently the interfaces and planners default to a single thread.  This makes it a pain to monkey-patch numpy or scipy with multi-threading enabled (as discussed in #205).

This PR causes pyFFTW to check the environment variable `PYFFTW_NUM_THREADS` upon import and use its value as the default number of threads in all planners and interfaces.  If the variable has not been defined, the current default of 1 thread is used.  If `PYFFTW_NUM_THREADS` is <= 0 then multiprocessing.cpu_count() is used to select all available threads.

@hgomersall, in #205, you had suggested some sort of lookup, but I wasn't clear on what you meant.  Can you think of a better approach to let the user configure this?

**TODO:**
- [ ] documentation
- [ ] test case(s)
- [ ] always set the number of threads to 1 if pyFFTW wasn't built with pthreads or OpenMP support
- [ ] extend to allowing the user to select the default planner effort as well?
