### PR TITLE
Update scipy.fft interface to fix shape handling and add workers argument

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -125,7 +125,7 @@ html_theme = 'default'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -510,7 +510,7 @@ and planning effort.
 
 The initial values in pyfftw.config at import time can be controlled via the
 environment variables as detailed in the
-:ref:`configuration <_configuration_variables>` documentation.
+:ref:`configuration <configuration_variables>` documentation.
 
 .. rubric:: Footnotes
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -107,7 +107,7 @@ number of threads to use can be configured by assigning a positive integer to
 <interfaces_tutorial>). The following code demonstrates using the :mod:`pyfftw`
 backend to speed up :func:`scipy.signal.fftconvolve`.
 
-.. codeblock:: python
+.. code-block:: python
 
    import pyfftw
    import multiprocessing
@@ -154,7 +154,7 @@ directly. :mod:`pyfftw.interfaces.numpy_fft` and
 :mod:`numpy.fft` and :mod:`scipy.fftpack` libraries respectively so it is
 possible to use them as replacements at run-time through monkey patching.
 
-.. codeblock:: python
+.. code-block:: python
 
    # Monkey patch fftpack with pyfftw.interfaces.scipy_fftpack
    scipy.fftpack = pyfftw.interfaces.scipy_fftpack
@@ -478,7 +478,7 @@ self-explanatory. We point the reader to the :mod:`API docs <pyfftw.builders>`
 for more information.
 
 If you like the :mod:`pyfftw.builders` functions, but do not need or wish to
-interact with :class:`pyfftw.FFTW`-instances directly, the third party 
+interact with :class:`pyfftw.FFTW`-instances directly, the third party
 :mod:`planfftw` package provides helper functions that return planned functions
 similar to those in :mod:`numpy.fft`, as well as FFTW-powered versions of some
 functions from :mod:`scipy.signal`.

--- a/pyfftw/interfaces/__init__.py
+++ b/pyfftw/interfaces/__init__.py
@@ -215,6 +215,10 @@ exceptions and with different defaults.
 
 * ``threads``: The number of threads used to perform the FFT.
 
+  In :mod:`~pyfftw.interfaces.scipy_fft`, this argument is replaced by
+  ``workers``, which serves the same purpose, but is also compatible with the
+  :func:`scipy.fft.set_workers` context manager.
+
   The default is ``1``.
 
 * ``auto_align_input``: Correctly byte align the input array for optimal

--- a/pyfftw/interfaces/scipy_fft.py
+++ b/pyfftw/interfaces/scipy_fft.py
@@ -181,16 +181,6 @@ def fftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None,
     the rest of the arguments are documented
     in the :ref:`additional argument docs<interfaces_additional_args>`.
     '''
-
-    if s is not None:
-        if ((axes is not None and len(s) != len(axes)) or
-                (axes is None and len(s) != x.ndim)):
-            raise ValueError(
-                'Shape error: In order to maintain better compatibility '
-                'with scipy.fft.fftn, a ValueError is raised when the length'
-                'of the s argument is not the same as x.ndim if axes is None '
-                'or the length of axes if it is not. If this is problematic, '
-                'consider using the numpy interface.')
     threads = _workers_to_threads(workers)
     return numpy_fft.fftn(x, s, axes, norm, overwrite_x, planner_effort,
                           threads, auto_align_input, auto_contiguous)
@@ -205,15 +195,6 @@ def ifftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None,
     the rest of the arguments are documented
     in the :ref:`additional argument docs<interfaces_additional_args>`.
     '''
-    if s is not None:
-        if ((axes is not None and len(s) != len(axes)) or
-                (axes is None and len(s) != x.ndim)):
-            raise ValueError(
-                'Shape error: In order to maintain better compatibility '
-                'with scipy.fft.ifftn, a ValueError is raised when the length'
-                'of the s argument is not the same as x.ndim if axes is None '
-                'or the length of axes if it is not. If this is problematic, '
-                'consider using the numpy interface.')
     threads = _workers_to_threads(workers)
     return numpy_fft.ifftn(x, s, axes, norm, overwrite_x, planner_effort,
                            threads, auto_align_input, auto_contiguous)
@@ -294,16 +275,6 @@ def rfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None,
     x = np.asanyarray(x)
     if x.dtype.kind == 'c':
         raise TypeError('x must be a real sequence')
