### PR TITLE
Document 2-D and N-D Dask FFT interface functions

### DIFF
--- a/docs/source/pyfftw/interfaces/dask_fft.rst
+++ b/docs/source/pyfftw/interfaces/dask_fft.rst
@@ -2,4 +2,4 @@
 ==========================
 
 .. automodule:: pyfftw.interfaces.dask_fft
-   :members: fft, ifft, rfft, irfft, hfft, ihfft
+   :members: fft, ifft, fft2, ifft2, fftn, ifftn, rfft, irfft, rfft2, irfft2, rfftn, irfftn, hfft, ihfft


### PR DESCRIPTION
These functions have already been here for a little bit, but were missing from the API documentation. This adds them there.