### PR TITLE
prevent absolute path from ending up in the egg-info SOURCES.txt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -558,7 +558,7 @@ def make_sniffer(compiler):
 
 def get_extensions():
     ext_modules = [Extension('pyfftw.pyfftw',
-                             sources=[os.path.join(os.getcwd(), 'pyfftw', 'pyfftw.pyx')])]
+                             sources=[os.path.join('pyfftw', 'pyfftw.pyx')])]
     return ext_modules
 
 


### PR DESCRIPTION
This resolves #249 (at least once we push a new source .tar.gz) to PyPI. I don't think we can remove the existing one, though? If not, we may have to tag a 0.11.1 release