### PR TITLE
Fix Dask test interface

### DIFF
--- a/pyfftw/interfaces/__init__.py
+++ b/pyfftw/interfaces/__init__.py
@@ -237,14 +237,9 @@ else:
     from . import scipy_fftpack
 
 try:
-    import dask.array.fft
-    dask.array.fft.fft_wrap
-except (ImportError, AttributeError):
+    from dask.array.fft import fft_wrap
+except ImportError:
     pass
 else:
+    del fft_wrap
     from . import dask_fft
-
-try:
-    del dask
-except NameError:
-    pass

--- a/test/test_pyfftw_dask_interface.py
+++ b/test/test_pyfftw_dask_interface.py
@@ -46,7 +46,7 @@ try:
     import dask.array as da
     from dask.array import fft as da_fft
     from dask.array.fft import fft_wrap
-except (ImportError, AttributeError):
+except ImportError:
     da = None
     da_fft = None
 

--- a/test/test_pyfftw_dask_interface.py
+++ b/test/test_pyfftw_dask_interface.py
@@ -108,7 +108,8 @@ class InterfacesDaskFFTTestFFT(unittest.TestCase):
             'c2r': (complex_dtypes, make_complex_data)}
 
     validator_module = da_fft
-    test_interface = interfaces.numpy_fft
+    test_wrapped_interface = interfaces.numpy_fft
+    test_interface = interfaces.dask_fft
     func = 'fft'
     axes_kw = 'axis'
     default_s_from_shape_slicer = slice(-1, None)
@@ -258,7 +259,7 @@ class InterfacesDaskFFTTestFFT(unittest.TestCase):
 
     def axes_from_kwargs(self, kwargs):
         default_args = get_default_args(
-            getattr(self.test_interface, self.func))
+            getattr(self.test_wrapped_interface, self.func))
 
         if 'axis' in kwargs:
             axes = (kwargs['axis'],)
@@ -286,7 +287,7 @@ class InterfacesDaskFFTTestFFT(unittest.TestCase):
         whether axis or axes is specified
         '''
         default_args = get_default_args(
-            getattr(self.test_interface, self.func))
+            getattr(self.test_wrapped_interface, self.func))
 
         if 'axis' in kwargs:
             s = test_shape[kwargs['axis']]

--- a/test/test_pyfftw_dask_interface.py
+++ b/test/test_pyfftw_dask_interface.py
@@ -82,7 +82,8 @@ functions = {
 acquired_names = ('fft_wrap',)
 
 @unittest.skipIf(
-    da_fft is None, "dask is not installed, so this feature is unavailable."
+    not hasattr(interfaces, "dask_fft"),
+    "dask interface is not available, so skipping tests."
 )
 class InterfacesDaskFFTTestModule(unittest.TestCase):
     ''' A really simple test suite to check the module works as expected.
@@ -98,7 +99,8 @@ class InterfacesDaskFFTTestModule(unittest.TestCase):
 
 
 @unittest.skipIf(
-    da_fft is None, "dask is not installed, so this feature is unavailable."
+    not hasattr(interfaces, "dask_fft"),
+    "dask interface is not available, so skipping tests."
 )
 class InterfacesDaskFFTTestFFT(unittest.TestCase):
 

--- a/test/test_pyfftw_dask_interface.py
+++ b/test/test_pyfftw_dask_interface.py
@@ -126,14 +126,6 @@ class InterfacesDaskFFTTestFFT(unittest.TestCase):
             ((64, 128, 16), {}),
             )
 
-    # invalid_s_shapes is:
-    # (size, invalid_args, error_type, error_string)
-    invalid_args = (
-            ((100,), ((100, 200),), TypeError, ''),
-            ((100, 200), ((100, 200),), TypeError, ''),
-            ((100,), (100, (-2, -1)), TypeError, ''),
-            ((100,), (100, -20), IndexError, ''))
-
     realinv = False
     has_norm_kwarg = _dask_array_fft_has_norm_kwarg()
 
@@ -337,23 +329,6 @@ class InterfacesDaskFFTTestFFT(unittest.TestCase):
 
                 self.validate(dtype_tuple[1],
                         test_shape, dtype, s, kwargs)
-
-
-    def test_fail_on_invalid_s_or_axes_or_norm(self):
-        dtype_tuple = self.io_dtypes[functions[self.func]]
-
-        for dtype in dtype_tuple[0]:
-
-            for test_shape, args, exception, e_str in self.invalid_args:
-                input_array = dtype_tuple[1](test_shape, dtype)
-
-                if len(args) > 2 and not self.has_norm_kwarg:
-                    # skip tests invovling norm argument if it isn't available
-                    continue
-
-                self.assertRaisesRegex(exception, e_str,
-                        getattr(self.test_interface, self.func),
-                        *((input_array,) + args))
 
 
     def test_same_sized_s(self):

--- a/test/test_pyfftw_dask_interface.py
+++ b/test/test_pyfftw_dask_interface.py
@@ -34,6 +34,11 @@
 
 from pyfftw import interfaces
 
