### PR TITLE
update test suite avoid mkl_fft when it is present

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,7 +56,7 @@ environment:
           NP_BUILD_DEP: "1.14"
           SP_BUILD_DEP: "1.1"
           CYTHON_BUILD_DEP: "0.28"
-          EXTRA_CONDA_ARGS: "-c conda-forge blas=*=openblas"  # needed for non-MKL numpy/scipy
+          # EXTRA_CONDA_ARGS: "-c conda-forge blas=*=openblas"  # needed for non-MKL numpy/scipy
 
 install:
     # Get and configure the FFTW libs

--- a/test/test_pyfftw_base.py
+++ b/test/test_pyfftw_base.py
@@ -39,6 +39,13 @@ from timeit import Timer
 
 import unittest
 
+try:
+    import mkl_fft
+    # mkl_fft monkeypatches numpy.fft so explicitly import from fftpack instead
+    from numpy.fft import fftpack as np_fft
+except ImportError:
+    from numpy import fft as np_fft
+
 def miss(*xs):
     '''Skip test if the precisions in the iterable `xs` are not available.'''
     msg = 'Requires %s' % _all_types_human_readable[xs[0]]
@@ -56,7 +63,7 @@ def require(self, *xs):
 class FFTWBaseTest(unittest.TestCase):
 
     def reference_fftn(self, a, axes):
-        return numpy.fft.fftn(a, axes=axes)
+        return np_fft.fftn(a, axes=axes)
 
     def __init__(self, *args, **kwargs):
 
@@ -72,7 +79,7 @@ class FFTWBaseTest(unittest.TestCase):
 
         self.input_dtype = numpy.complex64
         self.output_dtype = numpy.complex64
-        self.np_fft_comparison = numpy.fft.fft
+        self.np_fft_comparison = np_fft.fft
 
         self.direction = 'FFTW_FORWARD'
         return

--- a/test/test_pyfftw_complex.py
+++ b/test/test_pyfftw_complex.py
@@ -41,7 +41,8 @@ import time
 
 import unittest
 
-from .test_pyfftw_base import FFTWBaseTest, run_test_suites, miss
+from .test_pyfftw_base import FFTWBaseTest, run_test_suites, miss, np_fft
+
 
 # We make this 1D case not inherit from FFTWBaseTest.
 # It needs to be combined with FFTWBaseTest to work.
@@ -741,7 +742,7 @@ class Complex128FFTWTest(Complex64FFTWTest):
     def setUp(self):
         self.input_dtype = numpy.complex128
         self.output_dtype = numpy.complex128
-        self.np_fft_comparison = numpy.fft.fft
+        self.np_fft_comparison = np_fft.fft
 
         self.direction = 'FFTW_FORWARD'
         return
@@ -763,7 +764,7 @@ class ComplexLongDoubleFFTWTest(Complex64FFTWTest):
         # numpy.fft.fftn doesn't support complex256 type,
         # so we need to compare to a lower precision type.
         a = numpy.complex128(a)
-        return numpy.fft.fftn(a, axes=axes)
+        return np_fft.fftn(a, axes=axes)
 
     @unittest.skip('numpy.fft has issues with this dtype.')
     def test_time(self):

--- a/test/test_pyfftw_dask_interface.py
+++ b/test/test_pyfftw_dask_interface.py
@@ -39,6 +39,13 @@ try:
 except AttributeError:
     interfaces.dask_fft = None
 
+try:
+    # Kludge to skip dask tests when mkl_fft is present
+    import mkl_fft
+    interfaces.dask_fft = None
+except ImportError:
+    pass
+
 from .test_pyfftw_base import run_test_suites
 from .test_pyfftw_numpy_interface import complex_dtypes, real_dtypes
 from ._get_default_args import get_default_args

--- a/test/test_pyfftw_multithreaded.py
+++ b/test/test_pyfftw_multithreaded.py
@@ -36,7 +36,7 @@ from pyfftw import FFTW
 import numpy
 from timeit import Timer
 
-from .test_pyfftw_base import run_test_suites, miss
+from .test_pyfftw_base import run_test_suites, miss, np_fft
 
 import unittest
 
@@ -79,7 +79,7 @@ class Complex128MultiThreadedTest(Complex64MultiThreadedTest):
 
         self.input_dtype = numpy.complex128
         self.output_dtype = numpy.complex128
-        self.np_fft_comparison = numpy.fft.fft
+        self.np_fft_comparison = np_fft.fft
         return
 
 @unittest.skipIf(*miss('ld'))
@@ -97,7 +97,7 @@ class ComplexLongDoubleMultiThreadedTest(Complex64MultiThreadedTest):
         # numpy.fft.fftn doesn't support complex256 type,
         # so we need to compare to a lower precision type.
         a = numpy.complex128(a)
