### PR TITLE
Allow run-time choice of the default number of threads and planning effort

### DIFF
--- a/docs/source/pyfftw/pyfftw.rst
+++ b/docs/source/pyfftw/pyfftw.rst
@@ -98,3 +98,35 @@ Utility Functions
 .. autofunction:: pyfftw.is_n_byte_aligned
 
 .. autofunction:: pyfftw.next_fast_len
+
+.. _configuration_variables:
+
+FFTW Configuration
+------------------
+
+.. data:: pyfftw.config.NUM_THREADS
+
+   This variable controls the default number of threads used by the functions
+   in :mod:`pywt.builders` and :mod:`pywt.interfaces`.
+
+   The default value is read from the environment variable
+   ``PYFFTW_NUM_THREADS``. If this variable is undefined and the user's
+   underlying FFTW library was built using OpenMP threading, the number of
+   threads will be read from the environment variable ``OMP_NUM_THREADS``
+   instead. If neither environment variable is defined, the default value is 1.
+
+   If the specified value is ``<= 0``, the library will use
+   :func:`multiprocessing.cpu_count` to determine the number of threads.
+
+   The user can modify the value at run time by assigning to this variable.
+
+.. data:: pyfftw.config.PLANNER_EFFORT
+
+   This variable controls the default planning effort used by the functions
+   in :mod:`pywt.builders` and :mod:`pywt.interfaces`.
+
+   The default value of is determined by reading from the environment variable
+   ``PYFFTW_PLANNER_EFFORT``. If this environment variable is undefined, it
+   defaults to ``'FFTW_ESTIMATE'``.
+
+   The user can modify the value at run time by assigning to this variable.

--- a/docs/source/pyfftw/pyfftw.rst
+++ b/docs/source/pyfftw/pyfftw.rst
@@ -107,7 +107,7 @@ FFTW Configuration
 .. data:: pyfftw.config.NUM_THREADS
 
    This variable controls the default number of threads used by the functions
-   in :mod:`pywt.builders` and :mod:`pywt.interfaces`.
+   in :mod:`pyfftw.builders` and :mod:`pyfftw.interfaces`.
 
    The default value is read from the environment variable
    ``PYFFTW_NUM_THREADS``. If this variable is undefined and the user's
@@ -123,7 +123,7 @@ FFTW Configuration
 .. data:: pyfftw.config.PLANNER_EFFORT
 
    This variable controls the default planning effort used by the functions
-   in :mod:`pywt.builders` and :mod:`pywt.interfaces`.
+   in :mod:`pyfftw.builders` and :mod:`pyfftw.interfaces`.
 
    The default value of is determined by reading from the environment variable
    ``PYFFTW_PLANNER_EFFORT``. If this environment variable is undefined, it

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -102,7 +102,7 @@ Monkey patching 3rd party libraries
 Since :mod:`pyfftw.interfaces.numpy_fft` and
 :mod:`pyfftw.interfaces.scipy_fftpack` are drop-in replacements for their
 :mod:`numpy.fft` and :mod:`scipy.fftpack` libraries respectively, it is
