### PR TITLE
scipy.fft interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,11 @@ python:
   - 3.5
   - 3.6
 
+matrix:
+  include:
+    - python: 3.7
+      env: SCIPY_WHEELS="https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com/"
+
 branches:
     except:
         - gh-pages
@@ -32,9 +37,16 @@ before_install:
   - conda info -a
 
 install:
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION nomkl numpy scipy cython setuptools
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION nomkl numpy cython setuptools
   - conda install -q -n test-environment dask=0.15.0 || true
-  - source activate test-environment
+  - |
+    if [ -z "$SCIPY_WHEELS" ]; then
+      conda install -q -n test-environment scipy
+      source activate test-environment
+    else
+      source activate test-environment
+      pip install --pre --upgrade --timeout=60 -f "$SCIPY_WHEELS" scipy
+    fi
   - python setup.py -v build_ext --inplace
 
 script:

--- a/docs/source/pyfftw/interfaces/interfaces.rst
+++ b/docs/source/pyfftw/interfaces/interfaces.rst
@@ -5,6 +5,7 @@
    :hidden:
 
    numpy_fft
+   scipy_fft
    scipy_fftpack
    dask_fft
 

--- a/docs/source/pyfftw/interfaces/scipy_fft.rst
+++ b/docs/source/pyfftw/interfaces/scipy_fft.rst
@@ -2,4 +2,4 @@
 ==============================
 
 .. automodule:: pyfftw.interfaces.scipy_fft
-   :members: fft, ifft, fft2, ifft2, fftn, ifftn rfft, irfft, rfft2, irfft2, rfftn, irfftn, hfft, ihfft, next_fast_len
+   :members: fft, ifft, fft2, ifft2, fftn, ifftn, rfft, irfft, rfft2, irfft2, rfftn, irfftn, hfft, ihfft, next_fast_len

--- a/docs/source/pyfftw/interfaces/scipy_fft.rst
+++ b/docs/source/pyfftw/interfaces/scipy_fft.rst
@@ -1,0 +1,5 @@
+:mod:`scipy.fft` interface
+==============================
+
+.. automodule:: pyfftw.interfaces.scipy_fft
+   :members: fft, ifft, fft2, ifft2, fftn, ifftn rfft, irfft, rfft2, irfft2, rfftn, irfftn, hfft, ihfft, next_fast_len

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -124,7 +124,7 @@ backend to speed up :func:`scipy.signal.fftconvolve`.
 
    t = Timer(lambda: scipy.signal.fftconvolve(a, b))
 
-   print('Time with scipy.fft: %1.3f seconds' % t.timeit(number=100))
+   print('Time with scipy.fft default backend: %1.3f seconds' % t.timeit(number=100))
 
    # Configure PyFFTW to use all cores (the default is single-threaded)
    pyfftw.config.NUM_THREADS = multiprocessing.cpu_count()
@@ -136,15 +136,15 @@ backend to speed up :func:`scipy.signal.fftconvolve`.
         # Turn on the cache for optimum performance
         pyfftw.interfaces.cache.enable()
 
