### PR TITLE
Real-to-real transforms (version 3)

### DIFF
--- a/docs/source/pyfftw/interfaces/scipy_fftpack.rst
+++ b/docs/source/pyfftw/interfaces/scipy_fftpack.rst
@@ -2,4 +2,4 @@
 ==============================
 
 .. automodule:: pyfftw.interfaces.scipy_fftpack
-   :members: fft, ifft, fftn, ifftn, rfft, irfft, fft2, ifft2, next_fast_len
+   :members: fft, ifft, fftn, ifftn, rfft, irfft, fft2, ifft2, dct, idct, dst, idst, dctn, idctn, dstn, idstn, next_fast_len

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -245,6 +245,21 @@ Similarly, to plan the inverse:
 In this case, the direction argument is given as ``'FFTW_BACKWARD'``
 (to override the default of ``'FFTW_FORWARD'``).
 
+:class:`pyfftw.FFTW` also supports all of the discrete sine and cosine
+transformations (also called *real to real transformations*) implemented by
+FFTW: for example
+
+.. testcode::
+
+   d = pyfftw.empty_aligned(128, dtype='float64')
+   e = pyfftw.empty_aligned(128, dtype='float64')
+
+   dct_transform = pyfftw.FFTW(d, e, direction='FFTW_REDFT00')
+
+creates an instance of :class:`pyfftw.FFTW` which can execute the
+discrete cosine boundary condition with even boundary conditions on
+both ends (also known as the DCT-1).
+
 The actual FFT is performed by calling the returned objects:
 
 .. testcode::

--- a/pyfftw/builders/_utils.py
+++ b/pyfftw/builders/_utils.py
@@ -5,8 +5,6 @@
 #
 # Henry Gomersall
 # heng@kedevelopments.co.uk
-# David Wells
-# drwells <at> vt.edu
 #
 # All rights reserved.
 #
@@ -64,8 +62,9 @@ __all__ = ['_FFTWWrapper', '_rc_dtype_pairs', '_default_dtype', '_Xfftn',
 _valid_efforts = ('FFTW_ESTIMATE', 'FFTW_MEASURE',
         'FFTW_PATIENT', 'FFTW_EXHAUSTIVE')
 
-# Looking up a real dtype in here returns the complex complement of the same
-# precision, and vice versa.
+_real_to_real_dtypes = [numpy.dtype('float32'), numpy.dtype('float64'),
+                        numpy.dtype('longdouble')]
+
 # It is necessary to use .char as the keys due to MSVC mapping long
 # double to double and the way that numpy handles this.
 _rc_dtype_pairs = {}
@@ -136,18 +135,31 @@ def _norm_args(norm):
 
 
 def _Xfftn(a, s, axes, overwrite_input,
-        planner_effort, threads, auto_align_input, auto_contiguous,
-        avoid_copy, inverse, real, normalise_idft=True, ortho=False):
+           planner_effort, threads, auto_align_input, auto_contiguous,
+           avoid_copy, inverse, real, normalise_idft=True, ortho=False,
+           real_direction_flag=None):
     '''Generic transform interface for all the transforms. No
     defaults exist. The transform must be specified exactly.
+
+    The argument ``real_direction_flag`` is a slight exception to this
+    rule: for backwards compatibility this function defaults to standard
+    Fourier transforms (and not the specialized real to real variants).
+    If this flag is set to one of the standard real transform types
+    (e.g., 'FFTW_RODFT00') then the arguments ``inverse`` and ``real``
+    are ignored.
     '''
     a_orig = a
     invreal = inverse and real
 
-    if inverse:
+    if real_direction_flag is not None:
+        direction = real_direction_flag
+        real_to_real = True
+    elif inverse:
         direction = 'FFTW_BACKWARD'
+        real_to_real = False
     else:
         direction = 'FFTW_FORWARD'
+        real_to_real = False
 
     if planner_effort not in _valid_efforts:
         raise ValueError('Invalid planner effort: ', planner_effort)
