### PR TITLE
remove pypi deployment in favor of pyFFTW-wheels

### DIFF
--- a/appveyor/deploy.ps1
+++ b/appveyor/deploy.ps1
@@ -20,16 +20,7 @@ function deploy_to_bintray() {
     iex "curl.exe -s -T $filepath -u$username_password -H `"X-Bintray-Package:PyFFTW-development-builds`" -H `"X-Bintray-Version:$short_version`" -H `"X-Bintray-Publish: 1`" -H `"X-Bintray-Override: 1`" https://api.bintray.com/content/hgomersall/generic/$filename"
 }
 
-function deploy_to_pypi () {
-    Write-Host "Uploading to PyPI..."
-    iex "python setup.py bdist_wheel upload"
-}
-
 function main () {
-    if($env:appveyor_repo_tag -eq 'True') {
-        deploy_to_pypi
-    }
-
     deploy_to_bintray
 }
 


### PR DESCRIPTION
removes PyPI deployment from `appveyor/deploy.ps1`. This failed to work during the 0.11.0 release and we can soon upload wheels generated from pyFFTW-wheels instead (see pyFFTW/pyFFTW-wheels#24).