### PR TITLE
Fix dtype bug on systems where longdouble is equivalent to double

### DIFF
--- a/pyfftw/pyfftw.pyx
+++ b/pyfftw/pyfftw.pyx
@@ -58,8 +58,9 @@ _all_types_human_readable = {
 _all_types_np = {
     np.dtype(np.float32): '32',
     np.dtype(np.float64): '64',
-    np.dtype(np.longdouble): 'ld'
 }
+if np.dtype(np.longdouble) != np.dtype(np.float64):
+    _all_types_np[np.dtype(np.longdouble)] = 'ld'
 
 # the types supported in this build
 _supported_types = []

--- a/test/test_pyfftw_partial.py
+++ b/test/test_pyfftw_partial.py
@@ -56,6 +56,9 @@ class FFTWPartialTest(unittest.TestCase):
 
     def test_failure(self):
         for dtype, npdtype in zip(['32', '64', 'ld'], [np.complex64, np.complex128, np.clongdouble]):
+            if dtype == 'ld' and np.dtype(np.clongdouble) == np.dtype(np.complex128):
+                # skip this test on systems where clongdouble is complex128
+                continue
             if dtype not in _supported_types:
                 a = empty_aligned((1,1024), npdtype, n=16)
                 b = empty_aligned(a.shape, dtype=a.dtype, n=16)


### PR DESCRIPTION
In testing the recently merged #189 on a Windows system using the conda-forge FFTW libraries, I came across 2 test errors.  The conda-forge libs have single and double precision only.

It turns out the errors were both related to the fact that numpy on that system has a `longdouble` dtype that is identical to `double`.  For example, both of the following evaluate to true:
```python
np.dtype(np.longdouble) == np.dtype(np.float64)
np.dtype(np.clongdouble) == np.dtype(np.complex128)
```

This leads to a subtle bug when we set `_all_types_np` in `pyfftw.pyx`.  This currently uses
_all_types_np = {
    np.dtype(np.float32): '32',
    np.dtype(np.float64): '64',
    np.dtype(np.longdouble): 'ld',
}
However, on the system I tested on the last 2 keys are equivalent so `_all_types_np` only ends up with 2 entries:  ` {dtype('float32'): '32', dtype('float64'): 'ld'}`

There is a similar issue where tests are expecting a `NotImplementedError` to be raised for `np.clongdouble dtype`, but since this is actually equal to `np.complex128` it does not fail as expected. 

For reference I paste the exact test failures that this fixes here:
```
================================== FAILURES ===================================
_______________________ FFTWPartialTest.test_conversion _______________________

self = <test.test_pyfftw_partial.FFTWPartialTest testMethod=test_conversion>

    def test_conversion(self):
        self.conversion('float32', 'float64', 'longdouble')
>       self.conversion('float64', 'longdouble', 'single')

test\test_pyfftw_partial.py:102:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
test\test_pyfftw_partial.py:89: in conversion
    self.assertEqual(b.dtype, _rc_dtype_pairs[alt2.char])
E   AssertionError: dtype('complex128') != dtype('complex64')
________________________ FFTWPartialTest.test_failure _________________________

self = <test.test_pyfftw_partial.FFTWPartialTest testMethod=test_failure>

    def test_failure(self):
        for dtype, npdtype in zip(['32', '64', 'ld'], [np.complex64, np.complex128, np.clongdouble]):
            if dtype not in _supported_types:
                a = empty_aligned((1,1024), npdtype, n=16)
                b = empty_aligned(a.shape, dtype=a.dtype, n=16)
                msg = "Rebuild pyFFTW with support for %s precision!" % _all_types_human_readable[dtype]
                with self.assertRaisesRegex(NotImplementedError, msg):
>                   FFTW(a,b)
E                   AssertionError: NotImplementedError not raised

test\test_pyfftw_partial.py:64: AssertionError
```