@@ -160,32 +172,35 @@ def _Xfftn(a, s, axes, overwrite_input,
     a_is_complex = numpy.iscomplexobj(a)
 
     # Make the input dtype correct by transforming to an available type
-    if a.dtype.char not in _rc_dtype_pairs:
-        dtype = _default_dtype
-        if a.dtype == numpy.dtype('float16') and '32' in pyfftw._supported_types:
-            # convert half-precision to single precision, if available
-            dtype = numpy.dtype('float32')
+    if a.dtype not in _real_to_real_dtypes:
+        a = numpy.asarray(a, dtype=_default_dtype)
+    else:
+        if a.dtype.char not in _rc_dtype_pairs:
+            dtype = _default_dtype
+            if a.dtype == numpy.dtype('float16') and '32' in pyfftw._supported_types:
+                # convert half-precision to single precision, if available
+                dtype = numpy.dtype('float32')
 
-        # warn when losing precision but not when using a higher precision
-        if dtype.itemsize < a.dtype.itemsize:
-            warnings.warn("Narrowing conversion from %s to %s precision" % (a.dtype, dtype))
+            # warn when losing precision but not when using a higher precision
+            if dtype.itemsize < a.dtype.itemsize:
+                warnings.warn("Narrowing conversion from %s to %s precision" % (a.dtype, dtype))
 
-        if not real or inverse:
-            # It's going to be complex
-            dtype = numpy.dtype(_rc_dtype_pairs[dtype.char])
+            if not real or inverse:
+                # It's going to be complex
+                dtype = numpy.dtype(_rc_dtype_pairs[dtype.char])
 
-        # finally convert the input array
-        a = numpy.asarray(a, dtype=dtype)
-    elif not (real and not inverse) and not a_is_complex:
-        # We need to make it a complex dtype
-        a = numpy.asarray(a, dtype=_rc_dtype_pairs[a.dtype.char])
+            # finally convert the input array
+            a = numpy.asarray(a, dtype=dtype)
+        elif not (real and not inverse) and not a_is_complex:
+            # We need to make it a complex dtype
+            a = numpy.asarray(a, dtype=_rc_dtype_pairs[a.dtype.char])
 
-    elif (real and not inverse) and a_is_complex:
-        # It should be real
-        a = numpy.asarray(a, dtype=_rc_dtype_pairs[a.dtype.char])
+        elif (real and not inverse) and a_is_complex:
+            # It should be real
+            a = numpy.asarray(a, dtype=_rc_dtype_pairs[a.dtype.char])
 
     # Make the output dtype correct
-    if not real:
+    if not real: # 'real' implies c2r or r2c; hence 'not real' means r2r or c2c.
         output_dtype = a.dtype
 
     else:

--- a/pyfftw/builders/_utils.py
+++ b/pyfftw/builders/_utils.py
@@ -65,6 +65,9 @@ _valid_efforts = ('FFTW_ESTIMATE', 'FFTW_MEASURE',
 _real_to_real_dtypes = [numpy.dtype('float32'), numpy.dtype('float64'),
                         numpy.dtype('longdouble')]
 
+# Looking up a real dtype in here returns the complex complement of the same
+# precision, and vice versa.
+
 # It is necessary to use .char as the keys due to MSVC mapping long
 # double to double and the way that numpy handles this.
 _rc_dtype_pairs = {}
@@ -172,8 +175,9 @@ def _Xfftn(a, s, axes, overwrite_input,
     a_is_complex = numpy.iscomplexobj(a)
 
     # Make the input dtype correct by transforming to an available type
-    if a.dtype not in _real_to_real_dtypes:
-        a = numpy.asarray(a, dtype=_default_dtype)
+    if real_to_real:
+        if a.dtype not in _real_to_real_dtypes:
+            a = numpy.asarray(a, dtype=_default_dtype)
     else:
         if a.dtype.char not in _rc_dtype_pairs:
             dtype = _default_dtype

--- a/pyfftw/builders/builders.py
+++ b/pyfftw/builders/builders.py
@@ -549,7 +549,7 @@ def irfftn(a, s=None, axes=None,
 
 
 def dct(a, n=None, axis=-1, overwrite_input=False,
-        planner_effort='FFTW_MEASURE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, type=2):
     '''Return a :class:`pyfftw.FFTW` object representing a 1D DCT.
@@ -575,13 +575,16 @@ def dct(a, n=None, axis=-1, overwrite_input=False,
     inverse = False
     real = False
 
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
+
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
-            threads, auto_align_input, auto_contiguous,
+                  threads, auto_align_input, auto_contiguous,
                   avoid_copy, inverse, real, real_direction_flag=direction)
 
 
 def dst(a, n=None, axis=-1, overwrite_input=False,
-        planner_effort='FFTW_MEASURE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, type=2):
     '''Return a :class:`pyfftw.FFTW` object representing a 1D DST.
@@ -607,6 +610,9 @@ def dst(a, n=None, axis=-1, overwrite_input=False,
     inverse = False
     real = False
 
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
+
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
-            threads, auto_align_input, auto_contiguous,
+                  threads, auto_align_input, auto_contiguous,
                   avoid_copy, inverse, real, real_direction_flag=direction)

--- a/pyfftw/builders/builders.py
+++ b/pyfftw/builders/builders.py
@@ -569,7 +569,7 @@ def dct(a, n=None, axis=-1, overwrite_input=False,
     if isinstance(type, str):
         direction = type
     else:
-        direction = _dct_types[int(type) - 1]
+        direction = dct_types[int(type) - 1]
 
     s, axes = _precook_1d_args(a, n, axis)
     inverse = False
@@ -601,7 +601,7 @@ def dst(a, n=None, axis=-1, overwrite_input=False,
     if isinstance(type, str):
         direction = type
     else:
-        direction = _dct_types[int(type) - 1]
+        direction = dct_types[int(type) - 1]
 
     s, axes = _precook_1d_args(a, n, axis)
     inverse = False

--- a/pyfftw/builders/builders.py
+++ b/pyfftw/builders/builders.py
@@ -5,8 +5,6 @@
 #
 # Henry Gomersall
 # heng@kedevelopments.co.uk
-# David Wells
-# drwells <at> vt.edu
 #
 # All rights reserved.
 #
@@ -119,7 +117,8 @@ Supported Functions and Caveats
 
 The following functions are supported. They can be used with the
 same calling signature as their respective functions in
-:mod:`numpy.fft`.
+:mod:`numpy.fft` or (in the case of real-to-real transforms)
+:mod:`scipy.fftpack`.
 
 **Standard FFTs**
 
@@ -138,6 +137,11 @@ same calling signature as their respective functions in
 * :func:`~pyfftw.builders.irfft2`
 * :func:`~pyfftw.builders.rfftn`
 * :func:`~pyfftw.builders.irfftn`
+
+**DCTs and DSTs**
+
+* :func:`~pyfftw.builders.dct`
+* :func:`~pyfftw.builders.dst`
 
 The first caveat is that the dtype of the input array must match the
 transform. For example, for ``fft`` and ``ifft``, the dtype must
@@ -268,8 +272,7 @@ from ._utils import (_precook_1d_args, _Xfftn, _norm_args, _default_effort,
 
 __all__ = ['fft','ifft', 'fft2', 'ifft2', 'fftn',
            'ifftn', 'rfft', 'irfft', 'rfft2', 'irfft2', 'rfftn',
-           'irfftn']
-
+           'irfftn', 'dct', 'dst']
 
 def fft(a, n=None, axis=-1, overwrite_input=False,
         planner_effort=None, threads=None,
@@ -543,3 +546,67 @@ def irfftn(a, s=None, axes=None,
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
             threads, auto_align_input, auto_contiguous,
             avoid_copy, inverse, real, **_norm_args(norm))
+
+
+def dct(a, n=None, axis=-1, overwrite_input=False,
+        planner_effort='FFTW_MEASURE', threads=1,
+        auto_align_input=True, auto_contiguous=True,
+        avoid_copy=False, type=2):
+    '''Return a :class:`pyfftw.FFTW` object representing a 1D DCT.
+
+    The first three arguments and 'type' are as per
+    :func:`scipy.fftpack.dct`; the rest of the arguments are documented
+    :ref:`in the module docs <builders_args>`.
+    '''
+    dct_types = ['FFTW_REDFT00', 'FFTW_REDFT10', 'FFTW_REDFT01',
+                 'FFTW_REDFT11', 1, 2, 3, 4]
+    if type not in dct_types:
+        raise ValueError("Unrecognised DCT type {}".format(type))
+
+    if n is not None and n != a.shape[axis]:
+        raise NotImplementedError
+
+    if isinstance(type, str):
+        direction = type
+    else:
+        direction = _dct_types[int(type) - 1]
+
+    s, axes = _precook_1d_args(a, n, axis)
+    inverse = False
+    real = False
+
+    return _Xfftn(a, s, axes, overwrite_input, planner_effort,
+            threads, auto_align_input, auto_contiguous,
+                  avoid_copy, inverse, real, real_direction_flag=direction)
+
+
+def dst(a, n=None, axis=-1, overwrite_input=False,
+        planner_effort='FFTW_MEASURE', threads=1,
+        auto_align_input=True, auto_contiguous=True,
+        avoid_copy=False, type=2):
+    '''Return a :class:`pyfftw.FFTW` object representing a 1D DST.
+
+    The first three arguments and 'type' are as per
+    :func:`scipy.fftpack.dst`; the rest of the arguments are documented
+    :ref:`in the module docs <builders_args>`.
+    '''
+    dst_types = ['FFTW_RODFT00', 'FFTW_RODFT10', 'FFTW_RODFT01',
+                 'FFTW_RODFT11', 1, 2, 3, 4]
+    if type not in dst_types:
+        raise ValueError("Unrecognised DST type {}".format(type))
+
+    if n is not None and n != a.shape[axis]:
+        raise NotImplementedError
+
+    if isinstance(type, str):
+        direction = type
+    else:
+        direction = _dct_types[int(type) - 1]
+
+    s, axes = _precook_1d_args(a, n, axis)
+    inverse = False
+    real = False
+
+    return _Xfftn(a, s, axes, overwrite_input, planner_effort,
+            threads, auto_align_input, auto_contiguous,
+                  avoid_copy, inverse, real, real_direction_flag=direction)

--- a/pyfftw/builders/builders.py
+++ b/pyfftw/builders/builders.py
@@ -601,7 +601,7 @@ def dst(a, n=None, axis=-1, overwrite_input=False,
     if isinstance(type, str):
         direction = type
     else:
-        direction = dct_types[int(type) - 1]
+        direction = dst_types[int(type) - 1]
 
     s, axes = _precook_1d_args(a, n, axis)
     inverse = False

--- a/pyfftw/interfaces/_utils.py
+++ b/pyfftw/interfaces/_utils.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 #
 # Copyright 2014 Knowledge Economy Developments Ltd
+# Copyright 2014 David Wells
 #
 # Henry Gomersall
 # heng@kedevelopments.co.uk
@@ -49,7 +50,8 @@ from . import cache
 
 def _Xfftn(a, s, axes, overwrite_input, planner_effort,
         threads, auto_align_input, auto_contiguous,
-        calling_func, normalise_idft=True, ortho=False):
+        calling_func, normalise_idft=True, ortho=False,
+        real_direction_flag=None):
 
     work_with_copy = False
 
@@ -65,7 +67,13 @@ def _Xfftn(a, s, axes, overwrite_input, planner_effort,
     except TypeError:
         pass
 
-    if calling_func in ('irfft2', 'irfftn'):
+    if calling_func in ('dct', 'dst'):
+        # real-to-real transforms require passing an additional flag argument
+        avoid_copy = False
+        args = (a, s, axes, overwrite_input, planner_effort, threads,
+                auto_align_input, auto_contiguous, avoid_copy,
+                real_direction_flag)
+    elif calling_func in ('irfft2', 'irfftn'):
         # overwrite_input is not an argument to irfft2 or irfftn
         args = (planner_effort, threads, auto_align_input, auto_contiguous)
 

--- a/pyfftw/interfaces/_utils.py
+++ b/pyfftw/interfaces/_utils.py
@@ -70,7 +70,7 @@ def _Xfftn(a, s, axes, overwrite_input, planner_effort,
     if calling_func in ('dct', 'dst'):
         # real-to-real transforms require passing an additional flag argument
         avoid_copy = False
-        args = (a, s, axes, overwrite_input, planner_effort, threads,
+        args = (overwrite_input, planner_effort, threads,
                 auto_align_input, auto_contiguous, avoid_copy,
                 real_direction_flag)
     elif calling_func in ('irfft2', 'irfftn'):

--- a/pyfftw/interfaces/scipy_fft.py
+++ b/pyfftw/interfaces/scipy_fft.py
@@ -333,7 +333,7 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
         auto_contiguous=True):
     '''Perform a 1D discrete cosine transform.
 
-    The first three arguments are as per :func:`scipy.fftpack.dct`;
+    The first seven arguments are as per :func:`scipy.fft.dct`;
     the rest of the arguments are documented
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     '''
@@ -353,7 +353,7 @@ def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
          auto_contiguous=True):
     '''Perform an inverse 1D discrete cosine transform.
 
-    The first three arguments are as per :func:`scipy.fftpack.idct`;
+    The first seven arguments are as per :func:`scipy.fft.idct`;
     the rest of the arguments are documented
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     '''
@@ -373,7 +373,7 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
         auto_contiguous=True):
     '''Perform a 1D discrete sine transform.
 
-    The first three arguments are as per :func:`scipy.fftpack.dst`;
+    The first seven arguments are as per :func:`scipy.fft.dst`;
     the rest of the arguments are documented
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     '''
@@ -393,7 +393,7 @@ def idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
          auto_contiguous=True):
     '''Perform an inverse 1D discrete sine transform.
 
-    The first three arguments are as per :func:`scipy.fftpack.idst`;
+    The first seven arguments are as per :func:`scipy.fft.idst`;
     the rest of the arguments are documented
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     '''
@@ -412,7 +412,7 @@ def dctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
          auto_contiguous=True):
     """Performan a multidimensional Discrete Cosine Transform.
 
-    The first six arguments are as per :func:`scipy.fftpack.dctn`;
+    The first seven arguments are as per :func:`scipy.fft.dctn`;
     the rest of the arguments are documented
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     """
@@ -432,7 +432,7 @@ def idctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
           auto_contiguous=True):
     """Performan a multidimensional inverse Discrete Cosine Transform.
 
-    The first six arguments are as per :func:`scipy.fftpack.idctn`;
+    The first seven arguments are as per :func:`scipy.fft.idctn`;
     the rest of the arguments are documented
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     """
@@ -452,7 +452,7 @@ def dstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
          auto_contiguous=True):
     """Performan a multidimensional Discrete Sine Transform.
 
-    The first six arguments are as per :func:`scipy.fftpack.dstn`;
+    The first seven arguments are as per :func:`scipy.fft.dstn`;
     the rest of the arguments are documented
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     """
@@ -472,7 +472,7 @@ def idstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
           auto_contiguous=True):
     """Performan a multidimensional inverse Discrete Sine Transform.
 
-    The first six arguments are as per :func:`scipy.fftpack.idstn`;
+    The first seven arguments are as per :func:`scipy.fft.idstn`;
     the rest of the arguments are documented
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     """

--- a/pyfftw/interfaces/scipy_fft.py
+++ b/pyfftw/interfaces/scipy_fft.py
@@ -338,6 +338,8 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     '''
     threads = _workers_to_threads(workers)
+    if norm is None:
+        norm = 'backward'
     return _dct(x, type=type, n=n, axis=axis, norm=norm,
                 overwrite_x=overwrite_x,
                 planner_effort=planner_effort, threads=threads,
@@ -356,6 +358,8 @@ def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     '''
     threads = _workers_to_threads(workers)
+    if norm is None:
+        norm = 'backward'
     return _idct(x, type=type, n=n, axis=axis, norm=norm,
                  overwrite_x=overwrite_x,
                  planner_effort=planner_effort, threads=threads,
@@ -374,6 +378,8 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     '''
     threads = _workers_to_threads(workers)
+    if norm is None:
+        norm = 'backward'
     return _dst(x, type=type, n=n, axis=axis, norm=norm,
                 overwrite_x=overwrite_x,
                 planner_effort=planner_effort, threads=threads,
@@ -392,6 +398,8 @@ def idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     '''
     threads = _workers_to_threads(workers)
+    if norm is None:
+        norm = 'backward'
     return _idst(x, type=type, n=n, axis=axis, norm=norm,
                  overwrite_x=overwrite_x,
                  planner_effort=planner_effort, threads=threads,
@@ -399,7 +407,7 @@ def idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
                  auto_contiguous=auto_contiguous)
 
 @_implements(_fft.dctn)
-def dctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False,
+def dctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
          workers=None, planner_effort=None, auto_align_input=True,
          auto_contiguous=True):
     """Performan a multidimensional Discrete Cosine Transform.
@@ -409,7 +417,9 @@ def dctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False,
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     """
     threads = _workers_to_threads(workers)
-    return _dctn(x, type=type, s=shape, axes=axes, norm=norm,
+    if norm is None:
+        norm = 'backward'
+    return _dctn(x, type=type, shape=s, axes=axes, norm=norm,
                  overwrite_x=overwrite_x,
                  planner_effort=planner_effort, threads=threads,
                  auto_align_input=auto_align_input,
@@ -417,7 +427,7 @@ def dctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False,
 
 
 @_implements(_fft.idctn)
-def idctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False,
+def idctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
           workers=None, planner_effort=None, auto_align_input=True,
           auto_contiguous=True):
     """Performan a multidimensional inverse Discrete Cosine Transform.
@@ -427,7 +437,9 @@ def idctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False,
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     """
     threads = _workers_to_threads(workers)
-    return _idctn(x, type=type, s=shape, axes=axes, norm=norm,
+    if norm is None:
+        norm = 'backward'
+    return _idctn(x, type=type, shape=s, axes=axes, norm=norm,
                   overwrite_x=overwrite_x,
                   planner_effort=planner_effort, threads=threads,
                   auto_align_input=auto_align_input,
@@ -435,7 +447,7 @@ def idctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False,
 
 
 @_implements(_fft.dstn)
-def dstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False,
+def dstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
          workers=None, planner_effort=None, auto_align_input=True,
          auto_contiguous=True):
     """Performan a multidimensional Discrete Sine Transform.
@@ -445,7 +457,9 @@ def dstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False,
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     """
     threads = _workers_to_threads(workers)
-    return _dstn(x, type=type, s=shape, axes=axes, norm=norm,
+    if norm is None:
+        norm = 'backward'
+    return _dstn(x, type=type, shape=s, axes=axes, norm=norm,
                  overwrite_x=overwrite_x,
                  planner_effort=planner_effort, threads=threads,
                  auto_align_input=auto_align_input,
@@ -453,7 +467,7 @@ def dstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False,
 
 
 @_implements(_fft.idstn)
-def idstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False,
+def idstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
           workers=None, planner_effort=None, auto_align_input=True,
           auto_contiguous=True):
     """Performan a multidimensional inverse Discrete Sine Transform.
@@ -463,7 +477,9 @@ def idstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False,
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     """
     threads = _workers_to_threads(workers)
-    return _idstn(x, type=type, s=shape, axes=axes, norm=norm,
+    if norm is None:
+        norm = 'backward'
+    return _idstn(x, type=type, shape=s, axes=axes, norm=norm,
                   overwrite_x=overwrite_x,
                   planner_effort=planner_effort, threads=threads,
                   auto_align_input=auto_align_input,

--- a/pyfftw/interfaces/scipy_fft.py
+++ b/pyfftw/interfaces/scipy_fft.py
@@ -50,7 +50,8 @@ a 2D `s` argument will return without exception whereas
 import os
 
 from . import numpy_fft
-from . import scipy_fftpack
+from .scipy_fftpack import (_dct, _idct, _dctn, _idctn,
+                            _dst, _idst, _dstn, _idstn)
 
 # Complete the namespace (these are not actually used in this module)
 from scipy.fft import (hfft2, ihfft2, hfftn, ihfftn,
@@ -337,11 +338,11 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     '''
     threads = _workers_to_threads(workers)
-    return scipy_fftpack.dct(x, type=type, n=n, axis=axis, norm=norm,
-                             overwrite_x=overwrite_x,
-                             planner_effort=planner_effort, threads=threads,
-                             auto_align_input=auto_align_input,
-                             auto_contiguous=auto_contiguous)
+    return _dct(x, type=type, n=n, axis=axis, norm=norm,
+                overwrite_x=overwrite_x,
+                planner_effort=planner_effort, threads=threads,
+                auto_align_input=auto_align_input,
+                auto_contiguous=auto_contiguous)
 
 
 @_implements(_fft.idct)
@@ -355,11 +356,11 @@ def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     '''
     threads = _workers_to_threads(workers)
-    return scipy_fftpack.idct(x, type=type, n=n, axis=axis, norm=norm,
-                              overwrite_x=overwrite_x,
-                              planner_effort=planner_effort, threads=threads,
-                              auto_align_input=auto_align_input,
-                              auto_contiguous=auto_contiguous)
+    return _idct(x, type=type, n=n, axis=axis, norm=norm,
+                 overwrite_x=overwrite_x,
+                 planner_effort=planner_effort, threads=threads,
+                 auto_align_input=auto_align_input,
+                 auto_contiguous=auto_contiguous)
 
 
 @_implements(_fft.dst)
@@ -373,11 +374,11 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     '''
     threads = _workers_to_threads(workers)
-    return scipy_fftpack.dst(x, type=type, n=n, axis=axis, norm=norm,
-                             overwrite_x=overwrite_x,
-                             planner_effort=planner_effort, threads=threads,
-                             auto_align_input=auto_align_input,
-                             auto_contiguous=auto_contiguous)
+    return _dst(x, type=type, n=n, axis=axis, norm=norm,
+                overwrite_x=overwrite_x,
+                planner_effort=planner_effort, threads=threads,
+                auto_align_input=auto_align_input,
+                auto_contiguous=auto_contiguous)
 
 
 @_implements(_fft.idst)
@@ -391,11 +392,11 @@ def idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     '''
     threads = _workers_to_threads(workers)
-    return scipy_fftpack.idst(x, type=type, n=n, axis=axis, norm=norm,
-                              overwrite_x=overwrite_x,
-                              planner_effort=planner_effort, threads=threads,
-                              auto_align_input=auto_align_input,
-                              auto_contiguous=auto_contiguous)
+    return _idst(x, type=type, n=n, axis=axis, norm=norm,
+                 overwrite_x=overwrite_x,
+                 planner_effort=planner_effort, threads=threads,
+                 auto_align_input=auto_align_input,
+                 auto_contiguous=auto_contiguous)
 
 @_implements(_fft.dctn)
 def dctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False,
@@ -408,11 +409,11 @@ def dctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False,
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     """
     threads = _workers_to_threads(workers)
-    return scipy_fftpack.dctn(x, type=type, s=shape, axes=axes, norm=norm,
-                              overwrite_x=overwrite_x,
-                              planner_effort=planner_effort, threads=threads,
-                              auto_align_input=auto_align_input,
-                              auto_contiguous=auto_contiguous)
+    return _dctn(x, type=type, s=shape, axes=axes, norm=norm,
+                 overwrite_x=overwrite_x,
+                 planner_effort=planner_effort, threads=threads,
+                 auto_align_input=auto_align_input,
+                 auto_contiguous=auto_contiguous)
 
 
 @_implements(_fft.idctn)
@@ -426,11 +427,11 @@ def idctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False,
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     """
     threads = _workers_to_threads(workers)
-    return scipy_fftpack.idctn(x, type=type, s=shape, axes=axes, norm=norm,
-                               overwrite_x=overwrite_x,
-                               planner_effort=planner_effort, threads=threads,
-                               auto_align_input=auto_align_input,
-                               auto_contiguous=auto_contiguous)
+    return _idctn(x, type=type, s=shape, axes=axes, norm=norm,
+                  overwrite_x=overwrite_x,
+                  planner_effort=planner_effort, threads=threads,
+                  auto_align_input=auto_align_input,
+                  auto_contiguous=auto_contiguous)
 
 
 @_implements(_fft.dstn)
@@ -444,11 +445,11 @@ def dstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False,
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     """
     threads = _workers_to_threads(workers)
-    return scipy_fftpack.dstn(x, type=type, s=shape, axes=axes, norm=norm,
-                             overwrite_x=overwrite_x,
-                             planner_effort=planner_effort, threads=threads,
-                             auto_align_input=auto_align_input,
-                             auto_contiguous=auto_contiguous)
+    return _dstn(x, type=type, s=shape, axes=axes, norm=norm,
+                 overwrite_x=overwrite_x,
+                 planner_effort=planner_effort, threads=threads,
+                 auto_align_input=auto_align_input,
+                 auto_contiguous=auto_contiguous)
 
 
 @_implements(_fft.idstn)
@@ -462,8 +463,8 @@ def idstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False,
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
     """
     threads = _workers_to_threads(workers)
-    return scipy_fftpack.idstn(x, type=type, s=shape, axes=axes, norm=norm,
-                               overwrite_x=overwrite_x,
-                               planner_effort=planner_effort, threads=threads,
-                               auto_align_input=auto_align_input,
-                               auto_contiguous=auto_contiguous)
+    return _idstn(x, type=type, s=shape, axes=axes, norm=norm,
+                  overwrite_x=overwrite_x,
+                  planner_effort=planner_effort, threads=threads,
+                  auto_align_input=auto_align_input,
+                  auto_contiguous=auto_contiguous)

--- a/pyfftw/interfaces/scipy_fft.py
+++ b/pyfftw/interfaces/scipy_fft.py
@@ -50,10 +50,10 @@ a 2D `s` argument will return without exception whereas
 import os
 
 from . import numpy_fft
+from . import scipy_fftpack
 
 # Complete the namespace (these are not actually used in this module)
-from scipy.fft import (dct, idct, dst, idst, dctn, idctn, dstn, idstn,
-                       hfft2, ihfft2, hfftn, ihfftn,
+from scipy.fft import (hfft2, ihfft2, hfftn, ihfftn,
                        fftshift, ifftshift, fftfreq, rfftfreq,
                        get_workers, set_workers)
 
@@ -324,3 +324,146 @@ def ihfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None,
     threads = _workers_to_threads(workers)
     return numpy_fft.ihfft(x, n, axis, norm, overwrite_x, planner_effort,
                            threads, auto_align_input, auto_contiguous)
+
+
+@_implements(_fft.dct)
+def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
+        workers=None, planner_effort=None, auto_align_input=True,
+        auto_contiguous=True):
+    '''Perform a 1D discrete cosine transform.
+
+    The first three arguments are as per :func:`scipy.fftpack.dct`;
+    the rest of the arguments are documented
+    in the :ref:`additional arguments docs<interfaces_additional_args>`.
+    '''
+    threads = _workers_to_threads(workers)
+    return scipy_fftpack.dct(x, type=type, n=n, axis=axis, norm=norm,
+                             overwrite_x=overwrite_x,
+                             planner_effort=planner_effort, threads=threads,
+                             auto_align_input=auto_align_input,
+                             auto_contiguous=auto_contiguous)
+
+
+@_implements(_fft.idct)
+def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
+         workers=None, planner_effort=None, auto_align_input=True,
+         auto_contiguous=True):
+    '''Perform an inverse 1D discrete cosine transform.
+
+    The first three arguments are as per :func:`scipy.fftpack.idct`;
+    the rest of the arguments are documented
+    in the :ref:`additional arguments docs<interfaces_additional_args>`.
+    '''
+    threads = _workers_to_threads(workers)
+    return scipy_fftpack.idct(x, type=type, n=n, axis=axis, norm=norm,
+                              overwrite_x=overwrite_x,
+                              planner_effort=planner_effort, threads=threads,
+                              auto_align_input=auto_align_input,
+                              auto_contiguous=auto_contiguous)
+
+
+@_implements(_fft.dst)
+def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
+        workers=None, planner_effort=None, auto_align_input=True,
+        auto_contiguous=True):
+    '''Perform a 1D discrete sine transform.
+
+    The first three arguments are as per :func:`scipy.fftpack.dst`;
+    the rest of the arguments are documented
+    in the :ref:`additional arguments docs<interfaces_additional_args>`.
+    '''
+    threads = _workers_to_threads(workers)
+    return scipy_fftpack.dst(x, type=type, n=n, axis=axis, norm=norm,
+                             overwrite_x=overwrite_x,
+                             planner_effort=planner_effort, threads=threads,
+                             auto_align_input=auto_align_input,
+                             auto_contiguous=auto_contiguous)
+
+
+@_implements(_fft.idst)
+def idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
+         workers=None, planner_effort=None, auto_align_input=True,
+         auto_contiguous=True):
+    '''Perform an inverse 1D discrete sine transform.
+
+    The first three arguments are as per :func:`scipy.fftpack.idst`;
+    the rest of the arguments are documented
+    in the :ref:`additional arguments docs<interfaces_additional_args>`.
+    '''
+    threads = _workers_to_threads(workers)
+    return scipy_fftpack.idst(x, type=type, n=n, axis=axis, norm=norm,
+                              overwrite_x=overwrite_x,
+                              planner_effort=planner_effort, threads=threads,
+                              auto_align_input=auto_align_input,
+                              auto_contiguous=auto_contiguous)
+
+@_implements(_fft.dctn)
+def dctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False,
+         workers=None, planner_effort=None, auto_align_input=True,
+         auto_contiguous=True):
+    """Performan a multidimensional Discrete Cosine Transform.
+
+    The first six arguments are as per :func:`scipy.fftpack.dctn`;
+    the rest of the arguments are documented
+    in the :ref:`additional arguments docs<interfaces_additional_args>`.
+    """
+    threads = _workers_to_threads(workers)
+    return scipy_fftpack.dctn(x, type=type, s=shape, axes=axes, norm=norm,
+                              overwrite_x=overwrite_x,
+                              planner_effort=planner_effort, threads=threads,
+                              auto_align_input=auto_align_input,
+                              auto_contiguous=auto_contiguous)
+
+
+@_implements(_fft.idctn)
+def idctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False,
+          workers=None, planner_effort=None, auto_align_input=True,
+          auto_contiguous=True):
+    """Performan a multidimensional inverse Discrete Cosine Transform.
+
+    The first six arguments are as per :func:`scipy.fftpack.idctn`;
+    the rest of the arguments are documented
+    in the :ref:`additional arguments docs<interfaces_additional_args>`.
+    """
+    threads = _workers_to_threads(workers)
+    return scipy_fftpack.idctn(x, type=type, s=shape, axes=axes, norm=norm,
+                               overwrite_x=overwrite_x,
+                               planner_effort=planner_effort, threads=threads,
+                               auto_align_input=auto_align_input,
+                               auto_contiguous=auto_contiguous)
+
+
+@_implements(_fft.dstn)
+def dstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False,
+         workers=None, planner_effort=None, auto_align_input=True,
+         auto_contiguous=True):
+    """Performan a multidimensional Discrete Sine Transform.
+
+    The first six arguments are as per :func:`scipy.fftpack.dstn`;
+    the rest of the arguments are documented
+    in the :ref:`additional arguments docs<interfaces_additional_args>`.
+    """
+    threads = _workers_to_threads(workers)
+    return scipy_fftpack.dstn(x, type=type, s=shape, axes=axes, norm=norm,
+                             overwrite_x=overwrite_x,
+                             planner_effort=planner_effort, threads=threads,
+                             auto_align_input=auto_align_input,
+                             auto_contiguous=auto_contiguous)
+
+
+@_implements(_fft.idstn)
+def idstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False,
+          workers=None, planner_effort=None, auto_align_input=True,
+          auto_contiguous=True):
+    """Performan a multidimensional inverse Discrete Sine Transform.
+
+    The first six arguments are as per :func:`scipy.fftpack.idstn`;
+    the rest of the arguments are documented
+    in the :ref:`additional arguments docs<interfaces_additional_args>`.
+    """
+    threads = _workers_to_threads(workers)
+    return scipy_fftpack.idstn(x, type=type, s=shape, axes=axes, norm=norm,
+                               overwrite_x=overwrite_x,
+                               planner_effort=planner_effort, threads=threads,
+                               auto_align_input=auto_align_input,
+                               auto_contiguous=auto_contiguous)

--- a/pyfftw/interfaces/scipy_fftpack.py
+++ b/pyfftw/interfaces/scipy_fftpack.py
@@ -335,9 +335,9 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
         x = numpy.copy(x)
         sp = list(it.repeat(slice(None), len(x.shape)))
         sp[axis] = 0
-        x[sp] /= numpy.sqrt(x.shape[axis])
+        x[tuple(sp)] /= numpy.sqrt(x.shape[axis])
         sp[axis] = slice(1, None, None)
-        x[sp] /= numpy.sqrt(2*x.shape[axis])
+        x[tuple(sp)] /= numpy.sqrt(2*x.shape[axis])
 
     type_flag_lookup = {
         1: 'FFTW_REDFT00',
@@ -366,9 +366,9 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
         if type == 2:
             sp = list(it.repeat(slice(None), len(x.shape)))
             sp[axis] = 0
-            result_unnormalized[sp] /= numpy.sqrt(4*x.shape[axis])
+            result_unnormalized[tuple(sp)] /= numpy.sqrt(4*x.shape[axis])
             sp[axis] = slice(1, None, None)
-            result_unnormalized[sp] /= numpy.sqrt(2*x.shape[axis])
+            result_unnormalized[tuple(sp)] /= numpy.sqrt(2*x.shape[axis])
             result = result_unnormalized
         elif type == 3:
             # normalization implemented as data preprocessing
@@ -426,9 +426,9 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
         x = numpy.copy(x)
         sp = list(it.repeat(Ellipsis, len(x.shape)))
         sp[axis] = 0
-        x[sp] /= numpy.sqrt(x.shape[axis])
+        x[tuple(sp)] /= numpy.sqrt(x.shape[axis])
         sp[axis] = slice(1, None, None)
-        x[sp] /= numpy.sqrt(2*x.shape[axis])
+        x[tuple(sp)] /= numpy.sqrt(2*x.shape[axis])
 
     type_flag_lookup = {
         1: 'FFTW_RODFT00',
@@ -457,10 +457,10 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
         elif type == 2:
             sp = list(it.repeat(Ellipsis, len(x.shape)))
             sp[axis] = 0
-            result_unnormalized[sp] *= 1.0/(2*numpy.sqrt(x.shape[axis]))
+            result_unnormalized[tuple(sp)] *= 1.0/(2*numpy.sqrt(x.shape[axis]))
             sp = list(it.repeat(Ellipsis, len(x.shape)))
             sp[axis] = slice(1, None, None)
-            result_unnormalized[sp] *= 1.0/numpy.sqrt(2*x.shape[axis])
+            result_unnormalized[tuple(sp)] *= 1.0/numpy.sqrt(2*x.shape[axis])
             result = result_unnormalized
         elif type == 3:
             result = result_unnormalized

--- a/pyfftw/interfaces/scipy_fftpack.py
+++ b/pyfftw/interfaces/scipy_fftpack.py
@@ -310,7 +310,7 @@ def irfft(x, n=None, axis=-1, overwrite_x=False,
             planner_effort, threads, auto_align_input, auto_contiguous)
 
 def dct(x, n=None, axis=-1, norm=None, overwrite_x=False, type=2,
-        planner_effort='FFTW_MEASURE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D discrete cosine transform.
 
@@ -351,6 +351,8 @@ def dct(x, n=None, axis=-1, norm=None, overwrite_x=False, type=2,
         raise ValueError("Type %d not understood" % type)
 
     calling_func = 'dct'
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
 
     result_unnormalized = _Xfftn(x, n, axis, overwrite_x, planner_effort,
                                  threads, auto_align_input, auto_contiguous,
@@ -377,8 +379,8 @@ def dct(x, n=None, axis=-1, norm=None, overwrite_x=False, type=2,
         return result
 
 def idct(x, n=None, axis=-1, norm=None, overwrite_x=False, type=2,
-        planner_effort='FFTW_MEASURE', threads=1,
-        auto_align_input=True, auto_contiguous=True):
+         planner_effort=None, threads=None,
+         auto_align_input=True, auto_contiguous=True):
     '''Perform an inverse 1D discrete cosine transform.
 
     The first three arguments are as per :func:`scipy.fftpack.idct`;
@@ -390,13 +392,16 @@ def idct(x, n=None, axis=-1, norm=None, overwrite_x=False, type=2,
     except KeyError:
         raise ValueError("Type %d not understood" % type)
 
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
+
     return dct(x, n=n, axis=axis, norm=norm, overwrite_x=overwrite_x,
                type=inverse_type, planner_effort=planner_effort,
                threads=threads, auto_align_input=auto_align_input,
                auto_contiguous=auto_contiguous)
 
 def dst(x, n=None, axis=-1, norm=None, overwrite_x=False, type=2,
-        planner_effort='FFTW_MEASURE', threads=1,
+        planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D discrete sine transform.
 
@@ -437,6 +442,8 @@ def dst(x, n=None, axis=-1, norm=None, overwrite_x=False, type=2,
         raise ValueError("Type %d not understood" % type)
 
     calling_func = 'dst'
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
 
     result_unnormalized = _Xfftn(x, n, axis, overwrite_x, planner_effort,
                                  threads, auto_align_input, auto_contiguous,
@@ -463,8 +470,8 @@ def dst(x, n=None, axis=-1, norm=None, overwrite_x=False, type=2,
         return result
 
 def idst(x, n=None, axis=-1, norm=None, overwrite_x=False, type=2,
-        planner_effort='FFTW_MEASURE', threads=1,
-        auto_align_input=True, auto_contiguous=True):
+         planner_effort=None, threads=None,
+         auto_align_input=True, auto_contiguous=True):
     '''Perform an inverse 1D discrete sine transform.
 
     The first three arguments are as per :func:`scipy.fftpack.idst`;
@@ -475,6 +482,9 @@ def idst(x, n=None, axis=-1, norm=None, overwrite_x=False, type=2,
         inverse_type = {1: 1, 2: 3, 3:2}[type]
     except KeyError:
         raise ValueError("Type %d not understood" % type)
+
+    planner_effort = _default_effort(planner_effort)
+    threads = _default_threads(threads)
 
     return dst(x, n=n, axis=axis, norm=norm, overwrite_x=overwrite_x,
                type=inverse_type, planner_effort=planner_effort,

--- a/pyfftw/interfaces/scipy_fftpack.py
+++ b/pyfftw/interfaces/scipy_fftpack.py
@@ -381,9 +381,8 @@ def _dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
     elif n != x.shape[axis]:
         raise NotImplementedError("Padding/truncating not yet implemented")
 
-    if norm is not None:
-        if norm != 'ortho':
-            raise ValueError("Unknown normalize mode %s" % norm)
+    if norm not in [None, 'forward', 'backward', 'ortho']:
+        raise ValueError("Unknown normalize mode %s" % norm)
 
     if norm == 'ortho':
         if type == 1:
@@ -514,9 +513,8 @@ def _dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
     elif n != x.shape[axis]:
         raise NotImplementedError("Padding/truncating not yet implemented")
 
-    if norm is not None:
-        if norm != 'ortho':
-            raise ValueError("Unknown normalize mode %s" % norm)
+    if norm not in [None, 'forward', 'backward', 'ortho']:
+        raise ValueError("Unknown normalize mode %s" % norm)
 
     if type == 3 and norm == 'ortho':
         x = numpy.copy(x)

--- a/pyfftw/interfaces/scipy_fftpack.py
+++ b/pyfftw/interfaces/scipy_fftpack.py
@@ -309,7 +309,7 @@ def irfft(x, n=None, axis=-1, overwrite_x=False,
     return numpy_fft.irfft(complex_input, n, axis, None, overwrite_x,
             planner_effort, threads, auto_align_input, auto_contiguous)
 
-def dct(x, n=None, axis=-1, norm=None, overwrite_x=False, type=2,
+def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
         planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D discrete cosine transform.
@@ -378,7 +378,7 @@ def dct(x, n=None, axis=-1, norm=None, overwrite_x=False, type=2,
             result = result_unnormalized
         return result
 
-def idct(x, n=None, axis=-1, norm=None, overwrite_x=False, type=2,
+def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
          planner_effort=None, threads=None,
          auto_align_input=True, auto_contiguous=True):
     '''Perform an inverse 1D discrete cosine transform.
@@ -400,7 +400,7 @@ def idct(x, n=None, axis=-1, norm=None, overwrite_x=False, type=2,
                threads=threads, auto_align_input=auto_align_input,
                auto_contiguous=auto_contiguous)
 
-def dst(x, n=None, axis=-1, norm=None, overwrite_x=False, type=2,
+def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
         planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D discrete sine transform.
@@ -469,7 +469,7 @@ def dst(x, n=None, axis=-1, norm=None, overwrite_x=False, type=2,
             result = result_unnormalized
         return result
 
-def idst(x, n=None, axis=-1, norm=None, overwrite_x=False, type=2,
+def idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
          planner_effort=None, threads=None,
          auto_align_input=True, auto_contiguous=True):
     '''Perform an inverse 1D discrete sine transform.

--- a/pyfftw/interfaces/scipy_fftpack.py
+++ b/pyfftw/interfaces/scipy_fftpack.py
@@ -83,53 +83,6 @@ __all__ = ['fft', 'ifft', 'fftn', 'ifftn', 'rfft', 'irfft', 'fft2', 'ifft2',
            'shift', 'fftshift', 'ifftshift', 'fftfreq', 'rfftfreq', 'convolve',
            'next_fast_len', 'dctn', 'idctn', 'dstn', 'idstn']
 
-_NORM_MAP = {None: 0, 'backward': 0, 'ortho': 1, 'forward': 2}
-
-
-def _normalization(norm, forward):
-    """Returns the pypocketfft normalization mode from the norm argument"""
-    try:
-        inorm = _NORM_MAP[norm]
-        return inorm if forward else (2 - inorm)
-    except KeyError:
-        raise ValueError(
-            f'Invalid norm value {norm!r}, should '
-             'be "backward", "ortho" or "forward"') from None
-
-
-def _norm_factor(inorm, n):
-    if inorm == 0:
-        return 1
-    elif inorm == 2:
-        return 1 / n
-    elif inorm == 1:
-        return 1 / math.sqrt(n)
-
-
-def _norm_factor_nd(inorm, shape, axes, fct=1, delta=0):
-    if inorm == 0:
-        return 1
-    n = 1
-    for ax in axes:
-        n *= fct * (shape[ax] + delta)
-    return _norm_factor(inorm, n)
-
-
-def _dct_norm_factor(norm, forward, type, shape, axes):
-    inorm = _normalization(norm, forward)
-    if type == 1:
-        return _norm_factor_nd(inorm, shape, axes, fct=2, delta=-1)
-    else:
-        return _norm_factor_nd(inorm, shape, axes, fct=2)
-
-
-def _dst_norm_factor(norm, forward, type, shape, axes):
-    inorm = _normalization(norm, forward)
-    if type == 1:
-        return _norm_factor_nd(inorm, shape, axes, fct=2, delta=1)
-    else:
-        return _norm_factor_nd(inorm, shape, axes, fct=2)
-
 
 def fft(x, n=None, axis=-1, overwrite_x=False,
         planner_effort=None, threads=None,

--- a/pyfftw/interfaces/scipy_fftpack.py
+++ b/pyfftw/interfaces/scipy_fftpack.py
@@ -327,7 +327,7 @@ def dct(x, n=None, axis=-1, norm=None, overwrite_x=False, type=2,
     else:
         raise NotImplementedError("Padding/truncating not yet implemented")
 
-    if norm:
+    if norm is not None:
         if norm != 'ortho':
             raise ValueError("Unknown normalize mode %s" % norm)
 
@@ -355,7 +355,7 @@ def dct(x, n=None, axis=-1, norm=None, overwrite_x=False, type=2,
     result_unnormalized = _Xfftn(x, n, axis, overwrite_x, planner_effort,
                                  threads, auto_align_input, auto_contiguous,
                                  calling_func, real_direction_flag=type_flag)
-    if not norm:
+    if norm is None:
         return result_unnormalized
     else:
         if type == 1:
@@ -413,7 +413,7 @@ def dst(x, n=None, axis=-1, norm=None, overwrite_x=False, type=2,
     else:
         raise NotImplementedError("Padding/truncating not yet implemented")
 
-    if norm:
+    if norm is not None:
         if norm != 'ortho':
             raise ValueError("Unknown normalize mode %s" % norm)
 
@@ -441,7 +441,7 @@ def dst(x, n=None, axis=-1, norm=None, overwrite_x=False, type=2,
     result_unnormalized = _Xfftn(x, n, axis, overwrite_x, planner_effort,
                                  threads, auto_align_input, auto_contiguous,
                                  calling_func, real_direction_flag=type_flag)
-    if not norm:
+    if norm is None:
         return result_unnormalized
     else:
         if type == 1:

--- a/pyfftw/pyfftw.pxd
+++ b/pyfftw/pyfftw.pxd
@@ -137,6 +137,27 @@ cdef extern from 'fftw3.h':
             clongdouble *_in, long double *_out,
             unsigned flags) nogil
 
+    # Double precision real planner
+    fftw_plan fftw_plan_guru_r2r(
+            int rank, fftw_iodim *dims,
+            int howmany_rank, fftw_iodim *howmany_dims,
+            double *_in, double *_out,
+            int *kind, unsigned flags)
+
+    # Single precision real planner
+    fftwf_plan fftwf_plan_guru_r2r(
+            int rank, fftw_iodim *dims,
+            int howmany_rank, fftw_iodim *howmany_dims,
+            float *_in, float *_out,
+            int *kind, unsigned flags)
+
+    # Long double precision real planner
+    fftwl_plan fftwl_plan_guru_r2r(
+            int rank, fftw_iodim *dims,
+            int howmany_rank, fftw_iodim *howmany_dims,
+            long double *_in, long double *_out,
+            int *kind, unsigned flags)
+
     # Double precision complex new array execute
     void fftw_execute_dft(fftw_plan,
           cdouble *_in, cdouble *_out) nogil
@@ -172,6 +193,18 @@ cdef extern from 'fftw3.h':
     # Long double precision complex to real new array execute
     void fftwl_execute_dft_c2r(fftwl_plan,
           clongdouble *_in, long double *_out) nogil
+
+    # Double precision real new array execute
+    void fftw_execute_r2r(fftw_plan,
+          double *_in, double *_out) nogil
+
+    # Single precision real new array execute
+    void fftwf_execute_r2r(fftwf_plan,
+          float *_in, float *_out) nogil
+
+    # Long double precision real new array execute
+    void fftwl_execute_r2r(fftwl_plan,
+          long double *_in, long double *_out) nogil
 
     # Double precision plan destroyer
     void fftw_destroy_plan(fftw_plan)
@@ -243,7 +276,7 @@ ctypedef void * (*fftw_generic_plan_guru)(
         int rank, fftw_iodim *dims,
         int howmany_rank, fftw_iodim *howmany_dims,
         void *_in, void *_out,
-        int sign, unsigned flags) nogil
+        int *directions, unsigned flags) nogil
 
 ctypedef void (*fftw_generic_execute)(void *_plan, void *_in, void *_out) nogil
 
@@ -263,6 +296,15 @@ ctypedef bint (*validator)(np.ndarray input_array,
 cdef enum:
     FFTW_FORWARD = -1
     FFTW_BACKWARD = 1
+    # from fftw3.f 3.3.3; may not be valid for different versions of FFTW.
+    FFTW_REDFT00  = 3
+    FFTW_REDFT01  = 4
+    FFTW_REDFT10  = 5
+    FFTW_REDFT11  = 6
+    FFTW_RODFT00  = 7
+    FFTW_RODFT01  = 8
+    FFTW_RODFT10  = 9
+    FFTW_RODFT11  = 10
 
 # Documented flags
 cdef enum:

--- a/pyfftw/pyfftw.pyx
+++ b/pyfftw/pyfftw.pyx
@@ -146,7 +146,7 @@ cdef void* _fftw_plan_null(
             int rank, fftw_iodim *dims,
             int howmany_rank, fftw_iodim *howmany_dims,
             void *_in, void *_out,
-            int sign, unsigned flags):
+            int *direction, unsigned flags):
 
     raise RuntimeError("Undefined planner. This is a bug")
 
@@ -156,19 +156,19 @@ IF HAVE_DOUBLE:
                 int rank, fftw_iodim *dims,
                 int howmany_rank, fftw_iodim *howmany_dims,
                 void *_in, void *_out,
-                int sign, unsigned flags) nogil:
+                int *direction, unsigned flags) nogil:
 
         return <void *>fftw_plan_guru_dft(rank, dims,
                 howmany_rank, howmany_dims,
                 <cdouble *>_in, <cdouble *>_out,
-                sign, flags)
+                direction[0], flags)
 
     # real to complex double precision
     cdef void* _fftw_plan_guru_dft_r2c(
                 int rank, fftw_iodim *dims,
                 int howmany_rank, fftw_iodim *howmany_dims,
                 void *_in, void *_out,
-                int sign, unsigned flags) nogil:
+                int *direction, unsigned flags) nogil:
 
         return <void *>fftw_plan_guru_dft_r2c(rank, dims,
                 howmany_rank, howmany_dims,
@@ -180,7 +180,7 @@ IF HAVE_DOUBLE:
                 int rank, fftw_iodim *dims,
                 int howmany_rank, fftw_iodim *howmany_dims,
                 void *_in, void *_out,
-                int sign, unsigned flags) nogil:
+                int *direction, unsigned flags) nogil:
 
         return <void *>fftw_plan_guru_dft_c2r(rank, dims,
                 howmany_rank, howmany_dims,
@@ -205,19 +205,19 @@ IF HAVE_SINGLE:
                 int rank, fftw_iodim *dims,
                 int howmany_rank, fftw_iodim *howmany_dims,
                 void *_in, void *_out,
-                int sign, unsigned flags) nogil:
+                int *direction, unsigned flags) nogil:
 
         return <void *>fftwf_plan_guru_dft(rank, dims,
                 howmany_rank, howmany_dims,
                 <cfloat *>_in, <cfloat *>_out,
-                sign, flags)
+                direction[0], flags)
 
     # real to complex single precision
     cdef void* _fftwf_plan_guru_dft_r2c(
                 int rank, fftw_iodim *dims,
                 int howmany_rank, fftw_iodim *howmany_dims,
                 void *_in, void *_out,
-                int sign, unsigned flags) nogil:
+                int *direction, unsigned flags) nogil:
 
         return <void *>fftwf_plan_guru_dft_r2c(rank, dims,
                 howmany_rank, howmany_dims,
@@ -229,7 +229,7 @@ IF HAVE_SINGLE:
                 int rank, fftw_iodim *dims,
                 int howmany_rank, fftw_iodim *howmany_dims,
                 void *_in, void *_out,
-                int sign, unsigned flags) nogil:
+                int *direction, unsigned flags) nogil:
 
         return <void *>fftwf_plan_guru_dft_c2r(rank, dims,
                 howmany_rank, howmany_dims,
@@ -254,19 +254,19 @@ IF HAVE_LONG:
                 int rank, fftw_iodim *dims,
                 int howmany_rank, fftw_iodim *howmany_dims,
                 void *_in, void *_out,
-                int sign, unsigned flags) nogil:
+                int *direction, unsigned flags) nogil:
 
         return <void *>fftwl_plan_guru_dft(rank, dims,
                 howmany_rank, howmany_dims,
                 <clongdouble *>_in, <clongdouble *>_out,
-                sign, flags)
+                direction[0], flags)
 
     # real to complex long double precision
     cdef void* _fftwl_plan_guru_dft_r2c(
                 int rank, fftw_iodim *dims,
                 int howmany_rank, fftw_iodim *howmany_dims,
                 void *_in, void *_out,
-                int sign, unsigned flags) nogil:
+                int *direction, unsigned flags) nogil:
 
         return <void *>fftwl_plan_guru_dft_r2c(rank, dims,
                 howmany_rank, howmany_dims,
@@ -278,7 +278,7 @@ IF HAVE_LONG:
                 int rank, fftw_iodim *dims,
                 int howmany_rank, fftw_iodim *howmany_dims,
                 void *_in, void *_out,
-                int sign, unsigned flags) nogil:
+                int *direction, unsigned flags) nogil:
 
         return <void *>fftwl_plan_guru_dft_c2r(rank, dims,
                 howmany_rank, howmany_dims,

--- a/pyfftw/pyfftw.pyx
+++ b/pyfftw/pyfftw.pyx
@@ -1,7 +1,8 @@
 # cython: language_level=3
 #
 # Copyright 2015 Knowledge Economy Developments Ltd
-#
+# Copyright 2014 David Wells
+
 # Henry Gomersall
 # heng@kedevelopments.co.uk
 #
@@ -91,11 +92,27 @@ ELSE:
 
 cdef object directions
 directions = {'FFTW_FORWARD': FFTW_FORWARD,
-        'FFTW_BACKWARD': FFTW_BACKWARD}
+        'FFTW_BACKWARD': FFTW_BACKWARD,
+        'FFTW_REDFT00': FFTW_REDFT00,
+        'FFTW_REDFT10': FFTW_REDFT10,
+        'FFTW_REDFT01': FFTW_REDFT01,
+        'FFTW_REDFT11': FFTW_REDFT11,
+        'FFTW_RODFT00': FFTW_RODFT00,
+        'FFTW_RODFT10': FFTW_RODFT10,
+        'FFTW_RODFT01': FFTW_RODFT01,
+        'FFTW_RODFT11': FFTW_RODFT11}
 
 cdef object directions_lookup
 directions_lookup = {FFTW_FORWARD: 'FFTW_FORWARD',
-        FFTW_BACKWARD: 'FFTW_BACKWARD'}
+        FFTW_BACKWARD: 'FFTW_BACKWARD',
+        FFTW_REDFT00: 'FFTW_REDFT00',
+        FFTW_REDFT10: 'FFTW_REDFT10',
+        FFTW_REDFT01: 'FFTW_REDFT01',
+        FFTW_REDFT11: 'FFTW_REDFT11',
+        FFTW_RODFT00: 'FFTW_RODFT00',
+        FFTW_RODFT10: 'FFTW_RODFT10',
+        FFTW_RODFT01: 'FFTW_RODFT01',
+        FFTW_RODFT11: 'FFTW_RODFT11'}
 
 cdef object flag_dict
 flag_dict = {'FFTW_MEASURE': FFTW_MEASURE,
@@ -124,6 +141,7 @@ cdef object plan_lock = threading.Lock()
 #     Planners
 #     ========
 #
+
 cdef void* _fftw_plan_null(
             int rank, fftw_iodim *dims,
             int howmany_rank, fftw_iodim *howmany_dims,
@@ -169,6 +187,18 @@ IF HAVE_DOUBLE:
                 <cdouble *>_in, <double *>_out,
                 flags)
 
+    # real to real double precision
+    cdef void* _fftw_plan_guru_r2r(
+                int rank, fftw_iodim *dims,
+                int howmany_rank, fftw_iodim *howmany_dims,
+                void *_in, void *_out,
+                int *direction, int flags):
+
+        return <void *>fftw_plan_guru_r2r(rank, dims,
+                howmany_rank, howmany_dims,
+                <double *>_in, <double *>_out,
+                direction, flags)
+
 IF HAVE_SINGLE:
     # Complex single precision
     cdef void* _fftwf_plan_guru_dft(
@@ -206,6 +236,18 @@ IF HAVE_SINGLE:
                 <cfloat *>_in, <float *>_out,
                 flags)
 
+    # real to real single precision
+    cdef void* _fftwf_plan_guru_r2r(
+                int rank, fftw_iodim *dims,
+                int howmany_rank, fftw_iodim *howmany_dims,
+                void *_in, void *_out,
+                int *direction, int flags):
+
+        return <void *>fftwf_plan_guru_r2r(rank, dims,
+                howmany_rank, howmany_dims,
+                <float *>_in, <float *>_out,
+                direction, flags)
+
 IF HAVE_LONG:
     # Complex long double precision
     cdef void* _fftwl_plan_guru_dft(
@@ -242,6 +284,18 @@ IF HAVE_LONG:
                 howmany_rank, howmany_dims,
                 <clongdouble *>_in, <long double *>_out,
                 flags)
+
+    # real to real long double precision
+    cdef void* _fftwl_plan_guru_r2r(
+                int rank, fftw_iodim *dims,
+                int howmany_rank, fftw_iodim *howmany_dims,
+                void *_in, void *_out,
+                int *direction, int flags):
+
+        return <void *>fftwl_plan_guru_r2r(rank, dims,
+                howmany_rank, howmany_dims,
+                <long double *>_in, <long double *>_out,
+                direction, flags)
 
 #    Executors
 #    =========
@@ -308,6 +362,21 @@ IF HAVE_LONG:
         fftwl_execute_dft_c2r(<fftwl_plan>_plan,
                 <clongdouble *>_in, <long double *>_out)
 
+# real to real double precision
+cdef void _fftw_execute_r2r(void *_plan, void *_in, void *_out) nogil:
+
+    fftw_execute_r2r(<fftw_plan>_plan, <double *>_in, <double *>_out)
+
+# real to real single precision
+cdef void _fftwf_execute_r2r(void *_plan, void *_in, void *_out) nogil:
+
+    fftwf_execute_r2r(<fftwf_plan>_plan, <float *>_in, <float *>_out)
+
+# real to real long double precision
+cdef void _fftwl_execute_r2r(void *_plan, void *_in, void *_out) nogil:
+
+    fftwl_execute_r2r(<fftwl_plan>_plan, <long double *>_in, <long double *>_out)
+
 #    Destroyers
 #    ==========
 #
@@ -336,45 +405,52 @@ IF HAVE_LONG:
 # Function lookup tables
 # ======================
 
+
 # Planner table (of size the number of planners).
-cdef fftw_generic_plan_guru planners[9]
+cdef fftw_generic_plan_guru planners[12]
 
 cdef fftw_generic_plan_guru * _build_planner_list():
-    for i in range(9):
+    for i in range(12):
         planners[i] = <fftw_generic_plan_guru>&_fftw_plan_null
 
     IF HAVE_DOUBLE:
         planners[0] = <fftw_generic_plan_guru>&_fftw_plan_guru_dft
         planners[3] = <fftw_generic_plan_guru>&_fftw_plan_guru_dft_r2c
         planners[6] = <fftw_generic_plan_guru>&_fftw_plan_guru_dft_c2r
+        planners[9] = <fftw_generic_plan_guru>&_fftw_plan_guru_r2r
     IF HAVE_SINGLE:
         planners[1] = <fftw_generic_plan_guru>&_fftwf_plan_guru_dft
         planners[4] = <fftw_generic_plan_guru>&_fftwf_plan_guru_dft_r2c
         planners[7] = <fftw_generic_plan_guru>&_fftwf_plan_guru_dft_c2r
+        planners[10] = <fftw_generic_plan_guru>&_fftwf_plan_guru_r2r
     IF HAVE_LONG:
         planners[2] = <fftw_generic_plan_guru>&_fftwl_plan_guru_dft
         planners[5] = <fftw_generic_plan_guru>&_fftwl_plan_guru_dft_r2c
         planners[8] = <fftw_generic_plan_guru>&_fftwl_plan_guru_dft_c2r
+        planners[11] = <fftw_generic_plan_guru>&_fftwl_plan_guru_r2r
 
 # Executor table (of size the number of executors)
-cdef fftw_generic_execute executors[9]
+cdef fftw_generic_execute executors[12]
 
 cdef fftw_generic_execute * _build_executor_list():
-    for i in range(9):
+    for i in range(12):
         executors[i] = <fftw_generic_execute>&_fftw_execute_null
 
     IF HAVE_DOUBLE:
         executors[0] = <fftw_generic_execute>&_fftw_execute_dft
         executors[3] = <fftw_generic_execute>&_fftw_execute_dft_r2c
         executors[6] = <fftw_generic_execute>&_fftw_execute_dft_c2r
+        executors[9] = <fftw_generic_execute>&_fftw_execute_r2r
     IF HAVE_SINGLE:
         executors[1] = <fftw_generic_execute>&_fftwf_execute_dft
         executors[4] = <fftw_generic_execute>&_fftwf_execute_dft_r2c
         executors[7] = <fftw_generic_execute>&_fftwf_execute_dft_c2r
+        executors[10] = <fftw_generic_execute>&_fftwf_execute_r2r
     IF HAVE_LONG:
         executors[2] = <fftw_generic_execute>&_fftwl_execute_dft
         executors[5] = <fftw_generic_execute>&_fftwl_execute_dft_r2c
         executors[8] = <fftw_generic_execute>&_fftwl_execute_dft_c2r
+        executors[11] = <fftw_generic_execute>&_fftwl_execute_r2r
 
 # Destroyer table (of size the number of destroyers)
 cdef fftw_generic_destroy_plan destroyers[3]
@@ -550,7 +626,9 @@ fftw_schemes = {
         (np.dtype('float64'), np.dtype('complex128')): ('r2c', '64'),
         (np.dtype('float32'), np.dtype('complex64')): ('r2c', '32'),
         (np.dtype('complex128'), np.dtype('float64')): ('c2r', '64'),
-        (np.dtype('complex64'), np.dtype('float32')): ('c2r', '32')}
+        (np.dtype('complex64'), np.dtype('float32')): ('c2r', '32'),
+        (np.dtype('float32'), np.dtype('float32')): ('r2r', '32'),
+        (np.dtype('float64'), np.dtype('float64')): ('r2r', '64')}
 
 cdef object fftw_default_output
 fftw_default_output = {
@@ -563,7 +641,8 @@ if np.dtype('longdouble') != np.dtype('float64'):
     fftw_schemes.update({
         (np.dtype('clongdouble'), np.dtype('clongdouble')): ('c2c', 'ld'),
         (np.dtype('longdouble'), np.dtype('clongdouble')): ('r2c', 'ld'),
-        (np.dtype('clongdouble'), np.dtype('longdouble')): ('c2r', 'ld')})
+        (np.dtype('clongdouble'), np.dtype('longdouble')): ('c2r', 'ld'),
+        (np.dtype('longdouble'), np.dtype('longdouble')): ('r2r', 'ld')})
 
     fftw_default_output.update({
         np.dtype('longdouble'): np.dtype('clongdouble'),
@@ -579,7 +658,16 @@ scheme_directions = {
         ('r2c', 'ld'): ['FFTW_FORWARD'],
         ('c2r', '64'): ['FFTW_BACKWARD'],
         ('c2r', '32'): ['FFTW_BACKWARD'],
-        ('c2r', 'ld'): ['FFTW_BACKWARD']}
+        ('c2r', 'ld'): ['FFTW_BACKWARD'],
+        ('r2r', '64'): ['FFTW_REDFT00', 'FFTW_REDFT10', 'FFTW_REDFT01',
+                        'FFTW_REDFT11', 'FFTW_RODFT00', 'FFTW_RODFT10',
+                        'FFTW_RODFT01', 'FFTW_RODFT11'],
+        ('r2r', '32'): ['FFTW_REDFT00', 'FFTW_REDFT10', 'FFTW_REDFT01',
+                        'FFTW_REDFT11', 'FFTW_RODFT00', 'FFTW_RODFT10',
+                        'FFTW_RODFT01', 'FFTW_RODFT11'],
+        ('r2r', 'ld'): ['FFTW_REDFT00', 'FFTW_REDFT10', 'FFTW_REDFT01',
+                        'FFTW_REDFT11', 'FFTW_RODFT00', 'FFTW_RODFT10',
+                        'FFTW_RODFT01', 'FFTW_RODFT11']}
 
 # In the following, -1 denotes using the default. A segfault has been
 # reported on some systems when this is set to None. It seems
@@ -595,7 +683,9 @@ IF HAVE_DOUBLE:
         'fft_shape_lookup': _lookup_shape_r2c_arrays},
     ('c2r', '64'): {'planner':6, 'executor':6, 'generic_precision':0,
         'validator': 1,
-        'fft_shape_lookup': _lookup_shape_c2r_arrays}})
+        'fft_shape_lookup': _lookup_shape_c2r_arrays},
+    ('r2r', '64'): {'planner': 9, 'executor':9, 'generic_precision':0,
+        'validator': -1, 'fft_shape_lookup': -1}})
 IF HAVE_SINGLE:
     _scheme_functions.update({
     ('c2c', '32'): {'planner':1, 'executor':1, 'generic_precision':1,
@@ -605,7 +695,9 @@ IF HAVE_SINGLE:
         'fft_shape_lookup': _lookup_shape_r2c_arrays},
     ('c2r', '32'): {'planner':7, 'executor':7, 'generic_precision':1,
         'validator': 1,
-        'fft_shape_lookup': _lookup_shape_c2r_arrays}})
+        'fft_shape_lookup': _lookup_shape_c2r_arrays},
+    ('r2r', '32'): {'planner':10, 'executor':10, 'generic_precision':1,
+        'validator': -1, 'fft_shape_lookup': -1}})
 IF HAVE_LONG:
     _scheme_functions.update({
     ('c2c', 'ld'): {'planner':2, 'executor':2, 'generic_precision':2,
@@ -615,7 +707,9 @@ IF HAVE_LONG:
         'fft_shape_lookup': _lookup_shape_r2c_arrays},
     ('c2r', 'ld'): {'planner':8, 'executor':8, 'generic_precision':2,
         'validator': 1,
-        'fft_shape_lookup': _lookup_shape_c2r_arrays}})
+        'fft_shape_lookup': _lookup_shape_c2r_arrays},
+    ('r2r', 'ld'): {'planner':11, 'executor':11, 'generic_precision':2,
+        'validator': -1, 'fft_shape_lookup': -1}})
 
 def scheme_functions(scheme):
     if scheme in _scheme_functions:
@@ -772,7 +866,7 @@ cdef class FFTW:
 
     cdef np.ndarray _input_array
     cdef np.ndarray _output_array
-    cdef int _direction
+    cdef int *_direction
     cdef unsigned _flags
 
     cdef bint _simd_allowed
@@ -929,10 +1023,22 @@ cdef class FFTW:
 
     def _get_direction(self):
         '''
-        Return the planned FFT direction. Either `'FFTW_FORWARD'` or
-        `'FFTW_BACKWARD'`.
+        Return the planned FFT direction. Either `'FFTW_FORWARD'`,
+        `'FFTW_BACKWARD'`, or a list of real transform codes of the form
+        `['FFTW_R*DFT**']`.
         '''
-        return directions_lookup[self._direction]
+        cdef int i
+        transform_directions = list()
+        if self._direction[0] in [FFTW_FORWARD, FFTW_BACKWARD]:
+            # It would be nice to return a length-one list here (so that the
+            # return type is always [str]). This is an annoying type difference,
+            # but is backwards compatible.
+            return directions_lookup[self._direction[0]]
+        else:
+            for i in range(self._rank):
+                transform_directions.append(directions_lookup[
+                        self._direction[i]])
+        return transform_directions
 
     direction = property(_get_direction)
 
@@ -973,6 +1079,11 @@ cdef class FFTW:
                   bint normalise_idft=True, bint ortho=False,
                   *args, **kwargs):
 
