### PR TITLE
WIP: appveyor fixes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,11 +30,11 @@ environment:
           PYTHON_ARCH: "64"
           PYTHON_VERSION: "2.7"
 
-        - PYTHON_HOME: "C:\\Miniconda3"
+        - PYTHON_HOME: "C:\\Miniconda34"
           PYTHON_ARCH: "32"
           PYTHON_VERSION: "3.4"
 
-        - PYTHON_HOME: "C:\\Miniconda3-x64"
+        - PYTHON_HOME: "C:\\Miniconda34-x64"
           PYTHON_ARCH: "64"
           PYTHON_VERSION: "3.4"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
         CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
         # The miniconda installations are put in pyfftw_miniconda
         PYTHON_HOME: "C:\\pyfftw_miniconda"
-        NP_BUILD_DEP: "1.9"
+        NP_BUILD_DEP: "1.9.3"
 
     pypi_username:
         secure: qFSpEDsIOj6gzynjuHTX5A==
@@ -49,12 +49,12 @@ environment:
         - PYTHON_HOME: "C:\\Miniconda36"
           PYTHON_ARCH: "32"
           PYTHON_VERSION: "3.6"
-          NP_BUILD_DEP: "1.11"
+          NP_BUILD_DEP: "1.12.1"
 
         - PYTHON_HOME: "C:\\Miniconda36-x64"
           PYTHON_ARCH: "64"
           PYTHON_VERSION: "3.6"
-          NP_BUILD_DEP: "1.11"
+          NP_BUILD_DEP: "1.12.1"
 
 install:
     # Get and configure the FFTW libs
@@ -69,7 +69,7 @@ install:
     - "conda update -q conda"
     - "conda create -q -n build_env python=%PYTHON_VERSION% cython setuptools"
     - "activate build_env"
-    - "pip install numpy scipy dask"
+    - "pip install numpy==%NP_BUILD_DEP% scipy dask"
     - "%CMD_IN_ENV% python setup.py -v bdist_wheel"
     - "%CMD_IN_ENV% python setup.py -v build_ext --inplace"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -67,8 +67,9 @@ install:
 
     - "conda config --set always_yes yes --set changeps1 no"
     - "conda update -q conda"
-    - "conda create -q -n build_env python=%PYTHON_VERSION% nomkl numpy=%NP_BUILD_DEP% scipy cython dask setuptools"
+    - "conda create -q -n build_env python=%PYTHON_VERSION% cython setuptools"
     - "activate build_env"
+    - "pip install numpy scipy dask"
     - "%CMD_IN_ENV% python setup.py -v bdist_wheel"
     - "%CMD_IN_ENV% python setup.py -v build_ext --inplace"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -67,7 +67,7 @@ install:
 
     - "conda config --set always_yes yes --set changeps1 no"
     - "conda update -q conda"
-    - "conda create -q -n build_env python=%PYTHON_VERSION% numpy=%NP_BUILD_DEP% scipy cython dask setuptools"
+    - "conda create -q -n build_env python=%PYTHON_VERSION% nomkl numpy=%NP_BUILD_DEP% scipy cython dask setuptools"
     - "activate build_env"
     - "%CMD_IN_ENV% python setup.py -v bdist_wheel"
     - "%CMD_IN_ENV% python setup.py -v build_ext --inplace"


### PR DESCRIPTION
I added the nomkl flag to prevent conda from replacing numpy's FFTs with those from mkl_fft.  This is necessary to prevent test failures.

I have also tried changing `Miniconda3` to `Miniconda34` to see if that fixes the Python 3.4 failures