+try:
+    interfaces.dask_fft
+except AttributeError:
+    interfaces.dask_fft = None
+
 from .test_pyfftw_base import run_test_suites
 from .test_pyfftw_numpy_interface import complex_dtypes, real_dtypes
 from ._get_default_args import get_default_args
@@ -82,7 +87,7 @@ functions = {
 acquired_names = ('fft_wrap',)
 
 @unittest.skipIf(
-    not hasattr(interfaces, "dask_fft"),
+    not interfaces.dask_fft,
     "dask interface is not available, so skipping tests."
 )
 class InterfacesDaskFFTTestModule(unittest.TestCase):
@@ -99,7 +104,7 @@ class InterfacesDaskFFTTestModule(unittest.TestCase):
 
 
 @unittest.skipIf(
-    not hasattr(interfaces, "dask_fft"),
+    not interfaces.dask_fft,
     "dask interface is not available, so skipping tests."
 )
 class InterfacesDaskFFTTestFFT(unittest.TestCase):

--- a/test/test_pyfftw_dask_interface.py
+++ b/test/test_pyfftw_dask_interface.py
@@ -438,21 +438,6 @@ class InterfacesDaskFFTTestFFT(unittest.TestCase):
 
             self.validate(array_type, test_shape, dtype, s, _kwargs)
 
-    def test_auto_align_input(self):
-        dtype_tuple = self.io_dtypes[functions[self.func]]
-
-        for dtype in dtype_tuple[0]:
-            for test_shape, s, kwargs in self.test_data:
-                self.check_arg('auto_align_input', (True, False),
-                        dtype_tuple[1], test_shape, dtype, s, kwargs)
-
-    def test_auto_contiguous_input(self):
-        dtype_tuple = self.io_dtypes[functions[self.func]]
-
-        for dtype in dtype_tuple[0]:
-            for test_shape, s, kwargs in self.test_data:
-                self.check_arg('auto_contiguous', (True, False),
-                        dtype_tuple[1], test_shape, dtype, s, kwargs)
 
     def test_bigger_and_smaller_s(self):
         dtype_tuple = self.io_dtypes[functions[self.func]]
@@ -485,57 +470,6 @@ class InterfacesDaskFFTTestFFT(unittest.TestCase):
 
                 self.validate(dtype_tuple[1],
                         test_shape, dtype, s, kwargs)
-
-
-    def test_planner_effort(self):
-        '''Test the planner effort arg
-        '''
-        dtype_tuple = self.io_dtypes[functions[self.func]]
-        test_shape = (16,)
-
-        for dtype in dtype_tuple[0]:
-            s = None
-            if self.axes_kw == 'axis':
-                kwargs = {'axis': -1}
-            else:
-                kwargs = {'axes': (-1,)}
-
-            for each_effort in ('FFTW_ESTIMATE', 'FFTW_MEASURE',
-                    'FFTW_PATIENT', 'FFTW_EXHAUSTIVE'):
-
-                kwargs['planner_effort'] = each_effort
-
-                self.validate(
-                        dtype_tuple[1], test_shape, dtype, s, kwargs)
-
-            kwargs['planner_effort'] = 'garbage'
-
-            self.assertRaisesRegex(ValueError, 'Invalid planner effort',
-                    self.validate,
-                    *(dtype_tuple[1], test_shape, dtype, s, kwargs))
-
-    def test_threads_arg(self):
-        '''Test the threads argument
-        '''
-        dtype_tuple = self.io_dtypes[functions[self.func]]
-        test_shape = (16,)
-
-        for dtype in dtype_tuple[0]:
-            s = None
-            if self.axes_kw == 'axis':
-                kwargs = {'axis': -1}
-            else:
-                kwargs = {'axes': (-1,)}
-
-            self.check_arg('threads', (1, 2, 5, 10),
-                        dtype_tuple[1], test_shape, dtype, s, kwargs)
-
-            kwargs['threads'] = 'bleh'
-
-            # Should not work
-            self.assertRaises(TypeError,
-                    self.validate,
-                    *(dtype_tuple[1], test_shape, dtype, s, kwargs))
 
 
     def test_input_maintained(self):


### PR DESCRIPTION
Appears there was some copy-pasta in the tests that caused the NumPy FFT interface to be used for some things. This corrects it to be the Dask FFT interface instead.

As the test infrastructure uses some magic to find default arguments and use them in the tests, it gets confused by how the Dask FFT wrapper works. So we use the NumPy FFT interface (what Dask wraps) for the inference magic to inspect.

Due to these changes, a few argument tests that are not valid with the Dask interface fail. As the interface doesn't currently allow arbitrary arguments to be passed through or may deviate in terms of what exceptions it raises, we just have to drop these test cases as they simply are not supported at present. Raised issue ( https://github.com/dask/dask/issues/3278 ) upstream about getting arbitrary keyword arguments passed through. We can also discuss adjustments to the exceptions raised upstream if there is interest.