-
-    if s is not None:
-        if ((axes is not None and len(s) != len(axes)) or
-                (axes is None and len(s) != x.ndim)):
-            raise ValueError(
-                'Shape error: In order to maintain better compatibility '
-                'with scipy.fft.rfftn, a ValueError is raised when the length'
-                'of the s argument is not the same as x.ndim if axes is None '
-                'or the length of axes if it is not. If this is problematic, '
-                'consider using the numpy interface.')
     threads = _workers_to_threads(workers)
     return numpy_fft.rfftn(x, s, axes, norm, overwrite_x, planner_effort,
                            threads, auto_align_input, auto_contiguous)
@@ -318,15 +289,6 @@ def irfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None,
     the rest of the arguments are documented
     in the :ref:`additional argument docs<interfaces_additional_args>`.
     '''
-    if s is not None:
-        if ((axes is not None and len(s) != len(axes)) or
-                (axes is None and len(s) != x.ndim)):
-            raise ValueError(
-                'Shape error: In order to maintain better compatibility '
-                'with scipy.fft.irfftn, a ValueError is raised when the length'
-                'of the s argument is not the same as x.ndim if axes is None '
-                'or the length of axes if it is not. If this is problematic, '
-                'consider using the numpy interface.')
     threads = _workers_to_threads(workers)
     return numpy_fft.irfftn(x, s, axes, norm, overwrite_x, planner_effort,
                             threads, auto_align_input, auto_contiguous)

--- a/pyfftw/interfaces/scipy_fft.py
+++ b/pyfftw/interfaces/scipy_fft.py
@@ -47,13 +47,15 @@ a 2D `s` argument will return without exception whereas
 :func:`pyfftw.interfaces.scipy_fft.fft2` will raise a `ValueError`.
 
 '''
+import os
 
 from . import numpy_fft
 
 # Complete the namespace (these are not actually used in this module)
 from scipy.fft import (dct, idct, dst, idst, dctn, idctn, dstn, idstn,
                        hfft2, ihfft2, hfftn, ihfftn,
-                       fftshift, ifftshift, fftfreq, rfftfreq)
+                       fftshift, ifftshift, fftfreq, rfftfreq,
+                       get_workers, set_workers)
 
 # a next_fast_len specific to pyFFTW is used in place of the scipy.fft one
 from ..pyfftw import next_fast_len
@@ -66,7 +68,8 @@ __all__ = ['fft', 'ifft', 'fft2', 'ifft2', 'fftn', 'ifftn',
            'rfft', 'irfft', 'rfft2', 'irfft2', 'rfftn', 'irfftn',
            'hfft', 'ihfft', 'hfft2', 'ihfft2', 'hfftn', 'ihfftn',
            'dct', 'idct', 'dst', 'idst', 'dctn', 'idctn', 'dstn', 'idstn',
-           'fftshift', 'ifftshift', 'fftfreq', 'rfftfreq']
+           'fftshift', 'ifftshift', 'fftfreq', 'rfftfreq', 'get_workers',
+           'set_workers', 'next_fast_len']
 
 
 # Backend support for scipy.fft
@@ -74,6 +77,8 @@ __all__ = ['fft', 'ifft', 'fft2', 'ifft2', 'fftn', 'ifftn',
 _implemented = {}
 
 __ua_domain__ = 'numpy.scipy.fft'
+
+_cpu_count = os.cpu_count()
 
 
 def __ua_function__(method, args, kwargs):
@@ -92,68 +97,87 @@ def _implements(scipy_func):
     return inner
 
 
+def _workers_to_threads(workers):
+    """Handle conversion of workers to a positive number of threads in the
+    same way as scipy.fft.helpers._workers.
+    """
+    if workers is None:
+        return get_workers()
+
+    if workers < 0:
+        if workers >= -_cpu_count:
+            workers += 1 + _cpu_count
+        else:
+            raise ValueError("workers value out of range; got {}, must not be"
+                             " less than {}".format(workers, -_cpu_count))
+    elif workers == 0:
+        raise ValueError("workers must not be zero")
+    return workers
+
+
 @_implements(_fft.fft)
-def fft(x, n=None, axis=-1, norm=None, overwrite_x=False,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True):
+def fft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None,
+        planner_effort=None, auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D FFT.
 
-    The first five arguments are as per :func:`scipy.fft.fft`;
+    The first six arguments are as per :func:`scipy.fft.fft`;
     the rest of the arguments are documented
     in the :ref:`additional argument docs<interfaces_additional_args>`.
     '''
+    threads = _workers_to_threads(workers)
     return numpy_fft.fft(x, n, axis, norm, overwrite_x, planner_effort,
                          threads, auto_align_input, auto_contiguous)
 
+
 @_implements(_fft.ifft)
-def ifft(x, n=None, axis=-1, norm=None, overwrite_x=False,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True):
+def ifft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None,
+         planner_effort=None, auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D inverse FFT.
 
-    The first five arguments are as per :func:`scipy.fft.ifft`;
+    The first six arguments are as per :func:`scipy.fft.ifft`;
     the rest of the arguments are documented
     in the :ref:`additional argument docs<interfaces_additional_args>`.
     '''
+    threads = _workers_to_threads(workers)
     return numpy_fft.ifft(x, n, axis, norm, overwrite_x,
-            planner_effort, threads, auto_align_input, auto_contiguous)
+                          planner_effort, threads, auto_align_input,
+                          auto_contiguous)
 
 
 @_implements(_fft.fft2)
