### PR TITLE
less strict Numpy version comparison on import

### DIFF
--- a/pyfftw/interfaces/__init__.py
+++ b/pyfftw/interfaces/__init__.py
@@ -236,7 +236,12 @@ else:
     del scipy
     from . import scipy_fftpack
 
-from numpy.lib import NumpyVersion
+try:
+    # NumpyVersion was introduced in NumPy 1.9
+    from numpy.lib import NumpyVersion
+except ImportError:
+    from distutils.version import LooseVersion as NumpyVersion
+
 import numpy
 
 fft_wrap = None

--- a/pyfftw/interfaces/__init__.py
+++ b/pyfftw/interfaces/__init__.py
@@ -236,16 +236,16 @@ else:
     del scipy
     from . import scipy_fftpack
 
-from distutils.version import StrictVersion
+from numpy.lib import NumpyVersion
 import numpy
 
 fft_wrap = None
-if StrictVersion(numpy.__version__) >= StrictVersion("1.10.0"):
+if NumpyVersion(numpy.__version__) >= NumpyVersion("1.10.0"):
     try:
         from dask.array.fft import fft_wrap
     except ImportError:
         pass
-del StrictVersion
+del NumpyVersion
 del numpy
 
 if fft_wrap:


### PR DESCRIPTION
I happened to be working in a conda environment with a development build of numpy:
```numpy:           1.15dev-py36_blas_openblas_201 local       [blas_openblas]```

In this environment, the value of `numpy.__version__` is `1.15.0.dev0+7bb2d5a`. This version string leads to the following error in StrictVersion during import of pyFFTW:

```ValueError: invalid version number '1.15.0.dev0+7bb2d5a'```

Using either `distutils.version.LooseVersion` or `numpy.lib.NumpyVersion` seems to resolve the issue. 