-        return numpy.fft.fftn(a, axes=axes)
+        return np_fft.fftn(a, axes=axes)
 
 test_cases = (
         Complex64MultiThreadedTest,

--- a/test/test_pyfftw_numpy_interface.py
+++ b/test/test_pyfftw_numpy_interface.py
@@ -34,18 +34,12 @@
 
 from pyfftw import interfaces, _supported_types, _all_types_np
 
-from .test_pyfftw_base import run_test_suites
+from .test_pyfftw_base import run_test_suites, np_fft
 from ._get_default_args import get_default_args
 
 from distutils.version import LooseVersion
 import unittest
 import numpy
-try:
-    import mkl_fft
-    # mkl_fft monkeypatches numpy.fft so explicitly import from fftpack instead
-    from numpy.fft import fftpack as np_fft
-except ImportError:
-    from numpy import fft as np_fft
 import warnings
 import copy
 warnings.filterwarnings('always')

--- a/test/test_pyfftw_numpy_interface.py
+++ b/test/test_pyfftw_numpy_interface.py
@@ -40,7 +40,12 @@ from ._get_default_args import get_default_args
 from distutils.version import LooseVersion
 import unittest
 import numpy
-from numpy import fft as np_fft
+try:
+    import mkl_fft
+    # mkl_fft monkeypatches numpy.fft so explicitly import from fftpack instead
+    from numpy.fft import fftpack as np_fft
+except ImportError:
+    from numpy import fft as np_fft
 import warnings
 import copy
 warnings.filterwarnings('always')

--- a/test/test_pyfftw_real_backward.py
+++ b/test/test_pyfftw_real_backward.py
@@ -38,7 +38,7 @@ import numpy
 from timeit import Timer
 import time
 
-from .test_pyfftw_base import run_test_suites, miss, require
+from .test_pyfftw_base import run_test_suites, miss, require, np_fft
 
 import unittest
 
@@ -51,7 +51,7 @@ class RealBackwardDoubleFFTWTest(Complex64FFTWTest):
 
         self.input_dtype = numpy.complex128
         self.output_dtype = numpy.float64
-        self.np_fft_comparison = numpy.fft.irfft
+        self.np_fft_comparison = np_fft.irfft
 
         self.direction = 'FFTW_BACKWARD'
 
@@ -200,7 +200,7 @@ class RealBackwardDoubleFFTWTest(Complex64FFTWTest):
 
     def reference_fftn(self, a, axes):
         # This needs to be an inverse
-        return numpy.fft.irfftn(a, axes=axes)
+        return np_fft.irfftn(a, axes=axes)
 
     def test_wrong_direction_fail(self):
         in_shape = self.input_shapes['2d']
@@ -314,7 +314,7 @@ class RealBackwardSingleFFTWTest(RealBackwardDoubleFFTWTest):
 
         self.input_dtype = numpy.complex64
         self.output_dtype = numpy.float32
-        self.np_fft_comparison = numpy.fft.irfft
+        self.np_fft_comparison = np_fft.irfft
 
         self.direction = 'FFTW_BACKWARD'
 
@@ -325,14 +325,14 @@ class RealBackwardLongDoubleFFTWTest(RealBackwardDoubleFFTWTest):
 
         self.input_dtype = numpy.clongdouble
         self.output_dtype = numpy.longdouble
-        self.np_fft_comparison = numpy.fft.irfft
+        self.np_fft_comparison = np_fft.irfft
 
         self.direction = 'FFTW_BACKWARD'
 
     def reference_fftn(self, a, axes):
 
         a = numpy.complex128(a)
-        return numpy.fft.irfftn(a, axes=axes)
+        return np_fft.irfftn(a, axes=axes)
 
     @unittest.skip('numpy.fft has issues with this dtype.')
     def test_time(self):

--- a/test/test_pyfftw_real_forward.py
+++ b/test/test_pyfftw_real_forward.py
@@ -36,7 +36,7 @@ from pyfftw import FFTW
 import numpy
 from timeit import Timer
 
-from .test_pyfftw_base import run_test_suites, miss, require
+from .test_pyfftw_base import run_test_suites, miss, require, np_fft
 
 import unittest
 
@@ -49,7 +49,7 @@ class RealForwardDoubleFFTWTest(Complex64FFTWTest):
 
         self.input_dtype = numpy.float64
         self.output_dtype = numpy.complex128
-        self.np_fft_comparison = numpy.fft.rfft
+        self.np_fft_comparison = np_fft.rfft
 
         self.direction = 'FFTW_FORWARD'
 
@@ -76,7 +76,7 @@ class RealForwardDoubleFFTWTest(Complex64FFTWTest):
 
     def reference_fftn(self, a, axes):
 
-        return numpy.fft.rfftn(a, axes=axes)
+        return np_fft.rfftn(a, axes=axes)
 
     def test_wrong_direction_fail(self):
         in_shape = self.input_shapes['2d']
@@ -122,7 +122,7 @@ class RealForwardSingleFFTWTest(RealForwardDoubleFFTWTest):
 
         self.input_dtype = numpy.float32
         self.output_dtype = numpy.complex64
-        self.np_fft_comparison = numpy.fft.rfft
+        self.np_fft_comparison = np_fft.rfft
 
         self.direction = 'FFTW_FORWARD'
 
@@ -133,7 +133,7 @@ class RealForwardLongDoubleFFTWTest(RealForwardDoubleFFTWTest):
 
         self.input_dtype = numpy.longdouble
         self.output_dtype = numpy.clongdouble
-        self.np_fft_comparison = numpy.fft.rfft
+        self.np_fft_comparison = np_fft.rfft
 
         self.direction = 'FFTW_FORWARD'
 
@@ -148,7 +148,7 @@ class RealForwardLongDoubleFFTWTest(RealForwardDoubleFFTWTest):
     def reference_fftn(self, a, axes):
 
         a = numpy.float64(a)
-        return numpy.fft.rfftn(a, axes=axes)
+        return np_fft.rfftn(a, axes=axes)
 
 test_cases = (
         RealForwardDoubleFFTWTest,


### PR DESCRIPTION
seeing if this workaround gets the tests to pass with Numpy + mkl_fft. These were previously failing on Appveyor. 
In the past we tried to force OpenBLAS-based numpy on AppVeyor, but there seems to be a lack of Scipy + OpenBLAS packages on conda defaults and conda-forge. I'm not sure how it previously worked, but no longer does. Here I try a different strategy of using functions from within numpy.fft.fftpack instead of numpy.fft, hoping that this will avoid use of mkl_fft when it is present.