-def fft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False,
-         planner_effort=None, threads=None, auto_align_input=True,
-         auto_contiguous=True):
+def fft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None,
+         planner_effort=None, auto_align_input=True, auto_contiguous=True):
     '''Perform a 2D FFT.
 
-    The first three arguments are as per :func:`scipy.fft.fft2`;
+    The first six arguments are as per :func:`scipy.fft.fft2`;
     the rest of the arguments are documented
     in the :ref:`additional argument docs<interfaces_additional_args>`.
     '''
+    threads = _workers_to_threads(workers)
     return numpy_fft.fft2(x, s, axes, norm, overwrite_x, planner_effort,
                           threads, auto_align_input, auto_contiguous)
 
 
 @_implements(_fft.ifft2)
-def ifft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False,
-          planner_effort=None, threads=None, auto_align_input=True,
-          auto_contiguous=True):
+def ifft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None,
+          planner_effort=None, auto_align_input=True, auto_contiguous=True):
     '''Perform a 2D inverse FFT.
 
-    The first five arguments are as per :func:`scipy.fft.ifft2`;
+    The first six arguments are as per :func:`scipy.fft.ifft2`;
     the rest of the arguments are documented in the
     :ref:`additional argument docs <interfaces_additional_args>`.
     '''
+    threads = _workers_to_threads(workers)
     return numpy_fft.ifft2(x, s, axes, norm, overwrite_x, planner_effort,
                            threads, auto_align_input, auto_contiguous)
 
 
 @_implements(_fft.fftn)
-def fftn(x, s=None, axes=None, norm=None, overwrite_x=False,
-         planner_effort=None, threads=None, auto_align_input=True,
-         auto_contiguous=True):
+def fftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None,
+         planner_effort=None, auto_align_input=True, auto_contiguous=True):
     '''Perform an n-D FFT.
 
-    The first five arguments are as per :func:`scipy.fft.fftn`;
+    The first six arguments are as per :func:`scipy.fft.fftn`;
     the rest of the arguments are documented
     in the :ref:`additional argument docs<interfaces_additional_args>`.
     '''
@@ -161,110 +185,109 @@ def fftn(x, s=None, axes=None, norm=None, overwrite_x=False,
     if s is not None:
         if ((axes is not None and len(s) != len(axes)) or
                 (axes is None and len(s) != x.ndim)):
-            raise ValueError('Shape error: In order to maintain better '
-                    'compatibility with scipy.fft.fftn, a ValueError '
-                    'is raised when the length of the s argument is '
-                    'not the same as x.ndim if axes is None or the length '
-                    'of axes if it is not. If this is problematic, consider '
-                    'using the numpy interface.')
+            raise ValueError(
+                'Shape error: In order to maintain better compatibility '
+                'with scipy.fft.fftn, a ValueError is raised when the length'
+                'of the s argument is not the same as x.ndim if axes is None '
+                'or the length of axes if it is not. If this is problematic, '
+                'consider using the numpy interface.')
+    threads = _workers_to_threads(workers)
     return numpy_fft.fftn(x, s, axes, norm, overwrite_x, planner_effort,
                           threads, auto_align_input, auto_contiguous)
 
 
 @_implements(_fft.ifftn)
-def ifftn(x, s=None, axes=None, norm=None, overwrite_x=False,
-          planner_effort=None, threads=None, auto_align_input=True,
-          auto_contiguous=True):
+def ifftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None,
+          planner_effort=None, auto_align_input=True, auto_contiguous=True):
     '''Perform an n-D inverse FFT.
 
-    The first five arguments are as per :func:`scipy.fft.ifftn`;
+    The first six arguments are as per :func:`scipy.fft.ifftn`;
     the rest of the arguments are documented
     in the :ref:`additional argument docs<interfaces_additional_args>`.
     '''
     if s is not None:
         if ((axes is not None and len(s) != len(axes)) or
                 (axes is None and len(s) != x.ndim)):