+        if isinstance(direction, str):
+            given_directions = [direction]
+        else:
+            given_directions = list(direction)
+
         # Initialise the pointers that need to be freed
         self._plan = NULL
         self._dims = NULL
@@ -980,6 +1091,7 @@ cdef class FFTW:
 
         self._axes = NULL
         self._not_axes = NULL
+        self._direction = NULL
 
         self._normalise_idft = normalise_idft
         self._ortho = ortho
@@ -1089,12 +1201,32 @@ cdef class FFTW:
                     'The output array is expected to lie on a %d '
                     'byte boundary.' % self._output_array_alignment)
 
-        if not direction in scheme_directions[scheme]:
-            raise ValueError('Invalid direction: '
-                    'The direction is not valid for the scheme. '
-                    'Try setting it explicitly if it is not already.')
+        for direction in given_directions:
+            if direction not in scheme_directions[scheme]:
+                raise ValueError('Invalid direction: '
+                        'The direction is not valid for the scheme. '
+                        'Try setting it explicitly if it is not already.')
 
-        self._direction = directions[direction]
+        self._direction = <int *>malloc(len(axes)*sizeof(int))
+
+        real_transforms = True
+        cdef int i
+        if given_directions[0] in ['FFTW_FORWARD', 'FFTW_BACKWARD']:
+            self._direction[0] = directions[given_directions[0]]
+            real_transforms = False
+        else:
+            if len(axes) != len(given_directions):
+                raise ValueError('For real-to-real transforms, there must '
+                        'be exactly one specified transform for each '
+                        'transformed axis.')
+            for i in range(len(axes)):
+                if given_directions[0] in ['FFTW_FORWARD', 'FFTW_BACKWARD']:
+                    raise ValueError('Heterogeneous transforms cannot be '
+                            'assigned with \'FFTW_FORWARD\' or '
+                            '\'FFTW_BACKWARD\'.')
+                else:
+                    self._direction[i] = directions[given_directions[i]]
+
         self._input_shape = input_array.shape
         self._output_shape = output_array.shape
 
