### PR TITLE
Update Dask FFT listing in FFT interface overview

### DIFF
--- a/pyfftw/interfaces/__init__.py
+++ b/pyfftw/interfaces/__init__.py
@@ -134,8 +134,16 @@ being taken along that axes as many times as the axis occurs.
 
 * :func:`pyfftw.interfaces.dask_fft.fft`
 * :func:`pyfftw.interfaces.dask_fft.ifft`
+* :func:`pyfftw.interfaces.dask_fft.fft2`
+* :func:`pyfftw.interfaces.dask_fft.ifft2`
+* :func:`pyfftw.interfaces.dask_fft.fftn`
+* :func:`pyfftw.interfaces.dask_fft.ifftn`
 * :func:`pyfftw.interfaces.dask_fft.rfft`
 * :func:`pyfftw.interfaces.dask_fft.irfft`
+* :func:`pyfftw.interfaces.dask_fft.rfft2`
+* :func:`pyfftw.interfaces.dask_fft.irfft2`
+* :func:`pyfftw.interfaces.dask_fft.rfftn`
+* :func:`pyfftw.interfaces.dask_fft.irfftn`
 * :func:`pyfftw.interfaces.dask_fft.hfft`
 * :func:`pyfftw.interfaces.dask_fft.ihfft`
 


### PR DESCRIPTION
On the interface overview page, FFT interfaces for NumPy, SciPy, and Dask are listed. The Dask listing on this page was missing the 2-D and N-D functions that have been added since. This updates the listing on the overview page to include these 2-D and N-D Dask FFT interface functions.