-            raise ValueError('Shape error: In order to maintain better '
-                    'compatibility with scipy.fft.ifftn, a ValueError '
-                    'is raised when the length of the s argument is '
-                    'not the same as x.ndim if axes is None or the length '
-                    'of axes if it is not. If this is problematic, consider '
-                    'using the numpy interface.')
-
+            raise ValueError(
+                'Shape error: In order to maintain better compatibility '
+                'with scipy.fft.ifftn, a ValueError is raised when the length'
+                'of the s argument is not the same as x.ndim if axes is None '
+                'or the length of axes if it is not. If this is problematic, '
+                'consider using the numpy interface.')
+    threads = _workers_to_threads(workers)
     return numpy_fft.ifftn(x, s, axes, norm, overwrite_x, planner_effort,
                            threads, auto_align_input, auto_contiguous)
 
 
 @_implements(_fft.rfft)
-def rfft(x, n=None, axis=-1, norm=None, overwrite_x=False,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True):
+def rfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None,
+         planner_effort=None, auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D real FFT.
 
-    The first five arguments are as per :func:`scipy.fft.rfft`;
+    The first six arguments are as per :func:`scipy.fft.rfft`;
     the rest of the arguments are documented
     in the :ref:`additional argument docs<interfaces_additional_args>`.
     '''
     x = np.asanyarray(x)
     if x.dtype.kind == 'c':
         raise TypeError('x must be a real sequence')
-
+    threads = _workers_to_threads(workers)
     return numpy_fft.rfft(x, n, axis, norm, overwrite_x, planner_effort,
                           threads, auto_align_input, auto_contiguous)
 
+
 @_implements(_fft.irfft)
-def irfft(x, n=None, axis=-1, norm=None, overwrite_x=False,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True):
+def irfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None,
+          planner_effort=None, auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D real inverse FFT.
 
-    The first five arguments are as per :func:`scipy.fft.irfft`;
+    The first six arguments are as per :func:`scipy.fft.irfft`;
     the rest of the arguments are documented
     in the :ref:`additional argument docs<interfaces_additional_args>`.
     '''
+    threads = _workers_to_threads(workers)
     return numpy_fft.irfft(x, n, axis, norm, overwrite_x, planner_effort,
                            threads, auto_align_input, auto_contiguous)
 
 
 @_implements(_fft.rfft2)
-def rfft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False,
-          planner_effort=None, threads=None, auto_align_input=True,
-          auto_contiguous=True):
+def rfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None,
+          planner_effort=None, auto_align_input=True, auto_contiguous=True):
     '''Perform a 2D real FFT.
 
-    The first five arguments are as per :func:`scipy.fft.rfft2`;
+    The first six arguments are as per :func:`scipy.fft.rfft2`;
     the rest of the arguments are documented
     in the :ref:`additional argument docs<interfaces_additional_args>`.
     '''
     x = np.asanyarray(x)
     if x.dtype.kind == 'c':
         raise TypeError('x must be a real sequence')
-
+    threads = _workers_to_threads(workers)
     return numpy_fft.rfft2(x, s, axes, norm, overwrite_x, planner_effort,
                            threads, auto_align_input, auto_contiguous)
 
 
 @_implements(_fft.irfft2)
-def irfft2(x, s=None, axes=(-2,-1), norm=None, overwrite_x=False,
-           planner_effort=None, threads=None, auto_align_input=True,
+def irfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False,
+           workers=None, planner_effort=None, auto_align_input=True,
            auto_contiguous=True):
     '''Perform a 2D real inverse FFT.
 
-    The first five arguments are as per :func:`scipy.fft.irfft2`;
+    The first six arguments are as per :func:`scipy.fft.irfft2`;
     the rest of the arguments are documented in the
     :ref:`additional argument docs <interfaces_additional_args>`.
     '''
+    threads = _workers_to_threads(workers)
     return numpy_fft.irfft2(x, s, axes, norm, overwrite_x, planner_effort,
                             threads, auto_align_input, auto_contiguous)
 
 
 @_implements(_fft.rfftn)
