### PR TITLE
Handle all exceptions importing Dask causes

### DIFF
--- a/pyfftw/interfaces/__init__.py
+++ b/pyfftw/interfaces/__init__.py
@@ -238,7 +238,7 @@ else:
 
 try:
     from dask.array.fft import fft_wrap
-except ImportError:
+except Exception:
     pass
 else:
     del fft_wrap

--- a/test/test_pyfftw_dask_interface.py
+++ b/test/test_pyfftw_dask_interface.py
@@ -51,7 +51,7 @@ try:
     import dask.array as da
     from dask.array import fft as da_fft
     from dask.array.fft import fft_wrap
-except ImportError:
+except Exception:
     da = None
     da_fft = None
 


### PR DESCRIPTION
If importing Dask triggers any exception whatsover, simply catch that exception. In these cases, assume that Dask is not available and proceed without it.