### PR TITLE
remove import of non-public _fftpack within the scipy interfaces

### DIFF
--- a/pyfftw/interfaces/scipy_fftpack.py
+++ b/pyfftw/interfaces/scipy_fftpack.py
@@ -65,7 +65,7 @@ import numpy
 from scipy.fftpack import (dct, idct, dst, idst, diff, tilbert, itilbert,
         hilbert, ihilbert, cs_diff, sc_diff, ss_diff, cc_diff,
         shift, fftshift, ifftshift, fftfreq, rfftfreq,
-        convolve, _fftpack)
+        convolve)
 
 # a next_fast_len specific to pyFFTW is used in place of the scipy.fftpack one
 from ..pyfftw import next_fast_len

--- a/test/test_pyfftw_scipy_interface.py
+++ b/test/test_pyfftw_scipy_interface.py
@@ -61,8 +61,7 @@ funcs = ('fft','ifft', 'fft2', 'ifft2', 'fftn', 'ifftn',
 
 acquired_names = ('dct', 'idct', 'diff', 'tilbert', 'itilbert', 'hilbert',
         'ihilbert', 'cs_diff', 'sc_diff', 'ss_diff', 'cc_diff', 'shift',
-        'fftshift', 'ifftshift', 'fftfreq', 'rfftfreq', 'convolve',
-        '_fftpack')
+        'fftshift', 'ifftshift', 'fftfreq', 'rfftfreq', 'convolve')
 
 def make_complex_data(shape, dtype):
     ar, ai = dtype(numpy.random.randn(2, *shape))


### PR DESCRIPTION
This PR removes the import of the non-public `_fftpack` submodule.

SciPy is currently in the process of adding pypocketfft as a replacement for FFTPack in scipy/scipy/#10238. At one point during file reorganization this broke the PyFFTW scipy interfaces because the `_fftpack` module had been moved. 

We later decided to leave it in its original location, but in either case, I don't think pyFFTW should be importing this non-public part of the API.

@peterbell10:  I assume this is the source of the issue you mentioned to me or was there something else?

On a related note, that same SciPy PR adds a `scipy.fft` module that is going to be encouraged for new code (although the `scipy.fftpack` API will be preserved for backwards compatibility). We can discuss that along with the new `scipy.fft` backend design later in a separate issue once it is a bit farther along.
