### PR TITLE
Explicitly add Dask Array as an extra requirement

### DIFF
--- a/pyfftw/interfaces/__init__.py
+++ b/pyfftw/interfaces/__init__.py
@@ -236,10 +236,18 @@ else:
     del scipy
     from . import scipy_fftpack
 
-try:
-    from dask.array.fft import fft_wrap
-except ImportError:
-    pass
-else:
-    del fft_wrap
+from distutils.version import LooseVersion
+import numpy
+
+fft_wrap = None
+if LooseVersion(numpy.__version__) > LooseVersion("1.10"):
+    try:
+        from dask.array.fft import fft_wrap
+    except ImportError:
+        pass
+del LooseVersion
+del numpy
+
+if fft_wrap:
     from . import dask_fft
+del fft_wrap

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cython
 numpy>=1.6
 scipy>=0.12.0
-dask>=0.15.0
+dask[array]>=0.15.0

--- a/setup.py
+++ b/setup.py
@@ -759,6 +759,10 @@ def setup_package():
 
     install_requires = [numpy_requirement]
 
+    opt_requires = {
+        'dask': ['numpy>=1.10, <2.0', 'dask[array]>=0.15.0']
+    }
+
     setup_args = {
         'name': 'pyFFTW',
         'version': versioneer.get_version(),
@@ -786,6 +790,7 @@ def setup_package():
     if using_setuptools:
         setup_args['setup_requires'] = build_requires
         setup_args['install_requires'] = install_requires
+        setup_args['extras_require'] = opt_requires
 
     if len(sys.argv) >= 2 and (
         '--help' in sys.argv[1:] or

--- a/test/test_pyfftw_dask_interface.py
+++ b/test/test_pyfftw_dask_interface.py
@@ -47,13 +47,14 @@ from distutils.version import LooseVersion
 import unittest
 import numpy
 
-try:
+if interfaces.dask_fft:
     import dask.array as da
     from dask.array import fft as da_fft
     from dask.array.fft import fft_wrap
-except ImportError:
+else:
     da = None
     da_fft = None
+    fft_wrap = None
 
 import warnings
 import copy


### PR DESCRIPTION
Lists Dask Array as an extra requirement of pyFFTW. Make sure this requirement pulls in Dask with the Array extras and requires NumPy 1.10+. Also note this in the `requirements.txt` file as well.

In the event that Dask and pyFFTW end up in an environment without a compatible NumPy (e.g. older than NumPy 1.10), add a guard against adding the Dask interface that checks the NumPy version.