### PR TITLE
avoid multi-indexing warnings with numpy >= 1.15

### DIFF
--- a/pyfftw/interfaces/scipy_fftpack.py
+++ b/pyfftw/interfaces/scipy_fftpack.py
@@ -195,12 +195,12 @@ def _complex_to_rfft_output(complex_output, output_shape, axis):
     # First element
     source_slicer[axis] = slice(0, 1)
     target_slicer[axis] = slice(0, 1)
-    rfft_output[target_slicer] = complex_output[source_slicer].real
+    rfft_output[tuple(target_slicer)] = complex_output[tuple(source_slicer)].real
 
     # Real part
     source_slicer[axis] = slice(1, None)
     target_slicer[axis] = slice(1, None, 2)
-    rfft_output[target_slicer] = complex_output[source_slicer].real
+    rfft_output[tuple(target_slicer)] = complex_output[tuple(source_slicer)].real
 
     # Imaginary part
     if output_shape[axis] % 2 == 0:
@@ -210,7 +210,7 @@ def _complex_to_rfft_output(complex_output, output_shape, axis):
 
     source_slicer[axis] = slice(1, end_val, None)
     target_slicer[axis] = slice(2, None, 2)
-    rfft_output[target_slicer] = complex_output[source_slicer].imag
+    rfft_output[tuple(target_slicer)] = complex_output[tuple(source_slicer)].imag
 
     return rfft_output
 
@@ -231,24 +231,24 @@ def _irfft_input_to_complex(irfft_input, axis):
     # First element
     source_slicer[axis] = slice(0, 1)
     target_slicer[axis] = slice(0, 1)
-    complex_input[target_slicer] = irfft_input[source_slicer]
+    complex_input[tuple(target_slicer)] = irfft_input[tuple(source_slicer)]
 
     # Real part
     source_slicer[axis] = slice(1, None, 2)
     target_slicer[axis] = slice(1, None)
-    complex_input[target_slicer].real = irfft_input[source_slicer]
+    complex_input[tuple(target_slicer)].real = irfft_input[tuple(source_slicer)]
 
     # Imaginary part
     if irfft_input.shape[axis] % 2 == 0:
         end_val = -1
         target_slicer[axis] = slice(-1, None)
-        complex_input[target_slicer].imag = 0.0
+        complex_input[tuple(target_slicer)].imag = 0.0
     else:
         end_val = None
 
     source_slicer[axis] = slice(2, None, 2)
     target_slicer[axis] = slice(1, end_val)
-    complex_input[target_slicer].imag = irfft_input[source_slicer]
+    complex_input[tuple(target_slicer)].imag = irfft_input[tuple(source_slicer)]
 
     return complex_input
 

--- a/test/test_pyfftw_builders.py
+++ b/test/test_pyfftw_builders.py
@@ -409,6 +409,7 @@ class BuildersTestFFT(unittest.TestCase):
                 for each_dim in test_shape:
                     _test_shape.append(each_dim*2)
                     slices.append(slice(None, None, 2))
+                slices = tuple(slices)
 
                 input_array = dtype_tuple[1](_test_shape, dtype)[slices]
                 # check the input is non contiguous
@@ -543,7 +544,7 @@ class BuildersTestFFT(unittest.TestCase):
                 except TypeError:
                     s += n_add
                     padding_slicer[axes[0]] = slice(s, None)
-
+                padding_slicer = tuple(padding_slicer)
                 # Get a valid object
                 FFTW_object = self.validate_pyfftw_object(dtype_tuple[1],
                         test_shape, dtype, s, kwargs)
@@ -688,7 +689,7 @@ class BuildersTestFFT(unittest.TestCase):
 
                 non_contiguous_shape = [
                         each_dim * 2 for each_dim in test_shape]
-                non_contiguous_slices = (
+                non_contiguous_slices = tuple(
                         [slice(None, None, 2)] * len(test_shape))
 
                 misaligned_input_array = dtype_tuple[1](
@@ -802,8 +803,8 @@ class BuildersTestFFTWWrapper(unittest.TestCase):
 
         require(self, '64')
 
-        self.input_array_slicer = [slice(None), slice(256)]
-        self.FFTW_array_slicer = [slice(128), slice(None)]
+        self.input_array_slicer = tuple([slice(None), slice(256)])
+        self.FFTW_array_slicer = tuple([slice(128), slice(None)])
 
         self.input_array = empty_aligned((128, 512), dtype='complex128')
         self.output_array = empty_aligned((256, 256), dtype='complex128')


### PR DESCRIPTION
Indexing with lists of slices is raises a `FutureWarning` in numpy 1.15. This was occurring in the scipy interfaces and in some of the tests leading to tons of warnings in the test suite. This PR just converts these lists of slices to tuples.