@@ -1136,10 +1268,18 @@ cdef class FFTW:
                     'The input array should have no zero length'
                     'axes over which the FFT is to be taken')
 
-            if self._direction == FFTW_FORWARD:
-                total_N *= self._input_shape[self._axes[n]]
+            if real_transforms:
+                if self._direction[n] == FFTW_RODFT00:
+                    total_N *= 2*(self._input_shape[self._axes[n]] + 1)
+                elif self._direction[n] == FFTW_REDFT00:
+                    total_N *= 2*(self._input_shape[self._axes[n]] - 1)
+                else:
+                    total_N *= 2*self._input_shape[self._axes[n]]
             else:
-                total_N *= self._output_shape[self._axes[n]]
+                if self._direction[0] == FFTW_FORWARD:
+                    total_N *= self._input_shape[self._axes[n]]
+                else:
+                    total_N *= self._output_shape[self._axes[n]]
 
         self._total_size = total_N
         self._normalisation_scaling = 1/float(self.N)
@@ -1204,7 +1344,6 @@ cdef class FFTW:
         # Make sure that the arrays are not too big for fftw
         # This is hard to test, so we cross our fingers and hope for the
         # best (any suggestions, please get in touch).
-        cdef int i
         for i in range(0, len(self._input_shape)):
             if self._input_shape[i] >= <Py_ssize_t> limits.INT_MAX:
                 raise ValueError('Dimensions of the input array must be ' +
@@ -1267,12 +1406,11 @@ cdef class FFTW:
         cdef fftw_iodim *howmany_dims = <fftw_iodim *>self._howmany_dims
         cdef void *_in = <void *>np.PyArray_DATA(self._input_array)
         cdef void *_out = <void *>np.PyArray_DATA(self._output_array)
-        cdef int sign = self._direction
         cdef unsigned c_flags = self._flags
 
         with plan_lock, nogil:
             plan = fftw_planner(rank, dims, howmany_rank, howmany_dims,
-                                _in, _out, sign, c_flags)
+                                _in, _out, self._direction, c_flags)
         self._plan = plan
 
         if self._plan == NULL:
@@ -1510,6 +1648,9 @@ cdef class FFTW:
         if not self._howmany_dims == NULL:
             free(self._howmany_dims)
 