-possible use them as replacements at run-time through monkey patching. Note
+possible to use them as replacements at run-time through monkey patching. Note
 that the interfaces (and builders) all currently default to a single thread.
 The number of threads to use can be configured by assigning a positive integer
 to `pyfftw.config.NUM_THREADS` (see more details under
@@ -476,7 +476,7 @@ for more information.
 
 Configuring FFTW planning effort and number of threads
 ------------------------------------------------------
-The user my set the default number of threads used by the interfaces and
+The user may set the default number of threads used by the interfaces and
 builders at run time by assigning to ``pyfftw.config.NUM_THREADS``. Similarly
 the default
 `planning effort <http://www.fftw.org/fftw3_doc/Planner-Flags.html>`_

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -102,7 +102,11 @@ Monkey patching 3rd party libraries
 Since :mod:`pyfftw.interfaces.numpy_fft` and
 :mod:`pyfftw.interfaces.scipy_fftpack` are drop-in replacements for their
 :mod:`numpy.fft` and :mod:`scipy.fftpack` libraries respectively, it is
-possible use them as replacements at run-time through monkey patching.
+possible use them as replacements at run-time through monkey patching. Note
+that the interfaces (and builders) all currently default to a single thread.
+The number of threads to use can be configured by assigning a positive integer
+to `pyfftw.config.NUM_THREADS` (see more details under
+:ref:configuration <interfaces_tutorial>).
 
 The following code demonstrates :func:`scipy.signal.fftconvolve` being monkey
 patched in order to speed it up.
@@ -110,6 +114,7 @@ patched in order to speed it up.
 .. testcode::
 
    import pyfftw
+   import multiprocessing
    import scipy.signal
    import numpy
    from timeit import Timer
@@ -123,7 +128,10 @@ patched in order to speed it up.
    t = Timer(lambda: scipy.signal.fftconvolve(a, b))
 
    print('Time with scipy.fftpack: %1.3f seconds' % t.timeit(number=100))
-   
+
+   # Configure PyFFTW to use all cores (the default is single-threaded)
+   pyfftw.config.NUM_THREADS = multiprocessing.cpu_count()
+
    # Monkey patch fftpack with pyfftw.interfaces.scipy_fftpack
    scipy.fftpack = pyfftw.interfaces.scipy_fftpack
    scipy.signal.fftconvolve(a, b) # We cheat a bit by doing the planning first
@@ -463,6 +471,35 @@ This way, shapes are made consistent for copying.
 Understanding :mod:`numpy.fft`, these functions are largely
 self-explanatory. We point the reader to the :mod:`API docs <pyfftw.builders>`
 for more information.
+
+.. _configuration:
+
+Configuring FFTW planning effort and number of threads
+------------------------------------------------------
+The user my set the default number of threads used by the interfaces and
+builders at run time by assigning to ``pyfftw.config.NUM_THREADS``. Similarly
+the default
+`planning effort <http://www.fftw.org/fftw3_doc/Planner-Flags.html>`_
+may be set by assigning a string such as ``'FFTW_ESTIMATE'`` or
+``'FFTW_MEASURE'`` to ``pyfftw.config.PLANNER_EFFORT``.
+
+For example, to change the effort to ``'FFTW_MEASURE'`` and specify 4 threads:
+
+.. testcode::
+
+   import pyfftw
+
+   pyfftw.config.NUM_THREADS = 4
+
+   pyfftw.config.PLANNER_EFFORT = 'FFTW_MEASURE'
+
+All functions in :mod:`pyfftw.interfaces` and :mod:`pyfftw.builders` use the
+values from :mod:`pyfftw.config` when determining the default number of threads
+and planning effort.
+
+The initial values in pyfftw.config at import time can be controlled via the
+environment variables as detailed in the
+:ref:`configuration <_configuration_variables>` documentation.
 
 .. rubric:: Footnotes
 

--- a/pyfftw/__init__.py
+++ b/pyfftw/__init__.py
@@ -8,7 +8,9 @@ arrays.
 
 This module represents the full interface to the underlying `FFTW
 library <http://www.fftw.org/>`_. However, users may find it easier to
-use the helper routines provided in :mod:`pyfftw.builders`.
+use the helper routines provided in :mod:`pyfftw.builders`. Default values
+used by the helper routines can be controlled as via
+:ref:`configuration variables <configuration_variables>`.
 '''
 
 import os

--- a/pyfftw/__init__.py
+++ b/pyfftw/__init__.py
@@ -11,6 +11,8 @@ library <http://www.fftw.org/>`_. However, users may find it easier to
 use the helper routines provided in :mod:`pyfftw.builders`.
 '''
 
+import os
+
 from .pyfftw import (
         FFTW,
         export_wisdom,
@@ -30,11 +32,14 @@ from .pyfftw import (
         _supported_nptypes_complex,
         _supported_nptypes_real,
         _all_types_human_readable,
-        _all_types_np
+        _all_types_np,
+        _threading_type
 )
 
+from . import config
 from . import builders
 from . import interfaces
+
 
 # clean up the namespace
 del builders.builders

--- a/pyfftw/builders/_utils.py
+++ b/pyfftw/builders/_utils.py
@@ -50,6 +50,7 @@ Everything documented in this module is *not* part of the public API
 and may change in future versions.
 '''
 
+import multiprocessing
 import pyfftw
 import numpy
 import warnings
@@ -100,13 +101,18 @@ def _default_effort(effort):
     else:
         return effort
 
+
 def _default_threads(threads):
     if threads is None:
+        if config.NUM_THREADS <= 0:
+            return multiprocessing.cpu_count()
         return config.NUM_THREADS
     else:
         if threads > 1 and _threading_type is None:
             raise ValueError("threads > 1 requested, but pyFFTW was not built "
                              "with multithreaded FFTW.")
+        elif threads <= 0:
+            return multiprocessing.cpu_count()
         return threads
 
 

--- a/pyfftw/builders/_utils.py
+++ b/pyfftw/builders/_utils.py
@@ -53,6 +53,8 @@ and may change in future versions.
 import pyfftw
 import numpy
 import warnings
+from .. import _threading_type
+from .. import config
 
 __all__ = ['_FFTWWrapper', '_rc_dtype_pairs', '_default_dtype', '_Xfftn',
         '_setup_input_slicers', '_compute_array_shapes', '_precook_1d_args',
@@ -90,6 +92,22 @@ if '32' in pyfftw._supported_types:
         numpy.dtype('complex64').char: numpy.dtype('float32')})
 if _default_dtype is None:
     raise NotImplementedError("No default precision available")
+
+
+def _default_effort(effort):
+    if effort is None:
+        return config.PLANNER_EFFORT
+    else:
+        return effort
+
+def _default_threads(threads):
+    if threads is None:
+        return config.NUM_THREADS
+    else:
+        if threads > 1 and _threading_type is None:
+            raise ValueError("threads > 1 requested, but pyFFTW was not built "
+                             "with multithreaded FFTW.")
+        return threads
 
 
 def _unitary(norm):

--- a/pyfftw/builders/builders.py
+++ b/pyfftw/builders/builders.py
@@ -184,7 +184,7 @@ following additional keyword arguments:
 
   The valid strings, in order of their increasing impact on the time
   to compute  are:
-  ``'FFTW_ESTIMATE'``, ``'FFTW_MEASURE'`` (default), ``'FFTW_PATIENT'``
+  ``'FFTW_ESTIMATE'``, ``config.PLANNER_EFFORT`` (default), ``'FFTW_PATIENT'``
   and ``'FFTW_EXHAUSTIVE'``.
 
   The `Wisdom
@@ -263,8 +263,8 @@ The exceptions raised by each of these functions are as per their
 equivalents in :mod:`numpy.fft`, or as documented above.
 '''
 
-from ._utils import _precook_1d_args, _Xfftn, _norm_args
-
+from ._utils import (_precook_1d_args, _Xfftn, _norm_args, _default_effort,
+                     _default_threads)
 
 __all__ = ['fft','ifft', 'fft2', 'ifft2', 'fftn',
            'ifftn', 'rfft', 'irfft', 'rfft2', 'irfft2', 'rfftn',
@@ -272,7 +272,7 @@ __all__ = ['fft','ifft', 'fft2', 'ifft2', 'fftn',
 
 
 def fft(a, n=None, axis=-1, overwrite_input=False,
-        planner_effort='FFTW_MEASURE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a 1D FFT.
@@ -285,13 +285,15 @@ def fft(a, n=None, axis=-1, overwrite_input=False,
     real = False
 
     s, axes = _precook_1d_args(a, n, axis)
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
             avoid_copy, inverse, real, **_norm_args(norm))
 
 def ifft(a, n=None, axis=-1, overwrite_input=False,
-        planner_effort='FFTW_MEASURE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a 1D
@@ -306,6 +308,8 @@ def ifft(a, n=None, axis=-1, overwrite_input=False,
     real = False
 
     s, axes = _precook_1d_args(a, n, axis)
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
@@ -313,7 +317,7 @@ def ifft(a, n=None, axis=-1, overwrite_input=False,
 
 
 def fft2(a, s=None, axes=(-2,-1), overwrite_input=False,
-        planner_effort='FFTW_MEASURE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a 2D FFT.
@@ -326,13 +330,15 @@ def fft2(a, s=None, axes=(-2,-1), overwrite_input=False,
 
     inverse = False
     real = False
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
             avoid_copy, inverse, real, **_norm_args(norm))
 
 def ifft2(a, s=None, axes=(-2,-1), overwrite_input=False,
-        planner_effort='FFTW_MEASURE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a
@@ -346,6 +352,8 @@ def ifft2(a, s=None, axes=(-2,-1), overwrite_input=False,
 
     inverse = True
     real = False
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
@@ -353,7 +361,7 @@ def ifft2(a, s=None, axes=(-2,-1), overwrite_input=False,
 
 
 def fftn(a, s=None, axes=None, overwrite_input=False,
-        planner_effort='FFTW_MEASURE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a n-D FFT.
@@ -366,13 +374,15 @@ def fftn(a, s=None, axes=None, overwrite_input=False,
 
     inverse = False
     real = False
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
             avoid_copy, inverse, real, **_norm_args(norm))
 
 def ifftn(a, s=None, axes=None, overwrite_input=False,
-        planner_effort='FFTW_MEASURE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing an n-D
@@ -386,13 +396,15 @@ def ifftn(a, s=None, axes=None, overwrite_input=False,
 
     inverse = True
     real = False
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
             avoid_copy, inverse, real, **_norm_args(norm))
 
 def rfft(a, n=None, axis=-1, overwrite_input=False,
-        planner_effort='FFTW_MEASURE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a 1D
@@ -408,13 +420,15 @@ def rfft(a, n=None, axis=-1, overwrite_input=False,
     real = True
 
     s, axes = _precook_1d_args(a, n, axis)
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
             avoid_copy, inverse, real, **_norm_args(norm))
 
 def irfft(a, n=None, axis=-1, overwrite_input=False,
-        planner_effort='FFTW_MEASURE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a 1D
@@ -430,13 +444,15 @@ def irfft(a, n=None, axis=-1, overwrite_input=False,
     real = True
 
     s, axes = _precook_1d_args(a, n, axis)
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
             avoid_copy, inverse, real, **_norm_args(norm))
 
 def rfft2(a, s=None, axes=(-2,-1), overwrite_input=False,
-        planner_effort='FFTW_MEASURE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a 2D
@@ -449,13 +465,15 @@ def rfft2(a, s=None, axes=(-2,-1), overwrite_input=False,
 
     inverse = False
     real = True
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
             avoid_copy, inverse, real, **_norm_args(norm))
 
 def irfft2(a, s=None, axes=(-2,-1),
-        planner_effort='FFTW_MEASURE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing a 2D
@@ -471,6 +489,8 @@ def irfft2(a, s=None, axes=(-2,-1),
     real = True
 
     overwrite_input = True
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
@@ -478,7 +498,7 @@ def irfft2(a, s=None, axes=(-2,-1),
 
 
 def rfftn(a, s=None, axes=None, overwrite_input=False,
-        planner_effort='FFTW_MEASURE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing an n-D
@@ -492,6 +512,8 @@ def rfftn(a, s=None, axes=None, overwrite_input=False,
 
     inverse = False
     real = True
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
@@ -499,7 +521,7 @@ def rfftn(a, s=None, axes=None, overwrite_input=False,
 
 
 def irfftn(a, s=None, axes=None,
-        planner_effort='FFTW_MEASURE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
     '''Return a :class:`pyfftw.FFTW` object representing an n-D
@@ -515,6 +537,8 @@ def irfftn(a, s=None, axes=None,
     real = True
 
     overwrite_input = True
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,

--- a/pyfftw/config.py
+++ b/pyfftw/config.py
@@ -27,7 +27,7 @@ class _EnvReloader(object):
         for name, value in os.environ.items():
             if name.startswith('PYFFTW_') or name == 'OMP_NUM_THREADS':
                 new_environ[name] = value
-        # We update the config variables if at least one NUMBA environment
+        # We update the config variables if at least one PYFFTW environment
         # variable was modified.  This lets the user modify values
         # directly in the config module without having them when
         # reload_config() is called by the compiler.

--- a/pyfftw/config.py
+++ b/pyfftw/config.py
@@ -75,7 +75,7 @@ class _EnvReloader(object):
 _env_reloader = _EnvReloader()
 
 
-def reload_config():
+def _reload_config():
     """
     Reload the configuration from environment variables, if necessary.
     """

--- a/pyfftw/config.py
+++ b/pyfftw/config.py
@@ -1,0 +1,82 @@
+"""Global configuration variables for PyFFTW.
+
+The approach taken here was adapated from Numba's config.py.
+"""
+from __future__ import print_function, division, absolute_import
+
+import os
+import multiprocessing
+import warnings
+
+from .pyfftw import _threading_type
+
+
+class _EnvReloader(object):
+
+    def __init__(self):
+        self.reset()
+
+    def reset(self):
+        self.old_environ = {}
+        self.update(force=True)
+
+    def update(self, force=False):
+        new_environ = {}
+
+        # read local env var OMP_NUM_THREADS and any starting with PYFFTW_
+        for name, value in os.environ.items():
+            if name.startswith('PYFFTW_') or name == 'OMP_NUM_THREADS':
+                new_environ[name] = value
+        # We update the config variables if at least one NUMBA environment
+        # variable was modified.  This lets the user modify values
+        # directly in the config module without having them when
+        # reload_config() is called by the compiler.
+        if force or self.old_environ != new_environ:
+            self.process_environ(new_environ)
+            # Store a copy
+            self.old_environ = dict(new_environ)
+
+    def process_environ(self, environ):
+        def _readenv(name, ctor, default):
+            value = environ.get(name)
+            if value is None:
+                return default() if callable(default) else default
+            try:
+                return ctor(value)
+            except Exception:
+                warnings.warn("environ %s defined but failed to parse '%s'" %
+                              (name, value), RuntimeWarning)
+                return default
+
+        def optional_str(x):
+            return str(x) if x is not None else None
+
+        if _threading_type is None:
+            NUM_THREADS = 1
+        else:
+            if (_threading_type == "OMP" and
+                    "PYFFTW_NUM_THREADS" not in environ):
+                # fallback to OMP_NUM_THREADS if PYFFTW_NUM_THREADS undefined
+                NUM_THREADS = _readenv("OMP_NUM_THREADS", int, 1)
+            else:
+                NUM_THREADS = _readenv("PYFFTW_NUM_THREADS", int, 1)
+            # if user requested <= 0 threads, use the maximum available
+            if NUM_THREADS <= 0:
+                NUM_THREADS = multiprocessing.cpu_count()
+
+        PLANNER_EFFORT = _readenv(
+            "PYFFTW_PLANNER_EFFORT", str, "FFTW_ESTIMATE")
+
+        # Inject the configuration values into the module globals
+        for name, value in locals().copy().items():
+            if name.isupper():
+                globals()[name] = value
+
+_env_reloader = _EnvReloader()
+
+
+def reload_config():
+    """
+    Reload the configuration from environment variables, if necessary.
+    """
+    _env_reloader.update()

--- a/pyfftw/interfaces/numpy_fft.py
+++ b/pyfftw/interfaces/numpy_fft.py
@@ -60,7 +60,8 @@ which this may not be true.
 '''
 
 from ._utils import _Xfftn
-from ..builders._utils import _norm_args, _unitary
+from ..builders._utils import (_norm_args, _unitary, _default_effort,
+                               _default_threads)
 
 # Complete the namespace (these are not actually used in this module)
 from numpy.fft import fftfreq, fftshift, ifftshift
@@ -80,7 +81,7 @@ except ImportError:
 
 
 def fft(a, n=None, axis=-1, norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D FFT.
 
@@ -90,13 +91,15 @@ def fft(a, n=None, axis=-1, norm=None, overwrite_input=False,
     '''
 
     calling_func = 'fft'
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
 
     return _Xfftn(a, n, axis, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
             calling_func, **_norm_args(norm))
 
 def ifft(a, n=None, axis=-1, norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D inverse FFT.
 
@@ -105,6 +108,8 @@ def ifft(a, n=None, axis=-1, norm=None, overwrite_input=False,
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     '''
     calling_func = 'ifft'
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
 
     return _Xfftn(a, n, axis, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
@@ -112,7 +117,7 @@ def ifft(a, n=None, axis=-1, norm=None, overwrite_input=False,
 
 
 def fft2(a, s=None, axes=(-2,-1), norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 2D FFT.
 
@@ -121,13 +126,15 @@ def fft2(a, s=None, axes=(-2,-1), norm=None, overwrite_input=False,
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     '''
     calling_func = 'fft2'
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
             calling_func, **_norm_args(norm))
 
 def ifft2(a, s=None, axes=(-2,-1), norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 2D inverse FFT.
 
@@ -136,6 +143,8 @@ def ifft2(a, s=None, axes=(-2,-1), norm=None, overwrite_input=False,
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     '''
     calling_func = 'ifft2'
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
@@ -143,7 +152,7 @@ def ifft2(a, s=None, axes=(-2,-1), norm=None, overwrite_input=False,
 
 
 def fftn(a, s=None, axes=None, norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
     '''Perform an n-D FFT.
 
@@ -152,6 +161,8 @@ def fftn(a, s=None, axes=None, norm=None, overwrite_input=False,
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     '''
     calling_func = 'fftn'
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
@@ -159,7 +170,7 @@ def fftn(a, s=None, axes=None, norm=None, overwrite_input=False,
 
 
 def ifftn(a, s=None, axes=None, norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
     '''Perform an n-D inverse FFT.
 
@@ -168,6 +179,8 @@ def ifftn(a, s=None, axes=None, norm=None, overwrite_input=False,
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     '''
     calling_func = 'ifftn'
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
@@ -175,7 +188,7 @@ def ifftn(a, s=None, axes=None, norm=None, overwrite_input=False,
 
 
 def rfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D real FFT.
 
@@ -184,6 +197,8 @@ def rfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     '''
     calling_func = 'rfft'
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
 
     return _Xfftn(a, n, axis, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
@@ -191,7 +206,7 @@ def rfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
 
 
 def irfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D real inverse FFT.
 
@@ -200,6 +215,8 @@ def irfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     '''
     calling_func = 'irfft'
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
 
     return _Xfftn(a, n, axis, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
@@ -207,7 +224,7 @@ def irfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
 
 
 def rfft2(a, s=None, axes=(-2,-1), norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 2D real FFT.
 
@@ -216,6 +233,8 @@ def rfft2(a, s=None, axes=(-2,-1), norm=None, overwrite_input=False,
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     '''
     calling_func = 'rfft2'
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
@@ -223,7 +242,7 @@ def rfft2(a, s=None, axes=(-2,-1), norm=None, overwrite_input=False,
 
 
 def irfft2(a, s=None, axes=(-2,-1), norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 2D real inverse FFT.
 
@@ -232,6 +251,8 @@ def irfft2(a, s=None, axes=(-2,-1), norm=None, overwrite_input=False,
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     '''
     calling_func = 'irfft2'
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
@@ -239,7 +260,7 @@ def irfft2(a, s=None, axes=(-2,-1), norm=None, overwrite_input=False,
 
 
 def rfftn(a, s=None, axes=None, norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
     '''Perform an n-D real FFT.
 
@@ -248,6 +269,8 @@ def rfftn(a, s=None, axes=None, norm=None, overwrite_input=False,
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     '''
     calling_func = 'rfftn'
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
@@ -255,7 +278,7 @@ def rfftn(a, s=None, axes=None, norm=None, overwrite_input=False,
 
 
 def irfftn(a, s=None, axes=None, norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
     '''Perform an n-D real inverse FFT.
 
@@ -264,6 +287,8 @@ def irfftn(a, s=None, axes=None, norm=None, overwrite_input=False,
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     '''
     calling_func = 'irfftn'
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
@@ -271,7 +296,7 @@ def irfftn(a, s=None, axes=None, norm=None, overwrite_input=False,
 
 
 def hfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
-         planner_effort='FFTW_ESTIMATE', threads=1,
+         planner_effort=None, threads=None,
          auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D FFT of a signal with hermitian symmetry.
     This yields a real output spectrum. See :func:`numpy.fft.hfft`
@@ -291,6 +316,8 @@ def hfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
         raise ValueError("hfft requires input with length >= 2")
 
     calling_func = 'irfft'
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
 
     if _unitary(norm):
         if n is None:
@@ -308,7 +335,7 @@ def hfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
 
 
 def ihfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D inverse FFT of a real-spectrum, yielding
     a signal with hermitian symmetry. See :func:`numpy.fft.ihfft`
@@ -332,6 +359,9 @@ def ihfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
         scaling = 1.0/numpy.sqrt(n)
     else:
         scaling = 1.0/n
+
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
 
     return scaling * rfft(a, n, axis, None, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous).conj()

--- a/pyfftw/interfaces/scipy_fftpack.py
+++ b/pyfftw/interfaces/scipy_fftpack.py
@@ -57,6 +57,8 @@ a 2D `shape` argument will return without exception whereas
 '''
 
 from . import numpy_fft
+
+from ..builders._utils import _default_effort, _default_threads
 import numpy
 
 # Complete the namespace (these are not actually used in this module)
@@ -83,7 +85,7 @@ except ImportError:
 
 
 def fft(x, n=None, axis=-1, overwrite_x=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D FFT.
 
@@ -91,11 +93,13 @@ def fft(x, n=None, axis=-1, overwrite_x=False,
     the rest of the arguments are documented
     in the :ref:`additional argument docs<interfaces_additional_args>`.
     '''
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
     return numpy_fft.fft(x, n, axis, None, overwrite_x, planner_effort,
             threads, auto_align_input, auto_contiguous)
 
 def ifft(x, n=None, axis=-1, overwrite_x=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D inverse FFT.
 
@@ -103,13 +107,14 @@ def ifft(x, n=None, axis=-1, overwrite_x=False,
     the rest of the arguments are documented
     in the :ref:`additional argument docs<interfaces_additional_args>`.
     '''
-
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
     return numpy_fft.ifft(x, n, axis, None, overwrite_x,
             planner_effort, threads, auto_align_input, auto_contiguous)
 
 
 def fft2(x, shape=None, axes=(-2,-1), overwrite_x=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 2D FFT.
 
@@ -117,13 +122,14 @@ def fft2(x, shape=None, axes=(-2,-1), overwrite_x=False,
     the rest of the arguments are documented
     in the :ref:`additional argument docs<interfaces_additional_args>`.
     '''
-
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
     return numpy_fft.fft2(x, shape, axes, None, overwrite_x,
             planner_effort, threads, auto_align_input, auto_contiguous)
 
 
 def ifft2(x, shape=None, axes=(-2,-1), overwrite_x=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 2D inverse FFT.
 
@@ -131,13 +137,14 @@ def ifft2(x, shape=None, axes=(-2,-1), overwrite_x=False,
     the rest of the arguments are documented in the
     :ref:`additional argument docs <interfaces_additional_args>`.
     '''
-
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
     return numpy_fft.ifft2(x, shape, axes, None, overwrite_x,
             planner_effort, threads, auto_align_input, auto_contiguous)
 
 
 def fftn(x, shape=None, axes=None, overwrite_x=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
     '''Perform an n-D FFT.
 
@@ -155,13 +162,14 @@ def fftn(x, shape=None, axes=None, overwrite_x=False,
                     'not the same as x.ndim if axes is None or the length '
                     'of axes if it is not. If this is problematic, consider '
                     'using the numpy interface.')
-
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
     return numpy_fft.fftn(x, shape, axes, None, overwrite_x,
             planner_effort, threads, auto_align_input, auto_contiguous)
 
 
 def ifftn(x, shape=None, axes=None, overwrite_x=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
     '''Perform an n-D inverse FFT.
 
@@ -169,7 +177,8 @@ def ifftn(x, shape=None, axes=None, overwrite_x=False,
     the rest of the arguments are documented
     in the :ref:`additional argument docs<interfaces_additional_args>`.
     '''
-
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
     if shape is not None:
         if ((axes is not None and len(shape) != len(axes)) or
                 (axes is None and len(shape) != x.ndim)):
@@ -254,7 +263,7 @@ def _irfft_input_to_complex(irfft_input, axis):
 
 
 def rfft(x, n=None, axis=-1, overwrite_x=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D real FFT.
 
@@ -267,6 +276,8 @@ def rfft(x, n=None, axis=-1, overwrite_x=False,
                 'compatibility with scipy.fftpack.rfft.')
 
     x = numpy.asanyarray(x)
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
 
     complex_output = numpy_fft.rfft(x, n, axis, None, overwrite_x,
             planner_effort, threads, auto_align_input, auto_contiguous)
@@ -278,7 +289,7 @@ def rfft(x, n=None, axis=-1, overwrite_x=False,
     return _complex_to_rfft_output(complex_output, output_shape, axis)
 
 def irfft(x, n=None, axis=-1, overwrite_x=False,
-        planner_effort='FFTW_ESTIMATE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D real inverse FFT.
 
@@ -291,6 +302,8 @@ def irfft(x, n=None, axis=-1, overwrite_x=False,
                 'compatibility with scipy.fftpack.irfft.')
 
     x = numpy.asanyarray(x)
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
 
     if n is None:
         n = x.shape[axis]

--- a/pyfftw/pyfftw.pyx
+++ b/pyfftw/pyfftw.pyx
@@ -80,6 +80,13 @@ IF HAVE_LONG:
     _supported_nptypes_complex.append(np.clongdouble)
     _supported_nptypes_real.append(np.longdouble)
 
+IF (HAVE_SINGLE_OMP or HAVE_DOUBLE_OMP or HAVE_LONG_OMP):
+    _threading_type = 'OMP'
+ELIF (HAVE_SINGLE_THREADS or HAVE_DOUBLE_THREADS or HAVE_LONG_THREADS):
+    _threading_type = 'PTHREADS'
+ELSE:
+    _threading_type = None
+
 cdef object directions
 directions = {'FFTW_FORWARD': FFTW_FORWARD,
         'FFTW_BACKWARD': FFTW_BACKWARD}

--- a/test/test_pyfftw_config.py
+++ b/test/test_pyfftw_config.py
@@ -37,7 +37,7 @@ class ConfigTest(unittest.TestCase):
         os.environ.pop('OMP_NUM_THREADS', None)
         os.environ.pop('PYFFTW_PLANNER_EFFORT', None)
         # defaults to single-threaded and FFTW_ESTIMATE
-        config.reload_config()
+        config._reload_config()
         assert_equal(config.NUM_THREADS, 1)
         assert_equal(config.PLANNER_EFFORT, 'FFTW_ESTIMATE')
 
@@ -48,17 +48,17 @@ class ConfigTest(unittest.TestCase):
         os.environ.pop('OMP_NUM_THREADS', None)
 
         # defaults to single-threaded if neither variable is defined
-        config.reload_config()
+        config._reload_config()
         assert_equal(config.NUM_THREADS, 1)
 
         # load default from OMP_NUM_THREADS environment variable
         os.environ['OMP_NUM_THREADS'] = '2'
-        config.reload_config()
+        config._reload_config()
         assert_equal(config.NUM_THREADS, 2)
 
         # PYFFTW_NUM_THREADS overrides OMP_NUM_THREADS when both are defined
         os.environ['PYFFTW_NUM_THREADS'] = '4'
-        config.reload_config()
+        config._reload_config()
         assert_equal(config.NUM_THREADS, 4)
 
     def test_non_default_config(self):
@@ -69,7 +69,7 @@ class ConfigTest(unittest.TestCase):
             os.environ['PYFFTW_NUM_THREADS'] = '4'
         os.environ['PYFFTW_PLANNER_EFFORT'] = 'FFTW_MEASURE'
 
-        config.reload_config()
+        config._reload_config()
         assert_equal(config.NUM_THREADS, 4)
         assert_equal(config.PLANNER_EFFORT, 'FFTW_MEASURE')
 
@@ -77,8 +77,8 @@ class ConfigTest(unittest.TestCase):
         config.NUM_THREADS = 6
         config.PLANNER_EFFORT = 'FFTW_ESTIMATE'
 
-        # reload_config should preserve the user-defined values
-        config.reload_config()
+        # _reload_config preserves the user-defined values
+        config._reload_config()
         assert_equal(config.NUM_THREADS, 6)
         assert_equal(config.PLANNER_EFFORT, 'FFTW_ESTIMATE')
 

--- a/test/test_pyfftw_config.py
+++ b/test/test_pyfftw_config.py
@@ -1,0 +1,97 @@
+
+from pyfftw import config, _threading_type
+
+
+from .test_pyfftw_base import run_test_suites
+
+import unittest
+import os
+from numpy.testing import assert_equal
+
+
+class ConfigTest(unittest.TestCase):
+
+    env_keys = ['PYFFTW_NUM_THREADS', 'OMP_NUM_THREADS',
+                'PYFFTW_PLANNER_EFFORT']
+    orig_env = {}
+
+    def setUp(self):
+        # store environment variables prior to testing
+        for key in self.env_keys:
+            self.orig_env[key] = os.environ.get(key, None)
+        return
+
+    def tearDown(self):
+        # resstore original environment variables values
+        for key in self.env_keys:
+            val = self.orig_env[key]
+            if val is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = val
+        return
+
+    def test_default_config(self):
+        # unset environment variables if they were defined
+        os.environ.pop('PYFFTW_NUM_THREADS', None)
+        os.environ.pop('OMP_NUM_THREADS', None)
+        os.environ.pop('PYFFTW_PLANNER_EFFORT', None)
+        # defaults to single-threaded and FFTW_ESTIMATE
+        config.reload_config()
+        assert_equal(config.NUM_THREADS, 1)
+        assert_equal(config.PLANNER_EFFORT, 'FFTW_ESTIMATE')
+
+    @unittest.skipIf(_threading_type != 'OMP', reason='non-OpenMP build')
+    def test_default_threads_OpenMP(self):
+        # unset environment variables if they were defined
+        os.environ.pop('PYFFTW_NUM_THREADS', None)
+        os.environ.pop('OMP_NUM_THREADS', None)
+
+        # defaults to single-threaded if neither variable is defined
+        config.reload_config()
+        assert_equal(config.NUM_THREADS, 1)
+
+        # load default from OMP_NUM_THREADS environment variable
+        os.environ['OMP_NUM_THREADS'] = '2'
+        config.reload_config()
+        assert_equal(config.NUM_THREADS, 2)
+
+        # PYFFTW_NUM_THREADS overrides OMP_NUM_THREADS when both are defined
+        os.environ['PYFFTW_NUM_THREADS'] = '4'
+        config.reload_config()
+        assert_equal(config.NUM_THREADS, 4)
+
+    def test_non_default_config(self):
+        # set environment variables to non-default values
+        if _threading_type is None:
+            os.environ['PYFFTW_NUM_THREADS'] = '1'
+        else:
+            os.environ['PYFFTW_NUM_THREADS'] = '4'
+        os.environ['PYFFTW_PLANNER_EFFORT'] = 'FFTW_MEASURE'
+
+        config.reload_config()
+        assert_equal(config.NUM_THREADS, 4)
+        assert_equal(config.PLANNER_EFFORT, 'FFTW_MEASURE')
+
+        # set values to something else
+        config.NUM_THREADS = 6
+        config.PLANNER_EFFORT = 'FFTW_ESTIMATE'
+
+        # reload_config should preserve the user-defined values
+        config.reload_config()
+        assert_equal(config.NUM_THREADS, 6)
+        assert_equal(config.PLANNER_EFFORT, 'FFTW_ESTIMATE')
+
+        # can reset back to the values from the environment variables
+        config._env_reloader.reset()
+        assert_equal(config.NUM_THREADS, 4)
+        assert_equal(config.PLANNER_EFFORT, 'FFTW_MEASURE')
+
+
+test_cases = (ConfigTest, )
+
+test_set = None
+
+if __name__ == '__main__':
+
+    run_test_suites(test_cases, test_set)


### PR DESCRIPTION
This PR supersedes #208 (I think it is a better solution as it allows setting these at run-time as well). I am not sure why #208 was closed last time around, but I think some ability to configure the number of threads (and planner) used by the builders and interfaces is important.

Currently the interfaces and planners default to a single thread. This makes it a pain to monkey-patch numpy or scipy with multi-threading enabled (as discussed in #205).

With the solution in this PR, defaults for the number of threads are read at import time from `PYFFTW_NUM_THREADS` if it is defined (or if OpenMP-based threading is being used there is a fallback to `OMP_NUM_THREADS` when `PYFFTW_NUM_THREADS` is undefined). If neither environment variable is defined, the current default of 1 thread is used.

Similarly the environment variable `PYFFTW_PLANNER_EFFORT` can be used to select a different default planner effort. If it is undefined, the current default of `PYFFTW_ESTIMATE` is used.

Unlike in #208, the user can also modify these at runtime as follows:
```
from pyfftw import config

config.NUM_THREADS = 8
config.PLANNER_EFFORT = 'FFTW_MEASURE'
```
Subsequent calls to the builders or interfaces will then use these values instead. 

The implementation in `config.py` is a simplified version of Numba's config.py (their version also allows checking against a .yaml configuration file, etc., but I didn't think that was necessary in this case).

Please let me know if this implementation looks acceptable and I will add a commit to update the documentation.

**TODO:**
- [x] add documentation