### PR TITLE
Drop testing on Python 2.7 and 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,7 @@ os: linux
 
 jobs:
   include:
-    - python: 2.7
-      env:
-        - DASK_SPEC="dask=0.15"  # minimum supported version
-    - python: 3.5
+    - python: 3.6
       env:
         - DASK_SPEC="dask=0.15"  # minimum supported version
     - python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,18 +35,18 @@ addons:
         libfftw3-dev
 
 before_install:
-  - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  # reference: https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/use-conda-with-travis-ci.html#the-travis-yml-file
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
+  - source "$HOME/miniconda/etc/profile.d/conda.sh"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
 
 install:
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION setuptools
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION setuptools cython $NUMPY_SPEC $SCIPY_SPEC $DASK_SPEC blas=*=openblas
   - conda activate test-environment
-  - conda install -y cython $NUMPY_SPEC $SCIPY_SPEC $DASK_SPEC blas=*=openblas
   - python setup.py -v build_ext --inplace
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,19 +9,21 @@ os: linux
 
 jobs:
   include:
-    - python: 3.6
-      env:
-        - DASK_SPEC="dask=0.15"  # minimum supported version
-    - python: 3.6
-      env:
-        - DASK_SPEC="dask"  # most recent available
     - python: 3.7
       env:
-        - DASK_SPEC="dask"  # most recent available
+        - DASK_SPEC="dask=1.0"      # oldest supported
+        - SCIPY_SPEC="scipy=1.2"     # oldest supported
+        - NUMPY_SPEC="numpy=1.16"   # oldest supported
     - python: 3.8
       env:
         - DASK_SPEC="dask"  # most recent available
-        - SCIPY_WHEELS="https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com/"
+        - SCIPY_SPEC="scipy"
+        - NUMPY_SPEC="numpy"
+    - python: 3.9
+      env:
+        - DASK_SPEC="dask"  # most recent available
+        - SCIPY_SPEC="scipy"
+        - NUMPY_SPEC="numpy"
 
 branches:
     except:
@@ -42,17 +44,9 @@ before_install:
   - conda info -a
 
 install:
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION nomkl numpy setuptools
-  - conda install -q -n test-environment $DASK_SPEC || true
-  - |
-    if [ -z "$SCIPY_WHEELS" ]; then
-      conda install -q -n test-environment scipy
-      source activate test-environment
-    else
-      source activate test-environment
-      pip install --pre --upgrade --timeout=60 -f "$SCIPY_WHEELS" scipy
-    fi
-  - pip install cython  # conda doesn't have new enough Cython for Python 3.5
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION setuptools
+  - conda activate test-environment
+  - conda install -y cython $NUMPY_SPEC $SCIPY_SPEC $DASK_SPEC blas=*=openblas
   - python setup.py -v build_ext --inplace
 
 script:
@@ -74,5 +68,5 @@ deploy:
     on:
         repo: pyFFTW/pyFFTW
         # We only need to build deploy one source release
-        condition: $TRAVIS_PYTHON_VERSION = "2.7"
+        condition: $TRAVIS_PYTHON_VERSION = "3.6"
         tags: true

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The documentation can be found on
 
 ## Requirements (i.e. what it was designed for)
 
