### PR TITLE
bump conda package versions on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,7 @@ environment:
         CYTHON_BUILD_DEP: "=0.26"
         DASK_BUILD_DEP: "=0.16"
         EXTRA_CONDA_ARGS: ""
+        CONDA_ACTIVATE_CMD: "conda activate"
 
     pypi_username:
         secure: qFSpEDsIOj6gzynjuHTX5A==
@@ -34,13 +35,15 @@ environment:
           PYTHON_ARCH: "64"
           PYTHON_VERSION: "2.7"
 
-        - PYTHON_HOME: "C:\\Miniconda35"
+        - PYTHON_HOME: "C:\\Miniconda36"
           PYTHON_ARCH: "32"
           PYTHON_VERSION: "3.5"
+          CONDA_ACTIVATE_CMD: "activate"
 
-        - PYTHON_HOME: "C:\\Miniconda35-x64"
+        - PYTHON_HOME: "C:\\Miniconda36-x64"
           PYTHON_ARCH: "64"
           PYTHON_VERSION: "3.5"
+          CONDA_ACTIVATE_CMD: "activate"
 
         - PYTHON_HOME: "C:\\Miniconda36"
           PYTHON_ARCH: "32"
@@ -50,7 +53,7 @@ environment:
           PYTHON_ARCH: "64"
           PYTHON_VERSION: "3.6"
 
-        - PYTHON_HOME: "C:\\Miniconda37"
+        - PYTHON_HOME: "C:\\Miniconda36"
           PYTHON_ARCH: "32"
           PYTHON_VERSION: "3.7"
           NP_BUILD_DEP: ""
@@ -58,7 +61,7 @@ environment:
           CYTHON_BUILD_DEP: ""
           DASK_BUILD_DEP: ""
 
-        - PYTHON_HOME: "C:\\Miniconda37-x64"
+        - PYTHON_HOME: "C:\\Miniconda36-x64"
           PYTHON_ARCH: "64"
           PYTHON_VERSION: "3.7"
           NP_BUILD_DEP: ""
@@ -70,15 +73,13 @@ install:
     # Get and configure the FFTW libs
     - "%CMD_IN_ENV% ./appveyor/setup_fftw_dlls.cmd"
 
-    # Prepend newly installed Python to the PATH of this build (this cannot be
-    # done from inside the powershell script as it would require to restart
-    # the parent CMD process).
-    - "SET PATH=%PYTHON_HOME%;%PYTHON_HOME%\\Scripts;%PATH%"
+    # activate the conda environment
+    - CALL "%PYTHON_HOME%\\Scripts\\activate.bat"
 
     - "conda config --set always_yes yes --set changeps1 no"
     - "conda update -q conda"
     - "conda create -q -n build_env %EXTRA_CONDA_ARGS% python=%PYTHON_VERSION% numpy%NP_BUILD_DEP% scipy%SP_BUILD_DEP% cython%CYTHON_BUILD_DEP% dask%DASK_BUILD_DEP% setuptools"
-    - "activate build_env"
+    - "%CONDA_ACTIVATE_CMD% build_env"
     - "%CMD_IN_ENV% python setup.py -v bdist_wheel"
     - "%CMD_IN_ENV% python setup.py -v build_ext --inplace"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,9 +6,10 @@ environment:
         CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
         # The miniconda installations are put in pyfftw_miniconda
         PYTHON_HOME: "C:\\pyfftw_miniconda"
-        NP_BUILD_DEP: "1.11"
-        SP_BUILD_DEP: "0.19"
-        CYTHON_BUILD_DEP: "0.26"
+        NP_BUILD_DEP: "=1.11"
+        SP_BUILD_DEP: "=1.0"
+        CYTHON_BUILD_DEP: "=0.26"
+        DASK_BUILD_DEP: "=0.16"
         EXTRA_CONDA_ARGS: ""
 
     pypi_username:
@@ -33,14 +34,6 @@ environment:
           PYTHON_ARCH: "64"
           PYTHON_VERSION: "2.7"
 
