### PR TITLE
Dask Interface Extras

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
 
 install:
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION nomkl numpy scipy cython setuptools
-  - conda install -q -n test-environment dask=0.14.2 || true
+  - conda install -q -n test-environment dask=0.15.0 || true
   - source activate test-environment
   - python setup.py -v build_ext --inplace
 

--- a/pyfftw/interfaces/dask_fft.py
+++ b/pyfftw/interfaces/dask_fft.py
@@ -56,6 +56,10 @@ which this may not be true.
 from . import numpy_fft as _numpy_fft
 from dask.array.fft import (
     fft_wrap,
+    fftfreq,
+    rfftfreq,
+    fftshift,
+    ifftshift,
 )
 
 fft = fft_wrap(_numpy_fft.fft)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cython
 numpy>=1.6
 scipy>=0.12.0
-dask>=0.14.2
+dask>=0.15.0

--- a/test/test_pyfftw_dask_interface.py
+++ b/test/test_pyfftw_dask_interface.py
@@ -92,7 +92,7 @@ functions = {
         'hfft': 'c2r',
         'ihfft': 'r2c'}
 
-acquired_names = ('fft_wrap',)
+acquired_names = ('fft_wrap', 'fftfreq', 'rfftfreq', 'fftshift', 'ifftshift')
 
 @unittest.skipIf(
     not interfaces.dask_fft,


### PR DESCRIPTION
Requires https://github.com/pyFFTW/pyFFTW/pull/211
Requires https://github.com/pyFFTW/pyFFTW/pull/212
Related https://github.com/pyFFTW/pyFFTW/pull/154

Polishes off the Dask interface by importing a few functions that have been added to Dask into the interface to make it as easy replacement for Dask's FFT module. Includes some tests to make sure the functions are available from the interface. Bumps the Dask minimum version requirement to guarantee these functions are available.