+        if not self._direction == NULL:
+            free(self._direction)
+
     def __call__(self, input_array=None, output_array=None,
             normalise_idft=None, ortho=None):
         '''__call__(input_array=None, output_array=None, normalise_idft=True,
@@ -1635,7 +1776,8 @@ cdef class FFTW:
 
         if ortho == True:
             self._output_array *= self._sqrt_normalisation_scaling
-        elif self._direction == FFTW_BACKWARD and normalise_idft:
+
+        if self._direction[0] == FFTW_BACKWARD and normalise_idft:
             self._output_array *= self._normalisation_scaling
 
         return self._output_array

--- a/pyfftw/pyfftw.pyx
+++ b/pyfftw/pyfftw.pyx
@@ -1272,6 +1272,9 @@ cdef class FFTW:
                 if self._direction[n] == FFTW_RODFT00:
                     total_N *= 2*(self._input_shape[self._axes[n]] + 1)
                 elif self._direction[n] == FFTW_REDFT00:
+                    if (self._input_shape[self._axes[n]] < 2):
+                        raise ValueError('FFTW_REDFT00 (also known as DCT-1) is'
+                                ' not defined for inputs of length less than two.')
                     total_N *= 2*(self._input_shape[self._axes[n]] - 1)
                 else:
                     total_N *= 2*self._input_shape[self._axes[n]]

--- a/test/test_pyfftw_numpy_interface.py
+++ b/test/test_pyfftw_numpy_interface.py
@@ -706,9 +706,9 @@ class InterfacesNumpyFFTTestFFT2(InterfacesNumpyFFTTestFFT):
             )
 
     invalid_args = (
-            ((100,), ((100, 200),), ValueError, 'Shape error'),
-            ((100, 200), ((100, 200, 100),), ValueError, 'Shape error'),
-            ((100,), ((100, 200), (-3, -2, -1)), ValueError, 'Shape error'),
+            ((100,), ((100, 200),), ValueError, ''),
+            ((100, 200), ((100, 200, 100),), ValueError, ''),
+            ((100,), ((100, 200), (-3, -2, -1)), ValueError, ''),
             ((100, 200), (100, -1), TypeError, ''),
             ((100, 200), ((100, 200), (-3, -2)), IndexError, 'Invalid axes'),
             ((100, 200), ((100,), (-3,)), IndexError, 'Invalid axes'),

--- a/test/test_pyfftw_scipy_fft.py
+++ b/test/test_pyfftw_scipy_fft.py
@@ -39,7 +39,7 @@ except ImportError:
     scipy_version = '0.0.0'
 
 from distutils.version import LooseVersion
-has_scipy_fft = LooseVersion(scipy_version) >= LooseVersion('1.4.0')
+has_scipy_fft = LooseVersion(scipy_version) >= '1.4.0'
 
 if has_scipy_fft:
     import scipy.fft
@@ -128,6 +128,12 @@ atol_dict = dict(f=1e-5, d=1e-7, g=1e-7)
 rtol_dict = dict(f=1e-4, d=1e-5, g=1e-5)
 transform_types = [1, 2, 3, 4]
 
+if LooseVersion(scipy_version) >= '1.6.0':
+    # all norm options aside from None
+    scipy_norms = ['ortho', 'forward', 'backward']
+else:
+    scipy_norms = ['ortho']
+
 @unittest.skipIf(not has_scipy_fft, 'scipy.fft is unavailable')
 class InterfacesScipyR2RFFTTest(unittest.TestCase):
     ''' Class template for building the scipy real to real tests.
@@ -168,12 +174,11 @@ class InterfacesScipyR2RFFTTest(unittest.TestCase):
             self.assertTrue(numpy.allclose(data_hat_p, data_hat_s,
                                            atol=self.atol, rtol=self.rtol))
 
-
     def test_normalized(self):
         '''Test normalized against scipy results. Note that scipy does
         not support normalization for all transformations.
         '''
-        for norm in ['ortho', 'backward', 'forward']:
+        for norm in scipy_norms:
             for transform_type in transform_types:
                 data_hat_p = self.pyfftw_func(self.data, type=transform_type,
                                               norm=norm,

--- a/test/test_pyfftw_scipy_interface.py
+++ b/test/test_pyfftw_scipy_interface.py
@@ -187,51 +187,82 @@ class InterfacesScipyFFTPackTestSimple(unittest.TestCase):
 
             self.assertIs(fftpack_attr, acquired_attr)
 
+@unittest.skipIf(scipy_missing, 'scipy is not installed, so this feature is'
+                 'unavailable')
 class InterfacesScipyFFTTest(unittest.TestCase):
+    ''' Class template for building the scipy real to real tests.
+    '''
+
     # unittest is not very smart and will always turn this class into a test,
-    # even though it is not on the list. Hence this value is given as 'dct' and
-    # we just run those twice.
+    # even though it is not on the list. Hence mark test-dependent values as
+    # constants (so this particular test ends up being run twice).
     func_name = 'dct'
+    floating_type = numpy.float64
 
-    def runTest(self):
-        scipy_func = getattr(scipy.fftpack, self.func_name)
-        pyfftw_func = getattr(scipy_fftpack, self.func_name)
-        ndims = numpy.random.randint(1, high=3)
-        axis = numpy.random.randint(0, high=ndims) % ndims
-        shape = numpy.random.randint(2, high=10, size=ndims)
-        data = numpy.random.rand(*shape)
-        data_copy = data.copy()
+    def setUp(self):
+        self.scipy_func = getattr(scipy.fftpack, self.func_name)
+        self.pyfftw_func = getattr(scipy_fftpack, self.func_name)
+        self.ndims = numpy.random.randint(1, high=3)
+        self.shape = numpy.random.randint(2, high=10, size=self.ndims)
+        self.data = numpy.random.rand(*self.shape).astype(floating_type)
+        self.data_copy = self.data.copy()
 
-        # test unnormalized.
+    def test_unnormalized(self):
+        '''Test unnormalized pyfftw transformations against their scipy
+        equivalents.
+        '''
         for transform_type in range(1, 4):
-            data_hat_p = pyfftw_func(data, type=transform_type,
-                                     overwrite_x=False)
-            self.assertEqual(numpy.linalg.norm(data - data_copy), 0.0)
-            data_hat_s = scipy_func(data, type=transform_type,
-                                    overwrite_x=False)
+            data_hat_p = self.pyfftw_func(self.data, type=transform_type,
+                                          overwrite_x=False)
+            self.assertEqual(numpy.linalg.norm(self.data - self.data_copy), 0.0)
+            data_hat_s = self.scipy_func(self.data, type=transform_type,
+                                         overwrite_x=False)
             self.assertTrue(numpy.allclose(data_hat_p, data_hat_s))
 
-        # test normalized. These are not all implemented in scipy.
+    def test_normalized(self):
+        '''Test normalized against scipy results. Note that scipy does
+        not support normalization for all transformations.
+        '''
         for transform_type in range(1, 4):
-            data_hat_p = pyfftw_func(data, type=transform_type, norm='ortho',
-                                     overwrite_x=False)
-            self.assertEqual(numpy.linalg.norm(data - data_copy), 0.0)
+            data_hat_p = self.pyfftw_func(self.data, type=transform_type,
+                                          norm='ortho',
+                                          overwrite_x=False)
+            self.assertEqual(numpy.linalg.norm(self.data - self.data_copy), 0.0)
             try:
-                data_hat_s = scipy_func(data, type=transform_type, norm='ortho',
-                                        overwrite_x=False)
+                data_hat_s = self.scipy_func(self.data, type=transform_type,
+                                             norm='ortho',
+                                             overwrite_x=False)
+                self.assertTrue(numpy.allclose(data_hat_p, data_hat_s))
             except NotImplementedError:
-                continue
-            self.assertTrue(numpy.allclose(data_hat_p, data_hat_s))
+                return None
+
+    def test_normalization_inverses(self):
+        '''Test normalization in all of the pyfftw scipy wrappers.
+        '''
+        for transform_type in range(1, 4):
+            inverse_type = {1: 1, 2: 3, 3:2}[transform_type]
+            forward = self.pyfftw_func(self.data, type=transform_type,
+                                       norm='ortho',
+                                       overwrite_x=False)
+            result = self.pyfftw_func(forward, type=inverse_type,
+                                      norm='ortho',
+                                      overwrite_x=False)
+            self.assertTrue(numpy.allclose(self.data, result))
+
 
 built_classes = []
 # Construct the r2r test classes.
-for transform_name in ('dct', 'idct', 'dst', 'idst'):
-    class_name = 'InterfacesScipyFFTTest' + transform_name.upper()
+for floating_type, floating_name in [[numpy.float32, 'Float32'],
+                                     [numpy.float64, 'Float64']]:
+    for transform_name in ('dct', 'idct', 'dst', 'idst'):
+        class_name = ('InterfacesScipyFFTTest' + transform_name.upper()
+                      + floating_name)
 
-    globals()[class_name] = type(class_name, (InterfacesScipyFFTTest,),
-                                 {'func_name': transform_name})
+        globals()[class_name] = type(class_name, (InterfacesScipyFFTTest,),
+                                    {'func_name': transform_name,
+                                     'float_type': floating_type})
 
-    built_classes.append(globals()[class_name])
+        built_classes.append(globals()[class_name])
 
 
 # Construct the test classes derived from the numpy tests.

--- a/test/test_pyfftw_scipy_interface.py
+++ b/test/test_pyfftw_scipy_interface.py
@@ -34,6 +34,8 @@
 #
 
 from pyfftw.interfaces import scipy_fftpack
+from distutils.version import LooseVersion
+
 import pyfftw
 import numpy
 
@@ -203,9 +205,15 @@ class InterfacesScipyFFTTest(unittest.TestCase):
         self.scipy_func = getattr(scipy.fftpack, self.func_name)
         self.pyfftw_func = getattr(scipy_fftpack, self.func_name)
         self.ndims = numpy.random.randint(1, high=3)
+        self.axis = numpy.random.randint(0, high=self.ndims)
         self.shape = numpy.random.randint(2, high=10, size=self.ndims)
         self.data = numpy.random.rand(*self.shape).astype(floating_type)
         self.data_copy = self.data.copy()
+
+        if self.func_name in ['dctn', 'idctn', 'dstn', 'idstn']:
+            self.kwargs = dict(axes=(self.axis, ))
+        else:
+            self.kwargs = dict(axis=self.axis)
 
     def test_unnormalized(self):
         '''Test unnormalized pyfftw transformations against their scipy
@@ -213,10 +221,10 @@ class InterfacesScipyFFTTest(unittest.TestCase):
         '''
         for transform_type in range(1, 4):
             data_hat_p = self.pyfftw_func(self.data, type=transform_type,
-                                          overwrite_x=False)
+                                          overwrite_x=False, **self.kwargs)
             self.assertEqual(numpy.linalg.norm(self.data - self.data_copy), 0.0)
             data_hat_s = self.scipy_func(self.data, type=transform_type,
-                                         overwrite_x=False)
+                                         overwrite_x=False, **self.kwargs)
             self.assertTrue(numpy.allclose(data_hat_p, data_hat_s))
 
     def test_normalized(self):
@@ -226,12 +234,12 @@ class InterfacesScipyFFTTest(unittest.TestCase):
         for transform_type in range(1, 4):
             data_hat_p = self.pyfftw_func(self.data, type=transform_type,
                                           norm='ortho',
-                                          overwrite_x=False)
+                                          overwrite_x=False, **self.kwargs)
             self.assertEqual(numpy.linalg.norm(self.data - self.data_copy), 0.0)
             try:
                 data_hat_s = self.scipy_func(self.data, type=transform_type,
                                              norm='ortho',
-                                             overwrite_x=False)
+                                             overwrite_x=False, **self.kwargs)
                 self.assertTrue(numpy.allclose(data_hat_p, data_hat_s))
             except NotImplementedError:
                 return None
@@ -243,24 +251,97 @@ class InterfacesScipyFFTTest(unittest.TestCase):
             inverse_type = {1: 1, 2: 3, 3:2}[transform_type]
             forward = self.pyfftw_func(self.data, type=transform_type,
                                        norm='ortho',
-                                       overwrite_x=False)
+                                       overwrite_x=False, **self.kwargs)
             result = self.pyfftw_func(forward, type=inverse_type,
                                       norm='ortho',
-                                      overwrite_x=False)
+                                      overwrite_x=False, **self.kwargs)
             self.assertTrue(numpy.allclose(self.data, result))
+
+
+@unittest.skipIf(scipy_missing or
+                 (LooseVersion(scipy.__version__) <= LooseVersion('1.0.0')),
+                 'scipy is not installed, so this feature is unavailable')
+class InterfacesScipyFFTNTest(InterfacesScipyFFTTest):
+    ''' Class template for building the scipy real to real tests.
+    '''
+
+    # unittest is not very smart and will always turn this class into a test,
+    # even though it is not on the list. Hence mark test-dependent values as
+    # constants (so this particular test ends up being run twice).
+    func_name = 'dctn'
+    floating_type = numpy.float64
+
+    def setUp(self):
+        self.scipy_func = getattr(scipy.fftpack, self.func_name)
+        self.pyfftw_func = getattr(scipy_fftpack, self.func_name)
+        self.ndims = numpy.random.randint(1, high=3)
+        self.shape = numpy.random.randint(2, high=10, size=self.ndims)
+        self.data = numpy.random.rand(*self.shape).astype(floating_type)
+        self.data_copy = self.data.copy()
+        # random subset of axes
+        self.axes = tuple(range(0, numpy.random.randint(0, high=self.ndims)))
+        self.kwargs = dict(axes=self.axes)
+
+    def test_axes_none(self):
+        '''Test transformation over all axes.
+        '''
+        for transform_type in range(1, 4):
+            data_hat_p = self.pyfftw_func(self.data, type=transform_type,
+                                          overwrite_x=False, axes=None)
+            self.assertEqual(numpy.linalg.norm(self.data - self.data_copy), 0.0)
+            data_hat_s = self.scipy_func(self.data, type=transform_type,
+                                         overwrite_x=False, axes=None)
+            self.assertTrue(numpy.allclose(data_hat_p, data_hat_s))
+
+    @unittest.skipIf(LooseVersion(scipy.__version__) <= LooseVersion('1.2.0'),
+                     'scipy version not new enough')
+    def test_axes_scalar(self):
+        '''Test transformation over a single, scalar axis.
+        '''
+        for transform_type in range(1, 4):
+            if scipy.__version__ < 1.2:
+                # scalar axes not supported in older SciPy
+                continue
+            data_hat_p = self.pyfftw_func(self.data, type=transform_type,
+                                          overwrite_x=False, axes=-1)
+            self.assertEqual(numpy.linalg.norm(self.data - self.data_copy), 0.0)
+            data_hat_s = self.scipy_func(self.data, type=transform_type,
+                                         overwrite_x=False, axes=-1)
+            self.assertTrue(numpy.allclose(data_hat_p, data_hat_s))
 
 
 built_classes = []
 # Construct the r2r test classes.
 for floating_type, floating_name in [[numpy.float32, 'Float32'],
                                      [numpy.float64, 'Float64']]:
-    for transform_name in ('dct', 'idct', 'dst', 'idst'):
-        class_name = ('InterfacesScipyFFTTest' + transform_name.upper()
-                      + floating_name)
+    real_transforms = ('dct', 'idct', 'dst', 'idst')
+    try:
+        # additional n-dimensional real transforms in scipy 1.0+
+        from scipy.fftpack import dctn
+        real_transforms_nd = ('dctn', 'idctn', 'dstn', 'idstn')
+        real_transforms += real_transforms_nd
+    except ImportError:
+        real_transforms_nd = ()
+
+    # test-cases where only one axis is transformed
+    for transform_name in real_transforms:
+        class_name = ('InterfacesScipyFFTTest' + transform_name.upper() +
+                      floating_name)
 
         globals()[class_name] = type(class_name, (InterfacesScipyFFTTest,),
-                                    {'func_name': transform_name,
-                                     'float_type': floating_type})
+                                     {'func_name': transform_name,
+                                      'float_type': floating_type})
+
+        built_classes.append(globals()[class_name])
+
+    # n-dimensional test-cases
+    for transform_name in real_transforms_nd:
+        class_name = ('InterfacesScipyFFTNTest' + transform_name.upper() +
+                      floating_name)
+
+        globals()[class_name] = type(class_name, (InterfacesScipyFFTNTest,),
+                                     {'func_name': transform_name,
+                                      'float_type': floating_type})
 
         built_classes.append(globals()[class_name])
 

--- a/test/test_r2r.py
+++ b/test/test_r2r.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2014 Knowledge Economy Developments Ltd
+# Copyright 2014 David Wells
+#
+# Henry Gomersall
+# heng@kedevelopments.co.uk
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+from __future__ import division
+import itertools as it
+import random as rand
+import unittest
+import numpy as np
+import pyfftw
+
+discrete_sine_directions = ['FFTW_RODFT00', 'FFTW_RODFT01', 'FFTW_RODFT10',
+                            'FFTW_RODFT11']
+
+discrete_cosine_directions = ['FFTW_REDFT00', 'FFTW_REDFT01', 'FFTW_REDFT10',
+                              'FFTW_REDFT11']
+
+real_transforms = discrete_sine_directions + discrete_cosine_directions
+
+normalisation_lookup = {
+    'FFTW_RODFT00': lambda n: 2*(n + 1),
+    'FFTW_RODFT01': lambda n: 2*n,
+    'FFTW_RODFT10': lambda n: 2*n,
+    'FFTW_RODFT11': lambda n: 2*n,
+    'FFTW_REDFT00': lambda n: 2*(n - 1),
+    'FFTW_REDFT01': lambda n: 2*n,
+    'FFTW_REDFT10': lambda n: 2*n,
+    'FFTW_REDFT11': lambda n: 2*n,
+}
+
+inverse_lookup = {
+    'FFTW_RODFT00': 'FFTW_RODFT00',
+    'FFTW_RODFT01': 'FFTW_RODFT10',
+    'FFTW_RODFT10': 'FFTW_RODFT01',
+    'FFTW_RODFT11': 'FFTW_RODFT11',
+    'FFTW_REDFT00': 'FFTW_REDFT00',
+    'FFTW_REDFT01': 'FFTW_REDFT10',
+    'FFTW_REDFT10': 'FFTW_REDFT01',
+    'FFTW_REDFT11': 'FFTW_REDFT11',
+}
+
+interpolated_function_lookup = {
+    'FFTW_RODFT00': lambda k, x: np.sin(np.pi*(k + 1)*x),
+    'FFTW_RODFT01': lambda k, x: np.sin(np.pi*(k + 0.5)*x),
+    'FFTW_RODFT10': lambda k, x: np.sin(np.pi*(k + 1)*x),
+    'FFTW_RODFT11': lambda k, x: np.sin(np.pi*(k + 0.5)*x),
+
+    'FFTW_REDFT00': lambda k, x: np.cos(np.pi*k*x),
+    'FFTW_REDFT10': lambda k, x: np.cos(np.pi*k*x),
+    'FFTW_REDFT01': lambda k, x: np.cos(np.pi*(k + 0.5)*x),
+    'FFTW_REDFT11': lambda k, x: np.cos(np.pi*(k + 0.5)*x),
+}
+
+nodes_lookup = {
+    'FFTW_RODFT00': lambda n: np.arange(n + 2)[1:-1]/(n + 1),
+    'FFTW_RODFT01': lambda n: np.arange(1, n + 1)/n,
+    'FFTW_RODFT10': lambda n: (np.arange(n) + 0.5)/n,
+    'FFTW_RODFT11': lambda n: (np.arange(n) + 0.5)/n,
+
+    'FFTW_REDFT00': lambda n: np.arange(n)/(n - 1),
+    'FFTW_REDFT10': lambda n: (np.arange(n) + 0.5)/n,
+    'FFTW_REDFT01': lambda n: np.arange(n)/n,
+    'FFTW_REDFT11': lambda n: (np.arange(n) + 0.5)/n,
+}
+
+class TestRandomRealTransforms(unittest.TestCase):
+    def test_normalisation(self):
+        for _ in range(50):
+            testcase = random_testcase()
+            self.assertTrue(testcase.test_normalisation())
+
+    def test_exact_data(self):
+        for _ in range(50):
+            testcase = random_testcase()
+            self.assertTrue(testcase.test_against_exact_data())
+
+    def test_random_data(self):
+        for _ in range(50):
+            testcase = random_testcase()
+            self.assertTrue(testcase.test_against_random_data())
+
+def test_lookups():
+    """Test that the lookup tables correctly pair node choices and
+    function choices for using the DCT/DST as interpolators.
+    """
+    n = rand.randint(10, 20)
+    j = rand.randint(5, n) - 3
+    for transform in real_transforms:
+        nodes   = nodes_lookup[transform](n)
+        data    = interpolated_function_lookup[transform](j, nodes)
+        output  = np.empty_like(data)
+        plan    = pyfftw.FFTW(data, output, direction=[transform])
+        data[:] = interpolated_function_lookup[transform](j, nodes)
+        plan.execute()
+        tol = 4*j*n*1e-16
+        if transform == 'FFTW_RODFT00':
+            assert abs(output[j] - n - 1) < tol
+        elif transform == 'FFTW_REDFT00':
+            assert abs(output[j] - n + 1) < tol
+        else:
+            assert abs(output[j] - n) < tol
+
+class TestRealTransform(object):
+    def __init__(self, directions, dims, axes=None, noncontiguous=True):
+        """
+        Arguments:
+
+        - `directions`: List of abbreviated directions, like 'O11' or 'E01'.
+
+        - `dims`: Shape of the data.
+
+        - `axes`: Axes on which to take the transformation. Defaults to the
+                  number of directions.
+        """
+        if axes is None:
+            self.axes = tuple(range(len(directions)))
+        else:
+            self.axes = axes
+        for dim in dims:
+            if dim < 3:
+                raise NotImplementedError("Due to complications with the DCT1, "
+                                          "arrays must be of length at least "
+                                          "three.")
+
+        if len(self.axes) != len(directions):
+            raise ValueError("There must be exactly one axis per direction.")
+
+        self.directions = directions
+        self.inverse_directions = [inverse_lookup[direction]
+                                    for direction in directions]
+        self.dims = dims
+        self._normalisation_factor = 1.0
+        for index, axis in enumerate(self.axes):
+            dim = self.dims[axis]
+            direction = self.directions[index]
+            self._normalisation_factor *= normalisation_lookup[direction](dim)
+
+        if noncontiguous:
+            self._input_array = empty_noncontiguous(dims)
+            self._output_array = empty_noncontiguous(dims)
+        else:
+            self._input_array = np.zeros(dims)
+            self._output_array = np.zeros(dims)
+        self.plan = pyfftw.FFTW(self._input_array, self._output_array,
+            axes=self.axes, direction=self.directions)
+        self.inverse_plan = pyfftw.FFTW(self._input_array, self._output_array,
+            axes=self.axes, direction=self.inverse_directions)
+
+    def test_normalisation(self):
+        return self._normalisation_factor == float(self.plan._get_N())
+
+    def test_against_random_data(self):
+        data = np.random.rand(*self.dims)
+        self._input_array[:] = data
+        self.plan.execute()
+        self._input_array[:] = self._output_array[:]
+        self.inverse_plan.execute()
+
+        data *= self._normalisation_factor
+        err = np.mean(np.abs(data - self._output_array))/self._normalisation_factor
+        return err < 10e-8
+
+    def test_against_exact_data(self):
+        points = grid(self.dims, self.axes, self.directions)
+        data   = np.ones_like(points[0])
+        wavenumbers = list()
+        factors = list()
+
+        for index, axis in enumerate(self.axes):
+            # Simplification: don't test constant terms. They are weird.
+            if self.directions[index] in discrete_cosine_directions:
+                wavenumber_min = 1
+                wavenumber_max = self.dims[axis] - 2
+            else:
+                wavenumber_min = 0
+                wavenumber_max = self.dims[axis] - 2
+            _wavenumbers = sorted({rand.randint(wavenumber_min, wavenumber_max)
+                                 for _ in range(self.dims[axis])})
+            _factors = [rand.randint(1, 8) for _ in _wavenumbers]
+            interpolated_function = interpolated_function_lookup[
+                self.directions[index]]
+            data *= sum((factor*interpolated_function(wavenumber, points[axis])
+                         for factor, wavenumber in zip(_factors, _wavenumbers)))
+            wavenumbers.append(np.array(_wavenumbers))
+            factors.append(np.array(_factors))
+
+        self._input_array[:] = data
+        self.plan.execute()
+
+        # zero all of the entries that do not correspond to a wavenumber.
+        exact_coefficients = np.ones(data.shape)
+        for index, axis in enumerate(self.axes):
+            dim = self.dims[axis]
+            sp = list(it.repeat(slice(None), len(data.shape)))
+            zero_indicies = (np.array(list(set(np.arange(0, dim))
+                                      - set(wavenumbers[index]))))
+            if len(zero_indicies) == 0:
+                pass
+            else:
+                sp[axis] = zero_indicies
+                mask = np.ones(data.shape)
+                mask[sp] = 0.0
+                exact_coefficients *= mask
+
+        # create the 'known' array of interpolation coefficients.
+        normalisation = self.plan.N/(2**len(self.axes))
+        for index, axis in enumerate(self.axes):
+            for factor, wavenumber in zip(factors[index], wavenumbers[index]):
+                sp = list(it.repeat(slice(None), len(data.shape)))
+                sp[axis] = wavenumber
+                exact_coefficients[sp] *= factor
+
+        error = np.mean(np.abs(self._output_array/normalisation
+                              - exact_coefficients))
+        return error < 1e-8
+
+def random_testcase():
+    ndims = rand.randint(1, 5)
+
+    axes = list()
+    directions = list()
+    dims = list()
+    for dim in range(ndims):
+        if ndims > 3:
+            dims.append(rand.randint(3, 10))
+        else:
+            dims.append(rand.randint(3, 100))
+        # throw out some dimensions randomly
+        if rand.choice([True, True, False]):
+            directions.append(rand.choice(real_transforms))
+            axes.append(dim)
+
+    if len(axes) == 0:
+        # reroll.
+        return random_testcase()
+    else:
+        return TestRealTransform(directions, dims, axes=axes)
+
+def meshgrid(*x):
+    if len(x) == 1:
+        # necessary for one-dimensional case to work correctly. x is a
+        # tuple due to the * operator.
+        return x
+    else:
+        args = np.atleast_1d(*x)
+        s0 = (1,)*len(args)
+        return list(map(np.squeeze,
+                        np.broadcast_arrays(*[x.reshape(s0[:i] + (-1,) + s0[i + 1::])
+                                              for i, x in enumerate(args)])))
+
+def grid(shape, axes, directions, aspect_ratio=None):
+    grids = [np.linspace(1, 2, dim) for dim in shape]
+    for index, (axis, direction) in enumerate(zip(axes, directions)):
+        grids[axis] = nodes_lookup[direction](shape[axes[index]])
+
+    return np.array(meshgrid(*grids))
+
+def empty_noncontiguous(shape):
+    """Create a non-contiguous empty array with shape `shape`.
+    """
+    offsets = lambda s: [rand.randint(0, 3) for _ in s]
+    strides = lambda s: [rand.randint(1, 3) for _ in s]
+    parent_left_offsets = offsets(shape)
+    parent_right_offsets = offsets(shape)
+    parent_strides = strides(shape)
+
+    parent_shape = list()
+    child_slice = list()
+    for index, length in enumerate(shape):
+        left_offset = parent_left_offsets[index]
+        right_offset = parent_right_offsets[index]
+        stride = parent_strides[index]
+        parent_shape.append(left_offset + stride*length + right_offset)
+        if right_offset == 0:
+            child_slice.append(slice(left_offset, None, stride))
+        else:
+            child_slice.append(slice(left_offset, -1*right_offset, stride))
+
+    child = np.empty(parent_shape)[child_slice]
+    if list(child.shape) != list(shape):
+        raise ValueError("The shape of the noncontiguous array is incorrect."
+                         " This is a bug.")
+    return child
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_r2r.py
+++ b/test/test_r2r.py
@@ -225,7 +225,7 @@ class TestRealTransform(object):
             else:
                 sp[axis] = zero_indicies
                 mask = numpy.ones(data.shape)
-                mask[sp] = 0.0
+                mask[tuple(sp)] = 0.0
                 exact_coefficients *= mask
 
         # create the 'known' array of interpolation coefficients.
@@ -234,7 +234,7 @@ class TestRealTransform(object):
             for factor, wavenumber in zip(factors[index], wavenumbers[index]):
                 sp = list(it.repeat(slice(None), len(data.shape)))
                 sp[axis] = wavenumber
-                exact_coefficients[sp] *= factor
+                exact_coefficients[tuple(sp)] *= factor
 
         error = numpy.mean(numpy.abs(self._output_array/normalisation
                               - exact_coefficients))
@@ -283,7 +283,7 @@ def empty_noncontiguous(shape):
         else:
             child_slice.append(slice(left_offset, -1*right_offset, stride))
 
-    child = numpy.empty(parent_shape)[child_slice]
+    child = numpy.empty(parent_shape)[tuple(child_slice)]
     if list(child.shape) != list(shape):
         raise ValueError("The shape of the noncontiguous array is incorrect."
                          " This is a bug.")