-        - PYTHON_HOME: "C:\\Miniconda34"
-          PYTHON_ARCH: "32"
-          PYTHON_VERSION: "3.4"
-
-        - PYTHON_HOME: "C:\\Miniconda34-x64"
-          PYTHON_ARCH: "64"
-          PYTHON_VERSION: "3.4"
-
         - PYTHON_HOME: "C:\\Miniconda35"
           PYTHON_ARCH: "32"
           PYTHON_VERSION: "3.5"
@@ -49,14 +42,29 @@ environment:
           PYTHON_ARCH: "64"
           PYTHON_VERSION: "3.5"
 
-        # skipping 32-bit with Python 3.6: no 32-bit numpy with OpenBLAS
+        - PYTHON_HOME: "C:\\Miniconda36"
+          PYTHON_ARCH: "32"
+          PYTHON_VERSION: "3.6"
+
         - PYTHON_HOME: "C:\\Miniconda36-x64"
           PYTHON_ARCH: "64"
           PYTHON_VERSION: "3.6"
-          NP_BUILD_DEP: "1.14"
-          SP_BUILD_DEP: "1.1"
-          CYTHON_BUILD_DEP: "0.28"
-          # EXTRA_CONDA_ARGS: "-c conda-forge blas=*=openblas"  # needed for non-MKL numpy/scipy
+
+        - PYTHON_HOME: "C:\\Miniconda37"
+          PYTHON_ARCH: "32"
+          PYTHON_VERSION: "3.7"
+          NP_BUILD_DEP: ""
+          SP_BUILD_DEP: ""
+          CYTHON_BUILD_DEP: ""
+          DASK_BUILD_DEP: ""
+
+        - PYTHON_HOME: "C:\\Miniconda37-x64"
+          PYTHON_ARCH: "64"
+          PYTHON_VERSION: "3.7"
+          NP_BUILD_DEP: ""
+          SP_BUILD_DEP: ""
+          CYTHON_BUILD_DEP: ""
+          DASK_BUILD_DEP: ""
 
 install:
     # Get and configure the FFTW libs
@@ -69,7 +77,7 @@ install:
 
     - "conda config --set always_yes yes --set changeps1 no"
     - "conda update -q conda"
-    - "conda create -q -n build_env %EXTRA_CONDA_ARGS% python=%PYTHON_VERSION% numpy=%NP_BUILD_DEP% scipy=%SP_BUILD_DEP% cython=%CYTHON_BUILD_DEP% dask setuptools"
+    - "conda create -q -n build_env %EXTRA_CONDA_ARGS% python=%PYTHON_VERSION% numpy%NP_BUILD_DEP% scipy%SP_BUILD_DEP% cython%CYTHON_BUILD_DEP% dask%DASK_BUILD_DEP% setuptools"
     - "activate build_env"
     - "%CMD_IN_ENV% python setup.py -v bdist_wheel"
     - "%CMD_IN_ENV% python setup.py -v build_ext --inplace"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,9 +6,9 @@ environment:
         CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
         # The miniconda installations are put in pyfftw_miniconda
         PYTHON_HOME: "C:\\pyfftw_miniconda"
-        NP_BUILD_DEP: "1.10"
-        SP_BUILD_DEP: "0.16"
-        CYTHON_BUILD_DEP: "0.23"
+        NP_BUILD_DEP: "1.11"
+        SP_BUILD_DEP: "0.19"
+        CYTHON_BUILD_DEP: "0.26"
         EXTRA_CONDA_ARGS: ""
 
     pypi_username:


### PR DESCRIPTION
Checking the output of:
    ```conda search numpy[subdir=win-64] --info -c defaults | grep main```
    ```conda search scipy[subdir=win-64] --info -c defaults | grep main```
    ```conda search cython[subdir=win-64] --info -c defaults | grep main```

seems to indicate that:
`numpy 0.11.3`
`scipy 0.19.1`
`cython 0.26.1`

is probably the oldest combo that will work for the current defaults channel. I think that we can probably drop support for versions older than these at this point.

TODO: 
- [ ] update the docs accordingly