-def rfftn(x, s=None, axes=None, norm=None, overwrite_x=False,
-          planner_effort=None, threads=None, auto_align_input=True,
-          auto_contiguous=True):
+def rfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None,
+          planner_effort=None, auto_align_input=True, auto_contiguous=True):
     '''Perform an n-D real FFT.
 
-    The first five arguments are as per :func:`scipy.fft.rfftn`;
+    The first six arguments are as per :func:`scipy.fft.rfftn`;
     the rest of the arguments are documented
     in the :ref:`additional argument docs<interfaces_additional_args>`.
     '''
@@ -272,64 +295,63 @@ def rfftn(x, s=None, axes=None, norm=None, overwrite_x=False,
     if x.dtype.kind == 'c':
         raise TypeError('x must be a real sequence')
 
-
     if s is not None:
         if ((axes is not None and len(s) != len(axes)) or
                 (axes is None and len(s) != x.ndim)):
-            raise ValueError('Shape error: In order to maintain better '
-                    'compatibility with scipy.fft.rfftn, a ValueError '
-                    'is raised when the length of the s argument is '
-                    'not the same as x.ndim if axes is None or the length '
-                    'of axes if it is not. If this is problematic, consider '
-                    'using the numpy interface.')
+            raise ValueError(
+                'Shape error: In order to maintain better compatibility '
+                'with scipy.fft.rfftn, a ValueError is raised when the length'
+                'of the s argument is not the same as x.ndim if axes is None '
+                'or the length of axes if it is not. If this is problematic, '
+                'consider using the numpy interface.')
+    threads = _workers_to_threads(workers)
     return numpy_fft.rfftn(x, s, axes, norm, overwrite_x, planner_effort,
                            threads, auto_align_input, auto_contiguous)
 
 
 @_implements(_fft.irfftn)
-def irfftn(x, s=None, axes=None, norm=None, overwrite_x=False,
-           planner_effort=None, threads=None, auto_align_input=True,
-           auto_contiguous=True):
+def irfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None,
+           planner_effort=None, auto_align_input=True, auto_contiguous=True):
     '''Perform an n-D real inverse FFT.
 
-    The first five arguments are as per :func:`scipy.fft.irfftn`;
+    The first six arguments are as per :func:`scipy.fft.irfftn`;
     the rest of the arguments are documented
     in the :ref:`additional argument docs<interfaces_additional_args>`.
     '''
     if s is not None:
         if ((axes is not None and len(s) != len(axes)) or
                 (axes is None and len(s) != x.ndim)):
-            raise ValueError('Shape error: In order to maintain better '
-                    'compatibility with scipy.fft.irfftn, a ValueError '
-                    'is raised when the length of the s argument is '
-                    'not the same as x.ndim if axes is None or the length '
-                    'of axes if it is not. If this is problematic, consider '
-                    'using the numpy interface.')
-
+            raise ValueError(
+                'Shape error: In order to maintain better compatibility '
+                'with scipy.fft.irfftn, a ValueError is raised when the length'
+                'of the s argument is not the same as x.ndim if axes is None '
+                'or the length of axes if it is not. If this is problematic, '
+                'consider using the numpy interface.')
+    threads = _workers_to_threads(workers)
     return numpy_fft.irfftn(x, s, axes, norm, overwrite_x, planner_effort,
                             threads, auto_align_input, auto_contiguous)
 
 
 @_implements(_fft.hfft)
-def hfft(x, n=None, axis=-1, norm=None, overwrite_x=False,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True):
+def hfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None,
+         planner_effort=None, auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D Hermitian FFT.
 
-    The first five arguments are as per :func:`scipy.fft.hfft`;
+    The first six arguments are as per :func:`scipy.fft.hfft`;
     the rest of the arguments are documented
     in the :ref:`additional argument docs<interfaces_additional_args>`.
     '''
+    threads = _workers_to_threads(workers)
     return numpy_fft.hfft(x, n, axis, norm, overwrite_x, planner_effort,
                           threads, auto_align_input, auto_contiguous)
 
+
 @_implements(_fft.ihfft)
-def ihfft(x, n=None, axis=-1, norm=None, overwrite_x=False,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True):
+def ihfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None,
+          planner_effort=None, auto_align_input=True, auto_contiguous=True):
     '''Perform a 1D Hermitian inverse FFT.
 