--- a/test/test_r2r.py
+++ b/test/test_r2r.py
@@ -127,7 +127,7 @@ class TestRealTransform(object):
     takes multiple arguments as input which set up the size and
     directions of the transform.
     '''
-    def __init__(self, directions, dims, axes=None, noncontiguous=True):
+    def __init__(self, directions=['FFTW_REDFT00'], dims=(16, ), axes=None, noncontiguous=True):
         """
         Arguments:
 

--- a/test/test_r2r.py
+++ b/test/test_r2r.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 #
 # Copyright 2014 Knowledge Economy Developments Ltd
-# Copyright 2014 David Wells
+# Copyright 2014 - 2016 David Wells
 #
 # Henry Gomersall
 # heng@kedevelopments.co.uk
@@ -40,8 +39,10 @@ from __future__ import division
 import itertools as it
 import random as rand
 import unittest
-import numpy as np
+import numpy
+
 import pyfftw
+from .test_pyfftw_base import run_test_suites
 
 discrete_sine_directions = ['FFTW_RODFT00', 'FFTW_RODFT01', 'FFTW_RODFT10',
                             'FFTW_RODFT11']
@@ -74,67 +75,58 @@ inverse_lookup = {
 }
 
 interpolated_function_lookup = {
-    'FFTW_RODFT00': lambda k, x: np.sin(np.pi*(k + 1)*x),
-    'FFTW_RODFT01': lambda k, x: np.sin(np.pi*(k + 0.5)*x),
-    'FFTW_RODFT10': lambda k, x: np.sin(np.pi*(k + 1)*x),
-    'FFTW_RODFT11': lambda k, x: np.sin(np.pi*(k + 0.5)*x),
+    'FFTW_RODFT00': lambda k, x: numpy.sin(numpy.pi*(k + 1)*x),
+    'FFTW_RODFT01': lambda k, x: numpy.sin(numpy.pi*(k + 0.5)*x),
+    'FFTW_RODFT10': lambda k, x: numpy.sin(numpy.pi*(k + 1)*x),
+    'FFTW_RODFT11': lambda k, x: numpy.sin(numpy.pi*(k + 0.5)*x),
 
-    'FFTW_REDFT00': lambda k, x: np.cos(np.pi*k*x),
-    'FFTW_REDFT10': lambda k, x: np.cos(np.pi*k*x),
-    'FFTW_REDFT01': lambda k, x: np.cos(np.pi*(k + 0.5)*x),
-    'FFTW_REDFT11': lambda k, x: np.cos(np.pi*(k + 0.5)*x),
+    'FFTW_REDFT00': lambda k, x: numpy.cos(numpy.pi*k*x),
+    'FFTW_REDFT10': lambda k, x: numpy.cos(numpy.pi*k*x),
+    'FFTW_REDFT01': lambda k, x: numpy.cos(numpy.pi*(k + 0.5)*x),
+    'FFTW_REDFT11': lambda k, x: numpy.cos(numpy.pi*(k + 0.5)*x),
 }
 
 nodes_lookup = {
-    'FFTW_RODFT00': lambda n: np.arange(n + 2)[1:-1]/(n + 1),
-    'FFTW_RODFT01': lambda n: np.arange(1, n + 1)/n,
-    'FFTW_RODFT10': lambda n: (np.arange(n) + 0.5)/n,
-    'FFTW_RODFT11': lambda n: (np.arange(n) + 0.5)/n,
+    'FFTW_RODFT00': lambda n: numpy.arange(n + 2)[1:-1]/(n + 1),
+    'FFTW_RODFT01': lambda n: numpy.arange(1, n + 1)/n,
+    'FFTW_RODFT10': lambda n: (numpy.arange(n) + 0.5)/n,
+    'FFTW_RODFT11': lambda n: (numpy.arange(n) + 0.5)/n,
 
-    'FFTW_REDFT00': lambda n: np.arange(n)/(n - 1),
-    'FFTW_REDFT10': lambda n: (np.arange(n) + 0.5)/n,
-    'FFTW_REDFT01': lambda n: np.arange(n)/n,
-    'FFTW_REDFT11': lambda n: (np.arange(n) + 0.5)/n,
+    'FFTW_REDFT00': lambda n: numpy.arange(n)/(n - 1),
+    'FFTW_REDFT10': lambda n: (numpy.arange(n) + 0.5)/n,
+    'FFTW_REDFT01': lambda n: numpy.arange(n)/n,
+    'FFTW_REDFT11': lambda n: (numpy.arange(n) + 0.5)/n,
 }
 
-class TestRandomRealTransforms(unittest.TestCase):
-    def test_normalisation(self):
-        for _ in range(50):
-            testcase = random_testcase()
-            self.assertTrue(testcase.test_normalisation())
-
-    def test_exact_data(self):
-        for _ in range(50):
-            testcase = random_testcase()
-            self.assertTrue(testcase.test_against_exact_data())
-
-    def test_random_data(self):
-        for _ in range(50):
-            testcase = random_testcase()
-            self.assertTrue(testcase.test_against_random_data())
-
-def test_lookups():
-    """Test that the lookup tables correctly pair node choices and
+class TestRealToRealLookups(unittest.TestCase):
+    '''Test that the lookup tables correctly pair node choices and
     function choices for using the DCT/DST as interpolators.
-    """
-    n = rand.randint(10, 20)
-    j = rand.randint(5, n) - 3
-    for transform in real_transforms:
-        nodes   = nodes_lookup[transform](n)
-        data    = interpolated_function_lookup[transform](j, nodes)
-        output  = np.empty_like(data)
-        plan    = pyfftw.FFTW(data, output, direction=[transform])
-        data[:] = interpolated_function_lookup[transform](j, nodes)
-        plan.execute()
-        tol = 4*j*n*1e-16
-        if transform == 'FFTW_RODFT00':
-            assert abs(output[j] - n - 1) < tol
-        elif transform == 'FFTW_REDFT00':
-            assert abs(output[j] - n + 1) < tol
-        else:
-            assert abs(output[j] - n) < tol
+    '''
+    def test_lookups(self):
+        n = rand.randint(10, 20)
+        j = rand.randint(5, n) - 3
+        for transform in real_transforms:
+            nodes   = nodes_lookup[transform](n)
+            data    = interpolated_function_lookup[transform](j, nodes)
+            output  = numpy.empty_like(data)
+            plan    = pyfftw.FFTW(data, output, direction=[transform])
+            data[:] = interpolated_function_lookup[transform](j, nodes)
+            plan.execute()
+            tol = 4*j*n*1e-16
+            if transform == 'FFTW_RODFT00':
+                self.assertTrue(abs(output[j] - n - 1) < tol)
+            elif transform == 'FFTW_REDFT00':
+                self.assertTrue(abs(output[j] - n + 1) < tol)
+            else:
+                self.assertTrue(abs(output[j] - n) < tol)
 
 class TestRealTransform(object):
+    '''Common set of functionality for performing tests on the real to
+    real transforms. This is not implemented as a distinct test class
+    (inheriting from unittest.TestCase) because its `__init__` method
+    takes multiple arguments as input which set up the size and
+    directions of the transform.
+    '''
     def __init__(self, directions, dims, axes=None, noncontiguous=True):
         """
         Arguments:
@@ -173,8 +165,8 @@ class TestRealTransform(object):
             self._input_array = empty_noncontiguous(dims)
             self._output_array = empty_noncontiguous(dims)
         else:
-            self._input_array = np.zeros(dims)
-            self._output_array = np.zeros(dims)
+            self._input_array = numpy.zeros(dims)
+            self._output_array = numpy.zeros(dims)
         self.plan = pyfftw.FFTW(self._input_array, self._output_array,
             axes=self.axes, direction=self.directions)
         self.inverse_plan = pyfftw.FFTW(self._input_array, self._output_array,
@@ -184,19 +176,19 @@ class TestRealTransform(object):
         return self._normalisation_factor == float(self.plan._get_N())
 
     def test_against_random_data(self):
-        data = np.random.rand(*self.dims)
+        data = numpy.random.rand(*self.dims)
         self._input_array[:] = data
         self.plan.execute()
         self._input_array[:] = self._output_array[:]
         self.inverse_plan.execute()
 
         data *= self._normalisation_factor
-        err = np.mean(np.abs(data - self._output_array))/self._normalisation_factor
+        err = numpy.mean(numpy.abs(data - self._output_array))/self._normalisation_factor
         return err < 10e-8
 
     def test_against_exact_data(self):
         points = grid(self.dims, self.axes, self.directions)
-        data   = np.ones_like(points[0])
+        data   = numpy.ones_like(points[0])
         wavenumbers = list()
         factors = list()
 
@@ -215,24 +207,24 @@ class TestRealTransform(object):
                 self.directions[index]]
             data *= sum((factor*interpolated_function(wavenumber, points[axis])
                          for factor, wavenumber in zip(_factors, _wavenumbers)))
-            wavenumbers.append(np.array(_wavenumbers))
-            factors.append(np.array(_factors))
+            wavenumbers.append(numpy.array(_wavenumbers))
+            factors.append(numpy.array(_factors))
 
         self._input_array[:] = data
         self.plan.execute()
 
         # zero all of the entries that do not correspond to a wavenumber.
-        exact_coefficients = np.ones(data.shape)
+        exact_coefficients = numpy.ones(data.shape)
         for index, axis in enumerate(self.axes):
             dim = self.dims[axis]
             sp = list(it.repeat(slice(None), len(data.shape)))
-            zero_indicies = (np.array(list(set(np.arange(0, dim))
+            zero_indicies = (numpy.array(list(set(numpy.arange(0, dim))
                                       - set(wavenumbers[index]))))
             if len(zero_indicies) == 0:
                 pass
             else:
                 sp[axis] = zero_indicies
-                mask = np.ones(data.shape)
+                mask = numpy.ones(data.shape)
                 mask[sp] = 0.0
                 exact_coefficients *= mask
 
@@ -244,9 +236,59 @@ class TestRealTransform(object):
                 sp[axis] = wavenumber
                 exact_coefficients[sp] *= factor
 
-        error = np.mean(np.abs(self._output_array/normalisation
+        error = numpy.mean(numpy.abs(self._output_array/normalisation
                               - exact_coefficients))
         return error < 1e-8
+
+
+def meshgrid(*x):
+    if len(x) == 1:
+        # necessary for one-dimensional case to work correctly. x is a
+        # tuple due to the * operator.
+        return x
+    else:
+        args = numpy.atleast_1d(*x)
+        s0 = (1,)*len(args)
+        return list(map(numpy.squeeze,
+                        numpy.broadcast_arrays(*[x.reshape(s0[:i] + (-1,) + s0[i + 1::])
+                                              for i, x in enumerate(args)])))
+
+
+def grid(shape, axes, directions, aspect_ratio=None):
+    grids = [numpy.linspace(1, 2, dim) for dim in shape]
+    for index, (axis, direction) in enumerate(zip(axes, directions)):
+        grids[axis] = nodes_lookup[direction](shape[axes[index]])
+
+    return numpy.array(meshgrid(*grids))
+
+
+def empty_noncontiguous(shape):
+    '''Create a non-contiguous empty array with shape `shape`.
+    '''
+    offsets = lambda s: [rand.randint(0, 3) for _ in s]
+    strides = lambda s: [rand.randint(1, 3) for _ in s]
+    parent_left_offsets = offsets(shape)
+    parent_right_offsets = offsets(shape)
+    parent_strides = strides(shape)
+
+    parent_shape = list()
+    child_slice = list()
+    for index, length in enumerate(shape):
+        left_offset = parent_left_offsets[index]
+        right_offset = parent_right_offsets[index]
+        stride = parent_strides[index]
+        parent_shape.append(left_offset + stride*length + right_offset)
+        if right_offset == 0:
+            child_slice.append(slice(left_offset, None, stride))
+        else:
+            child_slice.append(slice(left_offset, -1*right_offset, stride))
+
+    child = numpy.empty(parent_shape)[child_slice]
+    if list(child.shape) != list(shape):
+        raise ValueError("The shape of the noncontiguous array is incorrect."
+                         " This is a bug.")
+    return child
+
 
 def random_testcase():
     ndims = rand.randint(1, 5)
@@ -270,51 +312,29 @@ def random_testcase():
     else:
         return TestRealTransform(directions, dims, axes=axes)
 
-def meshgrid(*x):
-    if len(x) == 1:
-        # necessary for one-dimensional case to work correctly. x is a
-        # tuple due to the * operator.
-        return x
-    else:
-        args = np.atleast_1d(*x)
-        s0 = (1,)*len(args)
-        return list(map(np.squeeze,
-                        np.broadcast_arrays(*[x.reshape(s0[:i] + (-1,) + s0[i + 1::])
-                                              for i, x in enumerate(args)])))
 
-def grid(shape, axes, directions, aspect_ratio=None):
-    grids = [np.linspace(1, 2, dim) for dim in shape]
-    for index, (axis, direction) in enumerate(zip(axes, directions)):
-        grids[axis] = nodes_lookup[direction](shape[axes[index]])
+class RealToRealNormalisation(unittest.TestCase):
+    def test_normalisation(self):
+        for _ in range(50):
+            testcase = random_testcase()
+            self.assertTrue(testcase.test_normalisation())
 
-    return np.array(meshgrid(*grids))
+class RealToRealExactData(unittest.TestCase):
+    def test_exact_data(self):
+        for _ in range(50):
+            testcase = random_testcase()
+            self.assertTrue(testcase.test_against_exact_data())
 
-def empty_noncontiguous(shape):
-    """Create a non-contiguous empty array with shape `shape`.
-    """
-    offsets = lambda s: [rand.randint(0, 3) for _ in s]
-    strides = lambda s: [rand.randint(1, 3) for _ in s]
-    parent_left_offsets = offsets(shape)
-    parent_right_offsets = offsets(shape)
-    parent_strides = strides(shape)
+class RealToRealRandomData(unittest.TestCase):
+    def test_random_data(self):
+        for _ in range(50):
+            testcase = random_testcase()
+            self.assertTrue(testcase.test_against_random_data())
 
-    parent_shape = list()
-    child_slice = list()
-    for index, length in enumerate(shape):
-        left_offset = parent_left_offsets[index]
-        right_offset = parent_right_offsets[index]
-        stride = parent_strides[index]
-        parent_shape.append(left_offset + stride*length + right_offset)
-        if right_offset == 0:
-            child_slice.append(slice(left_offset, None, stride))
-        else:
-            child_slice.append(slice(left_offset, -1*right_offset, stride))
-
-    child = np.empty(parent_shape)[child_slice]
-    if list(child.shape) != list(shape):
-        raise ValueError("The shape of the noncontiguous array is incorrect."
-                         " This is a bug.")
-    return child
+test_cases = (TestRealToRealLookups,
+              RealToRealNormalisation,
+              RealToRealExactData,
+              RealToRealRandomData,)
 
 if __name__ == '__main__':
-    unittest.main()
+    run_test_suites(test_cases)


### PR DESCRIPTION
I have rebased the nice work by @drwells from #95 on current master, so the first 20 or so commits here are the ones from that PR with modifications made only as necessary to resolve conflicts.

That initial rebase went fairly quickly, but then it took an hour or two to track down a few mistakes I made  (fixed in 527c4e3 and d7ee369).

I updated the `threads` and `planner_effort` handling to be consistent with pyFFTW 0.11+ and added the n-dimensional variants of the DCT and DST introduced in SciPy 1.0. Currently these are implemented by separable application of 1D transforms rather than trying to implement an n-dimensional R2R builder.

I have copied over the TODO list from a comment in #95 below for quick reference:

- [ ] Tests for builder functions
- [ ] Tests for failure modes
- [x] Improve SciPy interface's handling of `None` with orthogonalization
- [ ] Implement padding and truncation for the `dct` and `dst` functions
- [x] Clean up scipy tests
- [x] Clean up real to real tests (use existing infrastructure)
- [ ] Improve `_Xfftn`
- [x] Update documentation to describe real to real features 

New items I added
- [x] flexible defaults for threads and planner_effort in the builders and interfaces
- [x] dctn, idctn, dstn, dctn added to interfaces.scipy_fftpack
- [x] test axis argument of dct, etc. in the scipy interfaces tests
- [x] add tests for n-dimensional R2R transforms in the scipy interfaces
- [ ] n-dimensional builders for dctn, dstn?

If anyone want to volunteer to work on any of the remaining items, please do so.