### PR TITLE
Fix using non-tuple multidimensional indices

### DIFF
--- a/pyfftw/builders/_utils.py
+++ b/pyfftw/builders/_utils.py
@@ -362,7 +362,7 @@ def _setup_input_slicers(a_shape, input_shape):
             update_input_array_slicer[axis] = (
                     slice(0, a_shape[axis]))
 
-    return update_input_array_slicer, FFTW_array_slicer
+    return tuple(update_input_array_slicer), tuple(FFTW_array_slicer)
 
 def _compute_array_shapes(a, s, axes, inverse, real):
     '''Given a passed in array ``a``, and the rest of the arguments

--- a/test/test_pyfftw_builders.py
+++ b/test/test_pyfftw_builders.py
@@ -1105,9 +1105,9 @@ class BuildersTestUtilities(unittest.TestCase):
                 )
 
         outputs = (
-                ([slice(0, 4), slice(0, 5)], [slice(None), slice(None)]),
-                ([slice(0, 3), slice(0, 4)], [slice(None), slice(0, 4)]),
-                ([slice(0, 3), slice(0, 5)], [slice(None), slice(None)]),
+                ((slice(0, 4), slice(0, 5)), (slice(None), slice(None))),
+                ((slice(0, 3), slice(0, 4)), (slice(None), slice(0, 4))),
+                ((slice(0, 3), slice(0, 5)), (slice(None), slice(None))),
                 )
 
         for _input, _output in zip(inputs, outputs):


### PR DESCRIPTION
This caused the following numpy deprecation warning:
```bash
.../pyfftw/builders/_utils.py:208: FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result.
  a_copy[update_input_array_slicer])
.../pyfftw/builders/_utils.py:305: FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result.
  sliced_internal = internal_input_array[self._FFTW_array_slicer]
.../pyfftw/builders/_utils.py:306: FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result.
  sliced_input = input_array[self._input_array_slicer]
```