-- [Python](https://python.org) 2.7 or >= 3.4
+- [Python](https://python.org) >= 3.6
 - [Numpy](https://www.numpy.org) >= 1.10.4  (lower versions *may* work)
 - [FFTW](https://www.fftw.org) >= 3.3 (lower versions *may* work) libraries for
   single, double, and long double precision in serial and multithreading

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ The documentation can be found on
 
 ## Requirements (i.e. what it was designed for)
 
-- [Python](https://python.org) >= 3.6
-- [Numpy](https://www.numpy.org) >= 1.10.4  (lower versions *may* work)
+- [Python](https://python.org) >= 3.7 (lower versions *may* work)
+- [Numpy](https://www.numpy.org) >= 1.16 (lower versions *may* work)
 - [FFTW](https://www.fftw.org) >= 3.3 (lower versions *may* work) libraries for
   single, double, and long double precision in serial and multithreading
   (pthreads or openMP) versions.
@@ -59,10 +59,12 @@ it is not tested against them.
 
 ## Optional Dependencies
 
-- [Scipy](https://www.scipy.org) >= 0.16
-- [Dask](https://dask.pydata.org) >= 0.14.2
+- [Scipy](https://www.scipy.org) >= 1.2  (>= 1.4 required for the scipy.fft interface)
+- [Dask](https://dask.pydata.org) >= 1.0
 
 Scipy and Dask are only required in order to use their respective interfaces.
+In practice, older versions may work, but they are not tested against. On SciPy
+versions prior to 1.4, only the scipy.fftpack interface will be available.
 
 ## Installation
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,10 +6,10 @@ environment:
         CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
         # The miniconda installations are put in pyfftw_miniconda
         PYTHON_HOME: "C:\\pyfftw_miniconda"
-        NP_BUILD_DEP: "=1.11"
-        SP_BUILD_DEP: "=1.0"
-        CYTHON_BUILD_DEP: "==0.29"
-        DASK_BUILD_DEP: "=0.16"
+        NP_BUILD_DEP: ""
+        SP_BUILD_DEP: ""
+        CYTHON_BUILD_DEP: "=0.29"
+        DASK_BUILD_DEP: ""
         EXTRA_CONDA_ARGS: ""
         CONDA_ACTIVATE_CMD: "conda activate"
 
@@ -27,44 +27,46 @@ environment:
 
     matrix:
 
-        - PYTHON_HOME: "C:\\Miniconda36"
-          PYTHON_ARCH: "32"
-          PYTHON_VERSION: "3.6"
-
-        - PYTHON_HOME: "C:\\Miniconda36-x64"
-          PYTHON_ARCH: "64"
-          PYTHON_VERSION: "3.6"
-
-        - PYTHON_HOME: "C:\\Miniconda36"
+        - PYTHON_HOME: "C:\\Miniconda37"
           PYTHON_ARCH: "32"
           PYTHON_VERSION: "3.7"
-          NP_BUILD_DEP: ""
-          SP_BUILD_DEP: ""
-          CYTHON_BUILD_DEP: ""
-          DASK_BUILD_DEP: ""
+          NP_BUILD_DEP: "=1.16"
+          SP_BUILD_DEP: "=1.2"
+          DASK_BUILD_DEP: "=1.0"
 
-        - PYTHON_HOME: "C:\\Miniconda36-x64"
+        - PYTHON_HOME: "C:\\Miniconda37-x64"
           PYTHON_ARCH: "64"
           PYTHON_VERSION: "3.7"
-          NP_BUILD_DEP: ""
-          SP_BUILD_DEP: ""
-          CYTHON_BUILD_DEP: ""
-          DASK_BUILD_DEP: ""
+          NP_BUILD_DEP: "=1.16"
+          SP_BUILD_DEP: "=1.2"
+          DASK_BUILD_DEP: "=1.0"
 
-        - PYTHON_HOME: "C:\\Miniconda36"
+        - PYTHON_HOME: "C:\\Miniconda37"
           PYTHON_ARCH: "32"
           PYTHON_VERSION: "3.8"
           NP_BUILD_DEP: ""
           SP_BUILD_DEP: ""
-          CYTHON_BUILD_DEP: ""
           DASK_BUILD_DEP: ""
 
-        - PYTHON_HOME: "C:\\Miniconda36-x64"
+        - PYTHON_HOME: "C:\\Miniconda37-x64"
           PYTHON_ARCH: "64"
           PYTHON_VERSION: "3.8"
           NP_BUILD_DEP: ""
           SP_BUILD_DEP: ""
-          CYTHON_BUILD_DEP: ""
+          DASK_BUILD_DEP: ""
+
+        - PYTHON_HOME: "C:\\Miniconda37"
+          PYTHON_ARCH: "32"
+          PYTHON_VERSION: "3.9"
+          NP_BUILD_DEP: ""
+          SP_BUILD_DEP: ""
+          DASK_BUILD_DEP: ""
+
+        - PYTHON_HOME: "C:\\Miniconda37-x64"
+          PYTHON_ARCH: "64"
+          PYTHON_VERSION: "3.9"
+          NP_BUILD_DEP: ""
+          SP_BUILD_DEP: ""
           DASK_BUILD_DEP: ""
 
 install:
@@ -76,10 +78,9 @@ install:
 
     - "conda config --set always_yes yes --set changeps1 no"
     - "conda update -q conda"
-    - "conda create -q -n build_env %EXTRA_CONDA_ARGS% python=%PYTHON_VERSION% numpy%NP_BUILD_DEP% scipy%SP_BUILD_DEP% dask%DASK_BUILD_DEP% setuptools"
+    - "conda create -q -n build_env %EXTRA_CONDA_ARGS% python=%PYTHON_VERSION%
     - "%CONDA_ACTIVATE_CMD% build_env"
-    # install Cython via pip because conda doesn't have Cython 0.29 for Python 3.5
-    - pip install "cython%CYTHON_BUILD_DEP%"
+    - conda install -y cython%CYTHON_BUILD_DEP% numpy%NP_BUILD_DEP% scipy%SP_BUILD_DEP% dask%DASK_BUILD_DEP% setuptools
     - "%CMD_IN_ENV% python setup.py -v bdist_wheel"
     - "%CMD_IN_ENV% python setup.py -v build_ext --inplace"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,24 +27,6 @@ environment:
 
     matrix:
 
-        - PYTHON_HOME: "C:\\Miniconda"
-          PYTHON_ARCH: "32"
-          PYTHON_VERSION: "2.7"
-
-        - PYTHON_HOME: "C:\\Miniconda-x64"
-          PYTHON_ARCH: "64"
-          PYTHON_VERSION: "2.7"
-
-        - PYTHON_HOME: "C:\\Miniconda36"
-          PYTHON_ARCH: "32"
-          PYTHON_VERSION: "3.5"
-          CONDA_ACTIVATE_CMD: "activate"
-
-        - PYTHON_HOME: "C:\\Miniconda36-x64"
-          PYTHON_ARCH: "64"
-          PYTHON_VERSION: "3.5"
-          CONDA_ACTIVATE_CMD: "activate"
-
         - PYTHON_HOME: "C:\\Miniconda36"
           PYTHON_ARCH: "32"
           PYTHON_VERSION: "3.6"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -78,9 +78,9 @@ install:
 
     - "conda config --set always_yes yes --set changeps1 no"
     - "conda update -q conda"
-    - "conda create -q -n build_env %EXTRA_CONDA_ARGS% python=%PYTHON_VERSION%
+    - "conda create -q -n build_env %EXTRA_CONDA_ARGS% python=%PYTHON_VERSION%"
     - "%CONDA_ACTIVATE_CMD% build_env"
-    - conda install -y cython%CYTHON_BUILD_DEP% numpy%NP_BUILD_DEP% scipy%SP_BUILD_DEP% dask%DASK_BUILD_DEP% setuptools
+    - "conda install -y cython%CYTHON_BUILD_DEP% numpy%NP_BUILD_DEP% scipy%SP_BUILD_DEP% dask%DASK_BUILD_DEP% setuptools"
     - "%CMD_IN_ENV% python setup.py -v bdist_wheel"
     - "%CMD_IN_ENV% python setup.py -v build_ext --inplace"
 

--- a/pyfftw/cpu.pxd
+++ b/pyfftw/cpu.pxd
@@ -1,4 +1,4 @@
-# cython: language_level=3str
+# cython: language_level=3
 #
 # Copyright 2014 Knowledge Economy Developments Ltd
 #

--- a/pyfftw/pyfftw.pyx
+++ b/pyfftw/pyfftw.pyx
@@ -1,4 +1,4 @@
-# cython: language_level=3str
+# cython: language_level=3
 #
 # Copyright 2015 Knowledge Economy Developments Ltd
 #

--- a/setup.py
+++ b/setup.py
@@ -785,7 +785,8 @@ def setup_package():
             'Topic :: Scientific/Engineering',
             'Topic :: Scientific/Engineering :: Mathematics',
             'Topic :: Multimedia :: Sound/Audio :: Analysis'],
-        'cmdclass': cmdclass
+        'cmdclass': cmdclass,
+        'python_requires': ">=3.6",
     }
 
     if using_setuptools:


### PR DESCRIPTION
closes #270

Python 3.5 should continue to work for now, but I don't think we need to continue officially supporting it.

Many related packages may now be following NumPy's [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html) guidance and will have already dropped Python 3.5 support at this point.