-        print('Time with monkey patched scipy_fftpack: %1.3f seconds' %
+        print('Time with pyfftw backend installed: %1.3f seconds' %
                t.timeit(number=100))
 
 which outputs something like:
 
 .. code-block:: none
 
-   Time with scipy.fft: 0.598 seconds
-   Time with monkey patched scipy_fft: 0.251 seconds
+   Time with scipy.fft default backend: 0.598 seconds
+   Time with pyfftw backend installed: 0.251 seconds
 
 Prior to SciPy 1.4 it was necessary to monkey patch the libraries
 directly. :mod:`pyfftw.interfaces.numpy_fft` and

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -124,17 +124,19 @@ backend to speed up :func:`scipy.signal.fftconvolve`.
 
    t = Timer(lambda: scipy.signal.fftconvolve(a, b))
 
-   print('Time with scipy.fft default backend: %1.3f seconds' % t.timeit(number=100))
+   print('Time with scipy.fft default backend: %1.3f seconds' %
+         t.timeit(number=100))
 
    # Configure PyFFTW to use all cores (the default is single-threaded)
    pyfftw.config.NUM_THREADS = multiprocessing.cpu_count()
 
    # Use the backend pyfftw.interfaces.scipy_fft
    with scipy.fft.set_backend(pyfftw.interfaces.scipy_fft):
-        scipy.signal.fftconvolve(a, b) # We cheat a bit by doing the planning first
-
         # Turn on the cache for optimum performance
         pyfftw.interfaces.cache.enable()
+
+         # We cheat a bit by doing the planning first
+        scipy.signal.fftconvolve(a, b)
 
         print('Time with pyfftw backend installed: %1.3f seconds' %
                t.timeit(number=100))
@@ -143,8 +145,8 @@ which outputs something like:
 
 .. code-block:: none
 
-   Time with scipy.fft default backend: 0.598 seconds
-   Time with pyfftw backend installed: 0.251 seconds
+   Time with scipy.fft default backend: 0.267 seconds
+   Time with pyfftw backend installed: 0.162 seconds
 
 Prior to SciPy 1.4 it was necessary to monkey patch the libraries
 directly. :mod:`pyfftw.interfaces.numpy_fft` and
@@ -156,7 +158,7 @@ possible to use them as replacements at run-time through monkey patching.
 
    # Monkey patch fftpack with pyfftw.interfaces.scipy_fftpack
    scipy.fftpack = pyfftw.interfaces.scipy_fftpack
-   scipy.signal.fftconvolve(a, b) # We cheat a bit by doing the planning first
+   scipy.signal.fftconvolve(a, b)
 
 Note that prior to SciPy 0.16, it was necessary to patch the individual
 functions in ``scipy.signal.signaltools``. For example:

--- a/pyfftw/interfaces/__init__.py
+++ b/pyfftw/interfaces/__init__.py
@@ -259,17 +259,15 @@ try:
 except ImportError:
     pass
 else:
+    from distutils.version import LooseVersion as _LooseVersion
+
+    has_scipy_fft = _LooseVersion(scipy.__version__) >= _LooseVersion('1.4.0')
+    del _LooseVersion
     del scipy
+
     from . import scipy_fftpack
-
-
-try:
-    import scipy.fft
-except ImportError:
-    pass
-else:
-    del scipy
-    from . import scipy_fft
+    if has_scipy_fft:
+        from . import scipy_fft
 
 
 fft_wrap = None

--- a/pyfftw/interfaces/__init__.py
+++ b/pyfftw/interfaces/__init__.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
 '''The :mod:`pyfftw.interfaces` package provides interfaces to :mod:`pyfftw`
-that implement the API of other, more commonly used FFT libraries;
-specifically :mod:`numpy.fft` and :mod:`scipy.fftpack`. The
-intention is to satisfy two clear use cases:
+that implement the API of other, more commonly used FFT libraries; specifically
+:mod:`numpy.fft`, :mod:`scipy.fft` and :mod:`scipy.fftpack`. The intention is
+to satisfy two clear use cases:
 
 1. Simple, clean and well established interfaces to using :mod:`pyfftw`,
    removing the requirement for users to know or understand about creating and
@@ -79,24 +79,24 @@ having performed the transform once.
 Implemented Functions
 ---------------------
 
-The implemented functions are listed below. :mod:`numpy.fft` is implemented
-by :mod:`pyfftw.interfaces.numpy_fft` and :mod:`scipy.fftpack` by
-:mod:`pyfftw.interfaces.scipy_fftpack`. All the implemented functions are
-extended by the use of additional arguments, which are
+The implemented functions are listed below. :mod:`numpy.fft` is implemented by
+:mod:`pyfftw.interfaces.numpy_fft`, :mod:`scipy.fftpack` by
+:mod:`pyfftw.interfaces.scipy_fftpack` and :mod:`scipy.fft` by
+:mod:`pyfftw.interfaces.scipy_fft`. All the implemented functions are extended
+by the use of additional arguments, which are
 :ref:`documented below<interfaces_additional_args>`.
 
-Not all the functions provided by :mod:`numpy.fft` and :mod:`scipy.fftpack`
-are implemented by :mod:`pyfftw.interfaces`. In the case where a function is
-not implemented, the function is imported into the namespace from the
-corresponding library. This means that all the documented functionality of the
-library *is* provided through :mod:`pyfftw.interfaces`.
+Not all the functions provided by :mod:`numpy.fft`, :mod:`scipy.fft` and
+:mod:`scipy.fftpack` are implemented by :mod:`pyfftw.interfaces`. In the case
+where a function is not implemented, the function is imported into the
+namespace from the corresponding library. This means that all the documented
+functionality of the library *is* provided through :mod:`pyfftw.interfaces`.
 
-One known caveat is that repeated axes are potentially handled
-differently. This is certainly the case for :mod:`numpy.fft` and probably
-also true for :mod:`scipy.fftpack` (though it is not defined in the
-docs); axes that are repeated in the axes argument are considered only once, as
-compared to :mod:`numpy.fft` in which repeated axes results in the DFT
-being taken along that axes as many times as the axis occurs.
+One known caveat is that repeated axes are handled differently. Axes that are
+repeated in the ``axes`` argument are considered only once and without error;
+as compared to :mod:`numpy.fft` in which repeated axes results in the DFT being
+taken along that axes as many times as the axis occurs, or to :mod:`scipy`
+where an error is raised.
 
 :mod:`~pyfftw.interfaces.numpy_fft`
 """""""""""""""""""""""""""""""""""
@@ -115,6 +115,25 @@ being taken along that axes as many times as the axis occurs.
 * :func:`pyfftw.interfaces.numpy_fft.irfftn`
 * :func:`pyfftw.interfaces.numpy_fft.hfft`
 * :func:`pyfftw.interfaces.numpy_fft.ihfft`
+
+:mod:`~pyfftw.interfaces.scipy_fft`
+"""""""""""""""""""""""""""""""""""""""
+
+* :func:`pyfftw.interfaces.scipy_fft.fft`
+* :func:`pyfftw.interfaces.scipy_fft.ifft`
+* :func:`pyfftw.interfaces.scipy_fft.fft2`
+* :func:`pyfftw.interfaces.scipy_fft.ifft2`
+* :func:`pyfftw.interfaces.scipy_fft.fftn`
+* :func:`pyfftw.interfaces.scipy_fft.ifftn`
+* :func:`pyfftw.interfaces.scipy_fft.rfft`
+* :func:`pyfftw.interfaces.scipy_fft.irfft`
+* :func:`pyfftw.interfaces.scipy_fft.rfft2`
+* :func:`pyfftw.interfaces.scipy_fft.irfft2`
+* :func:`pyfftw.interfaces.scipy_fft.rfftn`
+* :func:`pyfftw.interfaces.scipy_fft.irfftn`
+* :func:`pyfftw.interfaces.scipy_fft.hfft`
+* :func:`pyfftw.interfaces.scipy_fft.ihfft`
+* :func:`pyfftw.interfaces.scipy_fft.next_fast_len`
 
 :mod:`~pyfftw.interfaces.scipy_fftpack`
 """""""""""""""""""""""""""""""""""""""
@@ -153,12 +172,11 @@ being taken along that axes as many times as the axis occurs.
 Additional Arguments
 --------------------
 
-In addition to the equivalent arguments in :mod:`numpy.fft` and
-:mod:`scipy.fftpack`, all these functions also add several additional
+In addition to the equivalent arguments in :mod:`numpy.fft`, :mod:`scipy.fft`
+and :mod:`scipy.fftpack`, all these functions also add several additional
 arguments for finer control over the FFT. These additional arguments are
-largely a subset of the
-keyword arguments in :mod:`pyfftw.builders` with a few exceptions and with
-different defaults.
+largely a subset of the keyword arguments in :mod:`pyfftw.builders` with a few
+exceptions and with different defaults.
 
 * ``overwrite_input``: Whether or not the input array can be
   overwritten during the transform. This sometimes results in a faster
@@ -167,9 +185,9 @@ different defaults.
   Unlike with :mod:`pyfftw.builders`, this argument is included with
   *every* function in this package.
 
-  In :mod:`~pyfftw.interfaces.scipy_fftpack`, this argument is replaced
-  by ``overwrite_x``, to which it is equivalent (albeit at the same
-  position).
+  In :mod:`~pyfftw.interfaces.scipy_fftpack` and
+  :mod:`~pyfftw.interfaces.scipy_fft`, this argument is replaced by
+  ``overwrite_x``, to which it is equivalent (albeit at the same position).
 
   The default is ``False`` to be consistent with :mod:`numpy.fft`.
 
@@ -243,6 +261,15 @@ except ImportError:
 else:
     del scipy
     from . import scipy_fftpack
+
+
+try:
+    import scipy.fft
+except ImportError:
+    pass
+else:
+    del scipy
+    from . import scipy_fft
 
 
 fft_wrap = None

--- a/pyfftw/interfaces/scipy_fft.py
+++ b/pyfftw/interfaces/scipy_fft.py
@@ -59,6 +59,8 @@ from scipy.fft import (dct, idct, dst, idst, dctn, idctn, dstn, idstn,
 # a next_fast_len specific to pyFFTW is used in place of the scipy.fft one
 from ..pyfftw import next_fast_len
 
+import scipy.fft as _fft
+
 
 __all__ = ['fft', 'ifft', 'fft2', 'ifft2', 'fftn', 'ifftn',
            'rfft', 'irfft', 'rfft2', 'irfft2', 'rfftn', 'irfftn',
@@ -67,6 +69,30 @@ __all__ = ['fft', 'ifft', 'fft2', 'ifft2', 'fftn', 'ifftn',
            'fftshift', 'ifftshift', 'fftfreq', 'rfftfreq']
 
 
+# Backend support for scipy.fft
+
+_implemented = {}
+
+__ua_domain__ = 'numpy.scipy.fft'
+
+
+def __ua_function__(method, args, kwargs):
+    fn = _implemented.get(method, None)
+    if fn is None:
+        return NotImplemented
+    return fn(*args, **kwargs)
+
+
+def _implements(scipy_func):
+    '''Decorator adds function to the dictionary of implemented functions'''
+    def inner(func):
+        _implemented[scipy_func] = func
+        return func
+
+    return inner
+
+
+@_implements(_fft.fft)
 def fft(x, n=None, axis=-1, norm=None, overwrite_x=False,
         planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
@@ -79,6 +105,7 @@ def fft(x, n=None, axis=-1, norm=None, overwrite_x=False,
     return numpy_fft.fft(x, n, axis, norm, overwrite_x, planner_effort,
             threads, auto_align_input, auto_contiguous)
 
+@_implements(_fft.ifft)
 def ifft(x, n=None, axis=-1, norm=None, overwrite_x=False,
         planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
@@ -92,6 +119,7 @@ def ifft(x, n=None, axis=-1, norm=None, overwrite_x=False,
             planner_effort, threads, auto_align_input, auto_contiguous)
 
 
+@_implements(_fft.fft2)
 def fft2(x, shape=None, axes=(-2,-1), norm=None, overwrite_x=False,
         planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
@@ -105,6 +133,7 @@ def fft2(x, shape=None, axes=(-2,-1), norm=None, overwrite_x=False,
             planner_effort, threads, auto_align_input, auto_contiguous)
 
 
+@_implements(_fft.ifft2)
 def ifft2(x, shape=None, axes=(-2,-1), norm=None, overwrite_x=False,
         planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
@@ -118,6 +147,7 @@ def ifft2(x, shape=None, axes=(-2,-1), norm=None, overwrite_x=False,
             planner_effort, threads, auto_align_input, auto_contiguous)
 
 
+@_implements(_fft.fftn)
 def fftn(x, shape=None, axes=None, norm=None, overwrite_x=False,
         planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
@@ -141,6 +171,7 @@ def fftn(x, shape=None, axes=None, norm=None, overwrite_x=False,
             planner_effort, threads, auto_align_input, auto_contiguous)
 
 
+@_implements(_fft.ifftn)
 def ifftn(x, shape=None, axes=None, norm=None, overwrite_x=False,
         planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
@@ -164,6 +195,7 @@ def ifftn(x, shape=None, axes=None, norm=None, overwrite_x=False,
             planner_effort, threads, auto_align_input, auto_contiguous)
 
 
+@_implements(_fft.rfft)
 def rfft(x, n=None, axis=-1, norm=None, overwrite_x=False,
         planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
@@ -176,6 +208,7 @@ def rfft(x, n=None, axis=-1, norm=None, overwrite_x=False,
     return numpy_fft.rfft(x, n, axis, norm, overwrite_x, planner_effort,
                           threads, auto_align_input, auto_contiguous)
 
+@_implements(_fft.irfft)
 def irfft(x, n=None, axis=-1, norm=None, overwrite_x=False,
         planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
@@ -189,6 +222,7 @@ def irfft(x, n=None, axis=-1, norm=None, overwrite_x=False,
                            threads, auto_align_input, auto_contiguous)
 
 
+@_implements(_fft.rfft2)
 def rfft2(x, shape=None, axes=(-2,-1), norm=None, overwrite_x=False,
         planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
@@ -202,6 +236,7 @@ def rfft2(x, shape=None, axes=(-2,-1), norm=None, overwrite_x=False,
             planner_effort, threads, auto_align_input, auto_contiguous)
 
 
+@_implements(_fft.irfft2)
 def irfft2(x, shape=None, axes=(-2,-1), norm=None, overwrite_x=False,
         planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
@@ -215,6 +250,7 @@ def irfft2(x, shape=None, axes=(-2,-1), norm=None, overwrite_x=False,
             planner_effort, threads, auto_align_input, auto_contiguous)
 
 
+@_implements(_fft.rfftn)
 def rfftn(x, shape=None, axes=None, norm=None, overwrite_x=False,
         planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
@@ -238,6 +274,7 @@ def rfftn(x, shape=None, axes=None, norm=None, overwrite_x=False,
             planner_effort, threads, auto_align_input, auto_contiguous)
 
 
+@_implements(_fft.irfftn)
 def irfftn(x, shape=None, axes=None, norm=None, overwrite_x=False,
         planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
@@ -261,6 +298,7 @@ def irfftn(x, shape=None, axes=None, norm=None, overwrite_x=False,
             planner_effort, threads, auto_align_input, auto_contiguous)
 
 
+@_implements(_fft.hfft)
 def hfft(x, n=None, axis=-1, norm=None, overwrite_x=False,
         planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
@@ -273,6 +311,7 @@ def hfft(x, n=None, axis=-1, norm=None, overwrite_x=False,
     return numpy_fft.hfft(x, n, axis, norm, overwrite_x, planner_effort,
                           threads, auto_align_input, auto_contiguous)
 
+@_implements(_fft.ihfft)
 def ihfft(x, n=None, axis=-1, norm=None, overwrite_x=False,
         planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):

--- a/pyfftw/interfaces/scipy_fft.py
+++ b/pyfftw/interfaces/scipy_fft.py
@@ -60,6 +60,7 @@ from scipy.fft import (dct, idct, dst, idst, dctn, idctn, dstn, idstn,
 from ..pyfftw import next_fast_len
 
 import scipy.fft as _fft
+import numpy as np
 
 
 __all__ = ['fft', 'ifft', 'fft2', 'ifft2', 'fftn', 'ifftn',
@@ -205,6 +206,10 @@ def rfft(x, n=None, axis=-1, norm=None, overwrite_x=False,
     the rest of the arguments are documented
     in the :ref:`additional argument docs<interfaces_additional_args>`.
     '''
+    x = np.asanyarray(x)
+    if not np.isrealobj(x):
+        raise TypeError('x must be a real sequence')
+
     return numpy_fft.rfft(x, n, axis, norm, overwrite_x, planner_effort,
                           threads, auto_align_input, auto_contiguous)
 
@@ -232,6 +237,10 @@ def rfft2(x, shape=None, axes=(-2,-1), norm=None, overwrite_x=False,
     the rest of the arguments are documented
     in the :ref:`additional argument docs<interfaces_additional_args>`.
     '''
+    x = np.asanyarray(x)
+    if not np.isrealobj(x):
+        raise TypeError('x must be a real sequence')
+
     return numpy_fft.rfft2(x, shape, axes, norm, overwrite_x,
             planner_effort, threads, auto_align_input, auto_contiguous)
 
@@ -260,6 +269,10 @@ def rfftn(x, shape=None, axes=None, norm=None, overwrite_x=False,
     the rest of the arguments are documented
     in the :ref:`additional argument docs<interfaces_additional_args>`.
     '''
+    x = np.asanyarray(x)
+    if not np.isrealobj(x):
+        raise TypeError('x must be a real sequence')
+
 
     if shape is not None:
         if ((axes is not None and len(shape) != len(axes)) or
@@ -321,5 +334,9 @@ def ihfft(x, n=None, axis=-1, norm=None, overwrite_x=False,
     the rest of the arguments are documented
     in the :ref:`additional argument docs<interfaces_additional_args>`.
     '''
+    x = np.asanyarray(x)
+    if not np.isrealobj(x):
+        raise TypeError('x must be a real sequence')
+
     return numpy_fft.ihfft(x, n, axis, norm, overwrite_x, planner_effort,
                            threads, auto_align_input, auto_contiguous)

--- a/pyfftw/interfaces/scipy_fft.py
+++ b/pyfftw/interfaces/scipy_fft.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 #
-# Henry Gomersall
-# heng@kedevelopments.co.uk
+# Copyright 2019, The pyFFTW developers
 #
 # All rights reserved.
 #
@@ -207,7 +206,7 @@ def rfft(x, n=None, axis=-1, norm=None, overwrite_x=False,
     in the :ref:`additional argument docs<interfaces_additional_args>`.
     '''
     x = np.asanyarray(x)
-    if not np.isrealobj(x):
+    if x.dtype.kind == 'c':
         raise TypeError('x must be a real sequence')
 
     return numpy_fft.rfft(x, n, axis, norm, overwrite_x, planner_effort,
@@ -238,7 +237,7 @@ def rfft2(x, shape=None, axes=(-2,-1), norm=None, overwrite_x=False,
     in the :ref:`additional argument docs<interfaces_additional_args>`.
     '''
     x = np.asanyarray(x)
-    if not np.isrealobj(x):
+    if x.dtype.kind == 'c':
         raise TypeError('x must be a real sequence')
 
     return numpy_fft.rfft2(x, shape, axes, norm, overwrite_x,
@@ -270,7 +269,7 @@ def rfftn(x, shape=None, axes=None, norm=None, overwrite_x=False,
     in the :ref:`additional argument docs<interfaces_additional_args>`.
     '''
     x = np.asanyarray(x)
-    if not np.isrealobj(x):
+    if x.dtype.kind == 'c':
         raise TypeError('x must be a real sequence')
 
 
@@ -335,7 +334,7 @@ def ihfft(x, n=None, axis=-1, norm=None, overwrite_x=False,
     in the :ref:`additional argument docs<interfaces_additional_args>`.
     '''
     x = np.asanyarray(x)
-    if not np.isrealobj(x):
+    if x.dtype.kind == 'c':
         raise TypeError('x must be a real sequence')
 
     return numpy_fft.ihfft(x, n, axis, norm, overwrite_x, planner_effort,

--- a/pyfftw/interfaces/scipy_fft.py
+++ b/pyfftw/interfaces/scipy_fft.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python
+#
+# Henry Gomersall
+# heng@kedevelopments.co.uk
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+'''
+This module implements those functions that replace aspects of the
+:mod:`scipy.fft` module. This module *provides* the entire documented namespace
+of :mod:`scipy.fft`, but those functions that are not included here are
+imported directly from :mod:`scipy.fft`.
+
+The exceptions raised by each of these functions are mostly as per their
+equivalents in :mod:`scipy.fft`, though there are some corner cases in which
+this may not be true.
+
+Some corner (mis)usages of :mod:`scipy.fft` may not transfer neatly.
+For example, using :func:`scipy.fft.fft2` with a non 1D array and
+a 2D `shape` argument will return without exception whereas
+:func:`pyfftw.interfaces.scipy_fft.fft2` will raise a `ValueError`.
+
+'''
+
+from . import numpy_fft
+
+# Complete the namespace (these are not actually used in this module)
+from scipy.fft import (dct, idct, dst, idst, dctn, idctn, dstn, idstn,
+                       hfft2, ihfft2, hfftn, ihfftn,
+                       fftshift, ifftshift, fftfreq, rfftfreq)
+
+# a next_fast_len specific to pyFFTW is used in place of the scipy.fft one
+from ..pyfftw import next_fast_len
+
+
+__all__ = ['fft', 'ifft', 'fft2', 'ifft2', 'fftn', 'ifftn',
+           'rfft', 'irfft', 'rfft2', 'irfft2', 'rfftn', 'irfftn',
+           'hfft', 'ihfft', 'hfft2', 'ihfft2', 'hfftn', 'ihfftn',
+           'dct', 'idct', 'dst', 'idst', 'dctn', 'idctn', 'dstn', 'idstn',
+           'fftshift', 'ifftshift', 'fftfreq', 'rfftfreq']
+
+
+def fft(x, n=None, axis=-1, norm=None, overwrite_x=False,
+        planner_effort=None, threads=None,
+        auto_align_input=True, auto_contiguous=True):
+    '''Perform a 1D FFT.
+
+    The first five arguments are as per :func:`scipy.fft.fft`;
+    the rest of the arguments are documented
+    in the :ref:`additional argument docs<interfaces_additional_args>`.
+    '''
+    return numpy_fft.fft(x, n, axis, norm, overwrite_x, planner_effort,
+            threads, auto_align_input, auto_contiguous)
+
+def ifft(x, n=None, axis=-1, norm=None, overwrite_x=False,
+        planner_effort=None, threads=None,
+        auto_align_input=True, auto_contiguous=True):
+    '''Perform a 1D inverse FFT.
+
+    The first five arguments are as per :func:`scipy.fft.ifft`;
+    the rest of the arguments are documented
+    in the :ref:`additional argument docs<interfaces_additional_args>`.
+    '''
+    return numpy_fft.ifft(x, n, axis, norm, overwrite_x,
+            planner_effort, threads, auto_align_input, auto_contiguous)
+
+
+def fft2(x, shape=None, axes=(-2,-1), norm=None, overwrite_x=False,
+        planner_effort=None, threads=None,
+        auto_align_input=True, auto_contiguous=True):
+    '''Perform a 2D FFT.
+
+    The first three arguments are as per :func:`scipy.fft.fft2`;
+    the rest of the arguments are documented
+    in the :ref:`additional argument docs<interfaces_additional_args>`.
+    '''
+    return numpy_fft.fft2(x, shape, axes, norm, overwrite_x,
+            planner_effort, threads, auto_align_input, auto_contiguous)
+
+
+def ifft2(x, shape=None, axes=(-2,-1), norm=None, overwrite_x=False,
+        planner_effort=None, threads=None,
+        auto_align_input=True, auto_contiguous=True):
+    '''Perform a 2D inverse FFT.
+
+    The first five arguments are as per :func:`scipy.fft.ifft2`;
+    the rest of the arguments are documented in the
+    :ref:`additional argument docs <interfaces_additional_args>`.
+    '''
+    return numpy_fft.ifft2(x, shape, axes, norm, overwrite_x,
+            planner_effort, threads, auto_align_input, auto_contiguous)
+
+
+def fftn(x, shape=None, axes=None, norm=None, overwrite_x=False,
+        planner_effort=None, threads=None,
+        auto_align_input=True, auto_contiguous=True):
+    '''Perform an n-D FFT.
+
+    The first five arguments are as per :func:`scipy.fft.fftn`;
+    the rest of the arguments are documented
+    in the :ref:`additional argument docs<interfaces_additional_args>`.
+    '''
+
+    if shape is not None:
+        if ((axes is not None and len(shape) != len(axes)) or
+                (axes is None and len(shape) != x.ndim)):
+            raise ValueError('Shape error: In order to maintain better '
+                    'compatibility with scipy.fft.fftn, a ValueError '
+                    'is raised when the length of the shape argument is '
+                    'not the same as x.ndim if axes is None or the length '
+                    'of axes if it is not. If this is problematic, consider '
+                    'using the numpy interface.')
+    return numpy_fft.fftn(x, shape, axes, norm, overwrite_x,
+            planner_effort, threads, auto_align_input, auto_contiguous)
+
+
+def ifftn(x, shape=None, axes=None, norm=None, overwrite_x=False,
+        planner_effort=None, threads=None,
+        auto_align_input=True, auto_contiguous=True):
+    '''Perform an n-D inverse FFT.
+
+    The first five arguments are as per :func:`scipy.fft.ifftn`;
+    the rest of the arguments are documented
+    in the :ref:`additional argument docs<interfaces_additional_args>`.
+    '''
+    if shape is not None:
+        if ((axes is not None and len(shape) != len(axes)) or
+                (axes is None and len(shape) != x.ndim)):
+            raise ValueError('Shape error: In order to maintain better '
+                    'compatibility with scipy.fft.ifftn, a ValueError '
+                    'is raised when the length of the shape argument is '
+                    'not the same as x.ndim if axes is None or the length '
+                    'of axes if it is not. If this is problematic, consider '
+                    'using the numpy interface.')
+
+    return numpy_fft.ifftn(x, shape, axes, norm, overwrite_x,
+            planner_effort, threads, auto_align_input, auto_contiguous)
+
+
+def rfft(x, n=None, axis=-1, norm=None, overwrite_x=False,
+        planner_effort=None, threads=None,
+        auto_align_input=True, auto_contiguous=True):
+    '''Perform a 1D real FFT.
+
+    The first five arguments are as per :func:`scipy.fft.rfft`;
+    the rest of the arguments are documented
+    in the :ref:`additional argument docs<interfaces_additional_args>`.
+    '''
+    return numpy_fft.rfft(x, n, axis, norm, overwrite_x, planner_effort,
+                          threads, auto_align_input, auto_contiguous)
+
+def irfft(x, n=None, axis=-1, norm=None, overwrite_x=False,
+        planner_effort=None, threads=None,
+        auto_align_input=True, auto_contiguous=True):
+    '''Perform a 1D real inverse FFT.
+
+    The first five arguments are as per :func:`scipy.fft.irfft`;
+    the rest of the arguments are documented
+    in the :ref:`additional argument docs<interfaces_additional_args>`.
+    '''
+    return numpy_fft.irfft(x, n, axis, norm, overwrite_x, planner_effort,
+                           threads, auto_align_input, auto_contiguous)
+
+
+def rfft2(x, shape=None, axes=(-2,-1), norm=None, overwrite_x=False,
+        planner_effort=None, threads=None,
+        auto_align_input=True, auto_contiguous=True):
+    '''Perform a 2D real FFT.
+
+    The first five arguments are as per :func:`scipy.fft.rfft2`;
+    the rest of the arguments are documented
+    in the :ref:`additional argument docs<interfaces_additional_args>`.
+    '''
+    return numpy_fft.rfft2(x, shape, axes, norm, overwrite_x,
+            planner_effort, threads, auto_align_input, auto_contiguous)
+
+
+def irfft2(x, shape=None, axes=(-2,-1), norm=None, overwrite_x=False,
+        planner_effort=None, threads=None,
+        auto_align_input=True, auto_contiguous=True):
+    '''Perform a 2D real inverse FFT.
+
+    The first five arguments are as per :func:`scipy.fft.irfft2`;
+    the rest of the arguments are documented in the
+    :ref:`additional argument docs <interfaces_additional_args>`.
+    '''
+    return numpy_fft.irfft2(x, shape, axes, norm, overwrite_x,
+            planner_effort, threads, auto_align_input, auto_contiguous)
+
+
+def rfftn(x, shape=None, axes=None, norm=None, overwrite_x=False,
+        planner_effort=None, threads=None,
+        auto_align_input=True, auto_contiguous=True):
+    '''Perform an n-D real FFT.
+
+    The first five arguments are as per :func:`scipy.fft.rfftn`;
+    the rest of the arguments are documented
+    in the :ref:`additional argument docs<interfaces_additional_args>`.
+    '''
+
+    if shape is not None:
+        if ((axes is not None and len(shape) != len(axes)) or
+                (axes is None and len(shape) != x.ndim)):
+            raise ValueError('Shape error: In order to maintain better '
+                    'compatibility with scipy.fft.rfftn, a ValueError '
+                    'is raised when the length of the shape argument is '
+                    'not the same as x.ndim if axes is None or the length '
+                    'of axes if it is not. If this is problematic, consider '
+                    'using the numpy interface.')
+    return numpy_fft.rfftn(x, shape, axes, norm, overwrite_x,
+            planner_effort, threads, auto_align_input, auto_contiguous)
+
+
+def irfftn(x, shape=None, axes=None, norm=None, overwrite_x=False,
+        planner_effort=None, threads=None,
+        auto_align_input=True, auto_contiguous=True):
+    '''Perform an n-D real inverse FFT.
+
+    The first five arguments are as per :func:`scipy.fft.irfftn`;
+    the rest of the arguments are documented
+    in the :ref:`additional argument docs<interfaces_additional_args>`.
+    '''
+    if shape is not None:
+        if ((axes is not None and len(shape) != len(axes)) or
+                (axes is None and len(shape) != x.ndim)):
+            raise ValueError('Shape error: In order to maintain better '
+                    'compatibility with scipy.fft.irfftn, a ValueError '
+                    'is raised when the length of the shape argument is '
+                    'not the same as x.ndim if axes is None or the length '
+                    'of axes if it is not. If this is problematic, consider '
+                    'using the numpy interface.')
+
+    return numpy_fft.irfftn(x, shape, axes, norm, overwrite_x,
+            planner_effort, threads, auto_align_input, auto_contiguous)
+
+
+def hfft(x, n=None, axis=-1, norm=None, overwrite_x=False,
+        planner_effort=None, threads=None,
+        auto_align_input=True, auto_contiguous=True):
+    '''Perform a 1D Hermitian FFT.
+
+    The first five arguments are as per :func:`scipy.fft.hfft`;
+    the rest of the arguments are documented
+    in the :ref:`additional argument docs<interfaces_additional_args>`.
+    '''
+    return numpy_fft.hfft(x, n, axis, norm, overwrite_x, planner_effort,
+                          threads, auto_align_input, auto_contiguous)
+
+def ihfft(x, n=None, axis=-1, norm=None, overwrite_x=False,
+        planner_effort=None, threads=None,
+        auto_align_input=True, auto_contiguous=True):
+    '''Perform a 1D Hermitian inverse FFT.
+
+    The first five arguments are as per :func:`scipy.fft.ihfft`;
+    the rest of the arguments are documented
+    in the :ref:`additional argument docs<interfaces_additional_args>`.
+    '''
+    return numpy_fft.ihfft(x, n, axis, norm, overwrite_x, planner_effort,
+                           threads, auto_align_input, auto_contiguous)

--- a/test/test_pyfftw_scipy_fft.py
+++ b/test/test_pyfftw_scipy_fft.py
@@ -1,7 +1,4 @@
-# Copyright 2014 Knowledge Economy Developments Ltd
-#
-# Henry Gomersall
-# heng@kedevelopments.co.uk
+# Copyright 2019, The pyFFTW developers
 #
 # All rights reserved.
 #

--- a/test/test_pyfftw_scipy_fft.py
+++ b/test/test_pyfftw_scipy_fft.py
@@ -1,0 +1,137 @@
+# Copyright 2014 Knowledge Economy Developments Ltd
+#
+# Henry Gomersall
+# heng@kedevelopments.co.uk
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+import pyfftw
+import numpy
+
+try:
+    import scipy.fft
+    from pyfftw.interfaces import scipy_fft
+    scipy_missing = False
+except ImportError:
+    scipy_missing = True
+
+import unittest
+from .test_pyfftw_base import run_test_suites, miss
+from . import test_pyfftw_numpy_interface
+
+'''pyfftw.interfaces.scipy_fft just wraps pyfftw.interfaces.numpy_fft.
+
+All the tests here just check that the call is made correctly.
+'''
+
+funcs = ('fft','ifft', 'fft2', 'ifft2', 'fftn', 'ifftn',
+         'rfft','irfft', 'rfft2', 'irfft2', 'rfftn', 'irfftn',
+         'hfft', 'ihfft')
+
+acquired_names = ('dct', 'idct', 'dst', 'idst', 'dctn', 'idctn', 'dstn', 'idstn',
+                  'hfft2', 'ihfft2', 'hfftn', 'ihfftn',
+                  'fftshift', 'ifftshift', 'fftfreq', 'rfftfreq')
+
+def make_complex_data(shape, dtype):
+    ar, ai = dtype(numpy.random.randn(2, *shape))
+    return ar + 1j*ai
+
+def make_r2c_real_data(shape, dtype):
+    return dtype(numpy.random.randn(*shape))
+
+def make_c2r_real_data(shape, dtype):
+    return dtype(numpy.random.randn(*shape))
+
+# reuse from numpy tests
+make_complex_data = test_pyfftw_numpy_interface.make_complex_data
+complex_dtypes = test_pyfftw_numpy_interface.complex_dtypes
+real_dtypes = test_pyfftw_numpy_interface.real_dtypes
+
+io_dtypes = {
+        'complex': (complex_dtypes, make_complex_data),
+        'r2c': (real_dtypes, make_r2c_real_data),
+        'c2r': (real_dtypes, make_c2r_real_data)}
+
+@unittest.skipIf(scipy_missing, 'scipy.fft is unavailable')
+class InterfacesScipyFFTTestSimple(unittest.TestCase):
+    ''' A simple test suite for a simple implementation.
+    '''
+
+    @unittest.skipIf(*miss('64'))
+    def test_scipy_backend(self):
+        a = pyfftw.empty_aligned((128, 64), dtype='complex128', n=16)
+        b = pyfftw.empty_aligned((128, 64), dtype='complex128', n=16)
+
+        a[:] = (numpy.random.randn(*a.shape) +
+                1j*numpy.random.randn(*a.shape))
+        b[:] = (numpy.random.randn(*b.shape) +
+                1j*numpy.random.randn(*b.shape))
+
+        scipy_c = scipy.signal.fftconvolve(a, b)
+
+        with scipy.fft.set_backend(scipy_fft, only=True):
+            scipy_replaced_c = scipy.signal.fftconvolve(a, b)
+
+        self.assertTrue(numpy.allclose(scipy_c, scipy_replaced_c))
+
+    def test_acquired_names(self):
+        for each_name in acquired_names:
+
+            fft_attr = getattr(scipy.fft, each_name)
+            acquired_attr = getattr(scipy_fft, each_name)
+
+            self.assertIs(fft_attr, acquired_attr)
+
+
+# Construct all the test classes automatically.
+test_cases = []
+if not scipy_missing:
+    for each_func in funcs:
+        class_name = 'InterfacesScipyFFTTest' + each_func.upper()
+
+        parent_class_name = 'InterfacesNumpyFFTTest' + each_func.upper()
+        parent_class = getattr(test_pyfftw_numpy_interface, parent_class_name)
+
+        class_dict = {'validator_module': scipy.fft,
+                      'test_interface': scipy_fft,
+                      'io_dtypes': io_dtypes,
+                      'overwrite_input_flag': 'overwrite_x',
+                      'default_s_from_shape_slicer': slice(None)}
+
+        globals()[class_name] = type(class_name, (parent_class,), class_dict)
+
+        test_cases.append(globals()[class_name])
+
+test_cases.append(InterfacesScipyFFTTestSimple)
+test_set = None
+
+
+if __name__ == '__main__':
+    run_test_suites(test_cases, test_set)


### PR DESCRIPTION
Closes #268

Since the `scipy.fft` interface matches `numpy.fft` very closely, this is simple enough to implement.  The exception is the n-dimensional `hfft`s which would require more work than the 1d `hfft` in the numpy interface