### PR TITLE
Optionally use Dask if Numpy is 1.10

### DIFF
--- a/pyfftw/interfaces/__init__.py
+++ b/pyfftw/interfaces/__init__.py
@@ -236,16 +236,16 @@ else:
     del scipy
     from . import scipy_fftpack
 
-from distutils.version import LooseVersion
+from distutils.version import StrictVersion
 import numpy
 
 fft_wrap = None
-if LooseVersion(numpy.__version__) > LooseVersion("1.10"):
+if StrictVersion(numpy.__version__) >= StrictVersion("1.10.0"):
     try:
         from dask.array.fft import fft_wrap
     except ImportError:
         pass
-del LooseVersion
+del StrictVersion
 del numpy
 
 if fft_wrap:


### PR DESCRIPTION
The previous Dask interface import guard check required NumPy to be greater than 1.10.0 to work. However it is also ok for NumPy to be equal to 1.10.0. This relaxes the check a bit to allow NumPy 1.10.0 for instance. However filters out dev and rc releases. The latter should have no practical importance given how old NumPy 1.10 is. Nevertheless it is good to be strict about having a formal release to avoid potential issues.