-    The first five arguments are as per :func:`scipy.fft.ihfft`;
+    The first six arguments are as per :func:`scipy.fft.ihfft`;
     the rest of the arguments are documented
     in the :ref:`additional argument docs<interfaces_additional_args>`.
     '''
@@ -337,5 +359,6 @@ def ihfft(x, n=None, axis=-1, norm=None, overwrite_x=False,
     if x.dtype.kind == 'c':
         raise TypeError('x must be a real sequence')
 
+    threads = _workers_to_threads(workers)
     return numpy_fft.ihfft(x, n, axis, norm, overwrite_x, planner_effort,
                            threads, auto_align_input, auto_contiguous)

--- a/test/test_pyfftw_base.py
+++ b/test/test_pyfftw_base.py
@@ -41,8 +41,13 @@ import unittest
 
 try:
     import mkl_fft
-    # mkl_fft monkeypatches numpy.fft so explicitly import from fftpack instead
-    from numpy.fft import fftpack as np_fft
+    # mkl_fft monkeypatches numpy.fft
+    # explicitly import from fftpack or pocketfft instead
+    try:
+        # numpy 1.17 replaced fftpack with pocketfft
+        from numpy.fft import pocketfft as np_fft
+    except ImportError:
+        from numpy.fft import fftpack as np_fft
 except ImportError:
     from numpy import fft as np_fft
 

--- a/test/test_pyfftw_numpy_interface.py
+++ b/test/test_pyfftw_numpy_interface.py
@@ -159,6 +159,7 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
     test_interface = interfaces.numpy_fft
     func = 'fft'
     axes_kw = 'axis'
+    threads_arg_name = 'threads'
     overwrite_input_flag = 'overwrite_input'
     default_s_from_shape_slicer = slice(-1, None)
 
@@ -593,10 +594,10 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
             else:
                 kwargs = {'axes': (-1,)}
 
-            self.check_arg('threads', (1, 2, 5, 10),
+            self.check_arg(self.threads_arg_name, (1, 2, 5, 10),
                         dtype_tuple[1], test_shape, dtype, s, kwargs)
 
-            kwargs['threads'] = 'bleh'
+            kwargs[self.threads_arg_name] = 'bleh'
 
             # Should not work
             self.assertRaises(TypeError,

--- a/test/test_pyfftw_scipy_fft.py
+++ b/test/test_pyfftw_scipy_fft.py
@@ -125,7 +125,8 @@ for each_func in funcs:
                   'test_interface': scipy_fft if has_scipy_fft else None,
                   'io_dtypes': io_dtypes,
                   'overwrite_input_flag': 'overwrite_x',
-                  'default_s_from_shape_slicer': slice(None)}
+                  'default_s_from_shape_slicer': slice(None),
+                  'threads_arg_name': 'workers'}
 
     cls = type(class_name, (parent_class,), class_dict)
     cls = unittest.skipIf(not has_scipy_fft, "scipy.fft is not available")(cls)

--- a/test/test_pyfftw_scipy_fft.py
+++ b/test/test_pyfftw_scipy_fft.py
@@ -43,6 +43,7 @@ has_scipy_fft = LooseVersion(scipy_version) >= LooseVersion('1.4.0')
 
 if has_scipy_fft:
     import scipy.fft
+    import scipy.signal
     from pyfftw.interfaces import scipy_fft
 
 import unittest
@@ -54,8 +55,8 @@ from . import test_pyfftw_numpy_interface
 All the tests here just check that the call is made correctly.
 '''
 
-funcs = ('fft','ifft', 'fft2', 'ifft2', 'fftn', 'ifftn',
-         'rfft','irfft', 'rfft2', 'irfft2', 'rfftn', 'irfftn',
+funcs = ('fft', 'ifft', 'fft2', 'ifft2', 'fftn', 'ifftn',
+         'rfft', 'irfft', 'rfft2', 'irfft2', 'rfftn', 'irfftn',
          'hfft', 'ihfft')
 
 acquired_names = ('dct', 'idct', 'dst', 'idst', 'dctn', 'idctn', 'dstn', 'idstn',


### PR DESCRIPTION
This PR updates the recently introduced `scipy.fft` interface so that it is in sync with SciPy master.

1.) This adds the `workers` argument to the `scipy.fft` interface to match scipy/scipy#10614 

2.) updates shape handling as in scipy/scipy#10594 (we can just fall back to the numpy_fft interface shape handling now)

Note: The `workers` argument here replaces the functionality previously provided by the `threads` argument. As we have never tagged a release with the new `scipy.fft` interface yet, I don't think this is a problem for backwards compatibility. 

The Travis case using the SciPy development wheels will be the relevant one to monitor here as SciPy 1.4 (which introduces the `scipy.fft` module) has not yet been released.
