### PR TITLE
Add optional SciPy requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -760,7 +760,8 @@ def setup_package():
     install_requires = [numpy_requirement]
 
     opt_requires = {
-        'dask': ['numpy>=1.10, <2.0', 'dask[array]>=0.15.0']
+        'dask': ['numpy>=1.10, <2.0', 'dask[array]>=0.15.0'],
+        'scipy': ['scipy>=0.12.0']
     }
 
     setup_args = {


### PR DESCRIPTION
Includes an optional requirement on SciPy that users can get by doing `pip install pyfftw[scipy]`. If users want both optional requirements (Dask and SciPy), they can do `pip install pyfftw[dask,scipy]`. For development builds, this would be `pip install -e .[dask,scipy]` where this is run in the pyFFTW source tree and `.` means current directory.