### PR TITLE
explicitly set the Cython language level

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_install:
   - conda info -a
 
 install:
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION nomkl numpy cython setuptools
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION nomkl numpy setuptools
   - conda install -q -n test-environment $DASK_SPEC || true
   - |
     if [ -z "$SCIPY_WHEELS" ]; then
@@ -55,6 +55,7 @@ install:
       source activate test-environment
       pip install --pre --upgrade --timeout=60 -f "$SCIPY_WHEELS" scipy
     fi
+  - pip install cython  # conda doesn't have new enough Cython for Python 3.5
   - python setup.py -v build_ext --inplace
 
 script:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The documentation can be found on
 - [FFTW](https://www.fftw.org) >= 3.3 (lower versions *may* work) libraries for
   single, double, and long double precision in serial and multithreading
   (pthreads or openMP) versions.
-- [Cython](https://cython.org) >= 0.23 (lower versions *may* work)
+- [Cython](https://cython.org) >= 0.29
 
 (install these as much as possible with your preferred package manager).
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
         PYTHON_HOME: "C:\\pyfftw_miniconda"
         NP_BUILD_DEP: "=1.11"
         SP_BUILD_DEP: "=1.0"
-        CYTHON_BUILD_DEP: "=0.29"
+        CYTHON_BUILD_DEP: "==0.29"
         DASK_BUILD_DEP: "=0.16"
         EXTRA_CONDA_ARGS: ""
         CONDA_ACTIVATE_CMD: "conda activate"
@@ -78,8 +78,10 @@ install:
 
     - "conda config --set always_yes yes --set changeps1 no"
     - "conda update -q conda"
-    - "conda create -q -n build_env %EXTRA_CONDA_ARGS% python=%PYTHON_VERSION% numpy%NP_BUILD_DEP% scipy%SP_BUILD_DEP% cython%CYTHON_BUILD_DEP% dask%DASK_BUILD_DEP% setuptools"
+    - "conda create -q -n build_env %EXTRA_CONDA_ARGS% python=%PYTHON_VERSION% numpy%NP_BUILD_DEP% scipy%SP_BUILD_DEP% dask%DASK_BUILD_DEP% setuptools"
     - "%CONDA_ACTIVATE_CMD% build_env"
+    # install Cython via pip because conda doesn't have Cython 0.29 for Python 3.5
+    - pip install "cython%CYTHON_BUILD_DEP%"
     - "%CMD_IN_ENV% python setup.py -v bdist_wheel"
     - "%CMD_IN_ENV% python setup.py -v build_ext --inplace"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
         PYTHON_HOME: "C:\\pyfftw_miniconda"
         NP_BUILD_DEP: "=1.11"
         SP_BUILD_DEP: "=1.0"
-        CYTHON_BUILD_DEP: "=0.26"
+        CYTHON_BUILD_DEP: "=0.29"
         DASK_BUILD_DEP: "=0.16"
         EXTRA_CONDA_ARGS: ""
         CONDA_ACTIVATE_CMD: "conda activate"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,6 +69,22 @@ environment:
           CYTHON_BUILD_DEP: ""
           DASK_BUILD_DEP: ""
 
+        - PYTHON_HOME: "C:\\Miniconda36"
+          PYTHON_ARCH: "32"
+          PYTHON_VERSION: "3.8"
+          NP_BUILD_DEP: ""
+          SP_BUILD_DEP: ""
+          CYTHON_BUILD_DEP: ""
+          DASK_BUILD_DEP: ""
+
+        - PYTHON_HOME: "C:\\Miniconda36-x64"
+          PYTHON_ARCH: "64"
+          PYTHON_VERSION: "3.8"
+          NP_BUILD_DEP: ""
+          SP_BUILD_DEP: ""
+          CYTHON_BUILD_DEP: ""
+          DASK_BUILD_DEP: ""
+
 install:
     # Get and configure the FFTW libs
     - "%CMD_IN_ENV% ./appveyor/setup_fftw_dlls.cmd"

--- a/pyfftw/cpu.pxd
+++ b/pyfftw/cpu.pxd
@@ -1,4 +1,4 @@
-# cython: language_level=3
+# cython: language_level=3str
 #
 # Copyright 2014 Knowledge Economy Developments Ltd
 #

--- a/pyfftw/cpu.pxd
+++ b/pyfftw/cpu.pxd
@@ -1,3 +1,5 @@
+# cython: language_level=3
+#
 # Copyright 2014 Knowledge Economy Developments Ltd
 #
 # Henry Gomersall

--- a/pyfftw/pyfftw.pyx
+++ b/pyfftw/pyfftw.pyx
@@ -1,4 +1,4 @@
-# cython: language_level=3
+# cython: language_level=3str
 #
 # Copyright 2015 Knowledge Economy Developments Ltd
 #

--- a/pyfftw/pyfftw.pyx
+++ b/pyfftw/pyfftw.pyx
@@ -1,3 +1,5 @@
+# cython: language_level=3
+#
 # Copyright 2015 Knowledge Economy Developments Ltd
 #
 # Henry Gomersall

--- a/pyfftw/utils.pxi
+++ b/pyfftw/utils.pxi
@@ -37,7 +37,7 @@
 
 from bisect import bisect_left
 cimport numpy as np
-cimport cpu
+from . cimport cpu
 from libc.stdint cimport intptr_t
 import warnings
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cython>=0.23
+cython>=0.29
 numpy>=1.10
 scipy>=0.16.0
 dask[array]>=0.15.0

--- a/setup.py
+++ b/setup.py
@@ -755,7 +755,7 @@ def setup_package():
     try:
         import cython
     except ImportError:
-        build_requires.append('cython>=0.23, <1.0')
+        build_requires.append('cython>=0.29, <1.0')
 
     install_requires = [numpy_requirement]
 


### PR DESCRIPTION
This avoids a warning when building with recent Python.