### PR TITLE
add pyproject.toml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ before_install:
 install:
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION setuptools cython $NUMPY_SPEC $SCIPY_SPEC $DASK_SPEC blas=*=openblas
   - conda activate test-environment
-  - python setup.py -v build_ext --inplace
+  - pip install -e . -v --no-build-isolation
 
 script:
   - python setup.py test

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,7 @@ include pyfftw/pyfftw.pxd
 include pyfftw/cpu.pxd
 include pyfftw/utils.pxi
 include test/*.py
+include pyproject.toml
 recursive-include include *.h
 
 # All documentation

--- a/README.md
+++ b/README.md
@@ -73,12 +73,12 @@ package index with tools such as pip:
 
     pip install pyfftw
 
-Pre-built binary wheels for 64-bit Python on Linux, Mac OS X and Windows are 
+Pre-built binary wheels for 64-bit Python on Linux, Mac OS X and Windows are
 available on the [PyPI](https://pypi.org/) page for all supported Python versions.
 Note that we only support binaries for 64-bit Python. If you need to use 32-bit
 python for some reason, you will have to build pyFFTW from source.
 
-Note that prior to Python 3.9, the Windows installation defaulted to being 32-bit 
+Note that prior to Python 3.9, the Windows installation defaulted to being 32-bit
 even on 64-bit Windows, so if you are having problems installing using pip
 (typically with an error message like `ERROR: Failed building wheel for pyfftw`)
 then please check your Python version.
@@ -106,11 +106,7 @@ Read on if you do want to build from source...
 
 To build in place:
 
-    python setup.py build_ext --inplace
-
-or:
-
-    pip install -r requirements.txt -e . -v
+    pip install -e . -v
 
 That cythonizes the python extension and builds it into a shared library
 which is placed in ``pyfftw/``. The directory can then be treated as a python

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -82,7 +82,7 @@ install:
     - "%CONDA_ACTIVATE_CMD% build_env"
     - "conda install -y cython%CYTHON_BUILD_DEP% numpy%NP_BUILD_DEP% scipy%SP_BUILD_DEP% dask%DASK_BUILD_DEP% setuptools"
     - "%CMD_IN_ENV% python setup.py -v bdist_wheel"
-    - "%CMD_IN_ENV% python setup.py -v build_ext --inplace"
+    - "%CMD_IN_ENV% pip install -e . -v --no-build-isolation"
 
 build: false  # Not a C# project, build stuff somewhere else.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,10 @@
 [build-system]
 requires = [
     "wheel",
-    "setuptools",
+    "setuptools>=40.2.0",
     "Cython>=0.23",
     "numpy==1.10.4; python_version<='3.5'",
     "numpy==1.12.1; python_version=='3.6'",
     "numpy==1.13.1; python_version>='3.7'",
 ]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+requires = [
+    "wheel",
+    "setuptools",
+    "Cython>=0.23",
+    "numpy==1.10.4; python_version<='3.5'",
+    "numpy==1.12.1; python_version=='3.6'",
+    "numpy==1.13.1; python_version>='3.7'",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,12 @@
 [build-system]
 requires = [
     "wheel",
-    "setuptools>=40.2.0",
-    "Cython>=0.23",
-    "numpy==1.10.4; python_version<='3.5'",
-    "numpy==1.12.1; python_version=='3.6'",
-    "numpy==1.13.1; python_version>='3.7'",
+    "setuptools",
+    "Cython>=0.29.18",
+    "numpy==1.16.5; python_version=='3.7'",
+    "numpy==1.17.3; python_version=='3.8'",
+    "numpy==1.19.5; python_version=='3.9'",
+    # do not pin numpy on future versions of python to avoid incompatible numpy and python versions
+    "numpy; python_version>='3.10'",
 ]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cython>=0.29
-numpy>=1.10
-scipy>=0.16.0
-dask[array]>=0.15.0
+cython>=0.29.18
+numpy>=1.16
+scipy>=1.2.0
+dask[array]>=1.0.0

--- a/setup.py
+++ b/setup.py
@@ -742,7 +742,7 @@ def setup_package():
 
     # Figure out whether to add ``*_requires = ['numpy']``.
     build_requires = []
-    numpy_requirement = 'numpy>=1.10, <2.0'
+    numpy_requirement = 'numpy>=1.16, <2.0'
     try:
         import numpy
     except ImportError:
@@ -755,13 +755,13 @@ def setup_package():
     try:
         import cython
     except ImportError:
-        build_requires.append('cython>=0.29, <1.0')
+        build_requires.append('cython>=0.29.18, <1.0')
 
     install_requires = [numpy_requirement]
 
     opt_requires = {
-        'dask': ['numpy>=1.10, <2.0', 'dask[array]>=0.15.0'],
-        'scipy': ['scipy>=0.12.0']
+        'dask': ['numpy>=1.16, <2.0', 'dask[array]>=1.0'],
+        'scipy': ['scipy>=1.2.0']
     }
 
     setup_args = {
@@ -786,7 +786,7 @@ def setup_package():
             'Topic :: Scientific/Engineering :: Mathematics',
             'Topic :: Multimedia :: Sound/Audio :: Analysis'],
         'cmdclass': cmdclass,
-        'python_requires': ">=3.6",
+        'python_requires': ">=3.7",
     }
 
     if using_setuptools:

--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,13 @@ from distutils.util import get_platform
 import contextlib
 import os
 import sys
-import versioneer
 
+# ensure the current directory is on sys.path so versioneer can be imported
+# when pip uses PEP 517/518 build rules.
+# https://github.com/python-versioneer/python-versioneer/issues/193
+sys.path.append(os.path.dirname(__file__))
+
+import versioneer
 
 if os.environ.get("READTHEDOCS") == "True":
     try:


### PR DESCRIPTION
Addition of `pyproject.toml` was removed from #204 due to current compatibility issue with pip 10.0.0. This PR should not be merged until after these issues have been resolved.

