### PR TITLE
Update Dask tests for compatibility with recent Dask

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,30 @@
 language: python
 
-sudo: false
-
 env:
     global:
         # github_changelog_generator API key
         - secure: "OX6AAzZeoC8SvhPbED0I59AhaSZr98kKoj8ZdLdkva6BVUJoR+giDCvARyzKT7Ikwoh8A1/Qo5BmEkWYXWxE8GRC+uyrKR67u0djv21oQB1y5NniWAxZ+WIr8beLvgJ3cbD6/pVrlkSz4VaDda09Ni6F/nOk00mj9N2fYq36DXCeK3mVIHXy1AhQxHbeDkISsfQsqBxSyz26fGbh/xbZwRFeD2EbHiRp/3STtae7VKbM02CNIS6zTpOzEfrd2oChRrteUZuCLz9yCRfi7awgJOJ00AsIdwuA8KktgNZWbOSHtrn7QaAuIyunBzZNleWkvcWIBHyE3eg9p49mv970W1QkKjh3CZI0uxVO6oeb934fbTXJSwVKh52rxFvKPh9qFZDCEj31tcrVThPEUT5DL6yx8EC+RhTPrWS37QcJoimMvSU9dKmiyNKnC0Lu3atRjq+qFv+ZLAEzAi4JV5L06VOpODHLijzb5zZ0FgysqpM+7jBzR92pf2kwupUwiDkGR7nzI49PnqZPnNTmYLol6i0LB80VPg3UKtBkJQXEIsbSRObwSlQ6oCp+FUI19O4dGcyY7uatu9JrsJtVjyDGuLd+A+HO/3SuugQV+F2QemU/mcQUnYrFpj4brF1FYSjaN9Sw8fTznzT1mYyD88Ii6arix2ApCSiTCrbtua9Tr1c="
 
-python:
-  - 2.7
-  - 3.4
-  - 3.5
-  - 3.6
+os: linux
 
-matrix:
+jobs:
   include:
+    - python: 2.7
+      env:
+        - DASK_SPEC="dask=0.15"  # minimum supported version
+    - python: 3.5
+      env:
+        - DASK_SPEC="dask=0.15"  # minimum supported version
+    - python: 3.6
+      env:
+        - DASK_SPEC="dask"  # most recent available
     - python: 3.7
-      env: SCIPY_WHEELS="https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com/"
+      env:
+        - DASK_SPEC="dask"  # most recent available
+    - python: 3.8
+      env:
+        - DASK_SPEC="dask"  # most recent available
+        - SCIPY_WHEELS="https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com/"
 
 branches:
     except:
@@ -38,7 +46,7 @@ before_install:
 
 install:
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION nomkl numpy cython setuptools
-  - conda install -q -n test-environment dask=0.15.0 || true
+  - conda install -q -n test-environment $DASK_SPEC || true
   - |
     if [ -z "$SCIPY_WHEELS" ]; then
       conda install -q -n test-environment scipy
@@ -61,7 +69,7 @@ before_deploy:
 deploy:
     provider: pypi
     skip_cleanup: true
-    user: "pyfftw_citools"
+    username: "pyfftw_citools"
     distributions: "sdist"
     password:
         secure: "n6/QGmA0PcMr9/ArpdS3jdcpMHlBOi6sXDT8jRV7MMaEaphsOkZAefK6/flJjwHA6oAu3lDDMJ1YsaxMfVMdSadUxpeYlh0f58WRryfcCIUFr9Rojz0iAtJNOZ1a+M6i6erwxif6y1f645sm72NAKX7m2KorGkH5CcjM+f4nABaLbAmAelIbYQpNMWOESEy2LKYx1xC7Gz1o3N4S/Z4g3o/to/1rNcQ0TujGHJBu/Skz+evhAkpPoEZjJI8TJChrhyODyVQwzNymiiBWmI0OxYmXi/HiH/NkmXjtXmbXVXKHJ7ReiyIAtJ1yDmDssPvnCYffP6Yrmpl9Zcp22LM0GmEIVXKfG5aj0csb784iZhweF1LySB/4mbModXxctO8otcZENnmQlpr3LJQX1hpUPQ9rg2J+uizbyg6loFdJ7V90XlRs4dMhtSIfTtP7zcaf2kYeq/JE56Hs9guMONewNxHtJNDRC4pG0j6VSsHMCdhFRkviLyTC/kbVFtY35uKQpT5e91L6yMRTWuMYUH2tEhmjgxnHOfP+MuXK3O/HttFBcd6gn66AUcO2KNQNHY2xbv35BUv1th64gqFTzrdjZ9j84MpfIk+z4v7bhCWP+sF2syzbYSkJN4WI/BVIi70Pmh7SvOy5dSQXEGNy96M5j4GxC8XVnHv7f82VS56UUqo="

--- a/test/test_pyfftw_dask_interface.py
+++ b/test/test_pyfftw_dask_interface.py
@@ -247,7 +247,7 @@ class InterfacesDaskFFTTestFFT(unittest.TestCase):
                     input_array, s, **kwargs)
 
             if (functions[self.func] == 'r2c'):
-                if numpy.iscomplexobj(input_array):
+                if input_array.dtype.kind == 'c':
                     if len(w) > 0:
                         # Make sure a warning is raised
                         self.assertIs(

--- a/test/test_pyfftw_dask_interface.py
+++ b/test/test_pyfftw_dask_interface.py
@@ -253,16 +253,21 @@ class InterfacesDaskFFTTestFFT(unittest.TestCase):
                         self.assertIs(
                                 w[-1].category, numpy.ComplexWarning)
 
+        # convert dask arrays to NumPy ones prior to calling allclose
+        output_np = output_array.compute()
+        input_np = input_array.compute()
+        test_out_array = test_out_array.compute()
+
         self.assertTrue(
-                numpy.allclose(output_array, test_out_array,
+                numpy.allclose(output_np, test_out_array,
                     rtol=1e-2, atol=1e-4))
 
-        if numpy.asanyarray(input_array).real.dtype == numpy.float16:
+        if input_np.real.dtype == numpy.float16:
             # FFTW output will never be single precision for half precision
             # inputs as there is no half-precision FFTW routine
             input_precision_dtype = numpy.float32
         else:
-            input_precision_dtype = numpy.asanyarray(input_array).real.dtype
+            input_precision_dtype = input_np.real.dtype
 
         self.assertEqual(input_precision_dtype,
                 output_array.real.dtype)

--- a/test/test_pyfftw_dask_interface.py
+++ b/test/test_pyfftw_dask_interface.py
@@ -455,7 +455,7 @@ class InterfacesDaskFFTTestFFT(unittest.TestCase):
                         test_shape, dtype, s, kwargs)
 
 
-    def test_dtype_coercian(self):
+    def test_dtype_coercion(self):
         # Make sure we input a dtype that needs to be coerced
         if functions[self.func] == 'r2c':
             dtype_tuple = self.io_dtypes['complex']


### PR DESCRIPTION
closes #276

Trying this first without bumping dask to 2.x to see if it maintains compatibility with old versions.
Then I can try the dask 2.8 bump as suggested in #277