### PR TITLE
ENH: update interfaces to support new numpy.fft normalization options

### DIFF
--- a/pyfftw/builders/_utils.py
+++ b/pyfftw/builders/_utils.py
@@ -126,7 +126,7 @@ def _norm_args(norm):
     Possible `norm` values are "backward" (alias of None), "ortho",
     "forward".
 
-    This function is used both by the builders and by the interfaces.
+    This function is used by both the builders and the interfaces.
 
     """
     if norm == "ortho":
@@ -139,8 +139,8 @@ def _norm_args(norm):
         ortho = False
         normalise_idft = False
     else:
-        raise ValueError(f'Invalid norm value {norm}; should be \"ortho\", '
-                         '\"backward\" or \"forward\".')
+        raise ValueError(f'Invalid norm value {norm}; should be "ortho", '
+                         '"backward" or "forward".')
     return dict(normalise_idft=normalise_idft, ortho=ortho)
 
 
@@ -197,8 +197,8 @@ def _Xfftn(a, s, axes, overwrite_input,
 
             # warn when losing precision but not when using a higher precision
             if dtype.itemsize < a.dtype.itemsize:
-                warnings.warn("Narrowing conversion from %s to %s\
-                              precision" % (a.dtype, dtype))
+                warnings.warn(f'Narrowing conversion from {a.dtype} to '
+                              f'{dtype} precision')
 
             if not real or inverse:
                 # It's going to be complex
@@ -250,12 +250,13 @@ def _Xfftn(a, s, axes, overwrite_input,
         # `a`, so we need to create a new array.
         input_array = pyfftw.empty_aligned(input_shape, a.dtype)
 
-        FFTW_object = _FFTWWrapper(input_array, output_array, axes, direction,
-                                   flags, threads,
-                                   input_array_slicer=update_input_array_slicer,
-                                   FFTW_array_slicer=FFTW_array_slicer,
-                                   normalise_idft=normalise_idft,
-                                   ortho=ortho)
+        FFTW_object = _FFTWWrapper(
+                            input_array, output_array, axes, direction,
+                            flags, threads,
+                            input_array_slicer=update_input_array_slicer,
+                            FFTW_array_slicer=FFTW_array_slicer,
+                            normalise_idft=normalise_idft,
+                            ortho=ortho)
 
         # We copy the data back into the internal FFTW object array
         internal_array = FFTW_object.input_array
@@ -288,9 +289,10 @@ def _Xfftn(a, s, axes, overwrite_input,
 
             input_array = pyfftw.byte_align(input_array)
 
-        FFTW_object = pyfftw.FFTW(input_array, output_array, axes, direction,
-                                  flags, threads,
-                                  normalise_idft=normalise_idft, ortho=ortho)
+        FFTW_object = pyfftw.FFTW(input_array, output_array, axes,
+                                  direction, flags, threads,
+                                  normalise_idft=normalise_idft,
+                                  ortho=ortho)
 
         if not avoid_copy:
             # Copy the data back into the (likely) destroyed array
@@ -301,8 +303,8 @@ def _Xfftn(a, s, axes, overwrite_input,
 
 class _FFTWWrapper(pyfftw.FFTW):
     """
-    A class that wraps :class:`pyfftw.FFTW`, providing a slicer on the input
-    stage during calls to
+    A class that wraps :class:`pyfftw.FFTW`, providing a slicer
+    on the input stage during calls to
     :meth:`~pyfftw.builders._utils._FFTWWrapper.__call__`.
 
     """
@@ -431,8 +433,8 @@ def _compute_array_shapes(a, s, axes, inverse, real):
     Given a passed in array ``a``, and the rest of the arguments (that have
     been fleshed out with :func:`~pyfftw.builders._utils._cook_nd_args`),
     compute the shape the input and output arrays need to be in order to
-    satisfy all the requirements for the transform. The input shape *may* be
-    different to the shape of a.
+    satisfy all the requirements for the transform. The input shape *may*
+    be different to the shape of a.
 
     Returns: ``(input_shape, output_shape)``
 

--- a/pyfftw/builders/_utils.py
+++ b/pyfftw/builders/_utils.py
@@ -112,8 +112,8 @@ def _default_threads(threads):
         return config.NUM_THREADS
     else:
         if threads > 1 and _threading_type is None:
-            raise ValueError("threads > 1 requested, but pyFFTW was not built "
-                             "with multithreaded FFTW.")
+            raise ValueError("threads > 1 requested, but pyFFTW was not "
+                             "built with multithreaded FFTW.")
         elif threads <= 0:
             return multiprocessing.cpu_count()
         return threads
@@ -190,7 +190,8 @@ def _Xfftn(a, s, axes, overwrite_input,
     else:
         if a.dtype.char not in _rc_dtype_pairs:
             dtype = _default_dtype
-            if a.dtype == numpy.dtype('float16') and '32' in pyfftw._supported_types:
+            if a.dtype == numpy.dtype('float16'
+                                      ) and '32' in pyfftw._supported_types:
                 # convert half-precision to single precision, if available
                 dtype = numpy.dtype('float32')
 
@@ -253,7 +254,8 @@ def _Xfftn(a, s, axes, overwrite_input,
                                    flags, threads,
                                    input_array_slicer=update_input_array_slicer,
                                    FFTW_array_slicer=FFTW_array_slicer,
-                                   normalise_idft=normalise_idft, ortho=ortho)
+                                   normalise_idft=normalise_idft,
+                                   ortho=ortho)
 
         # We copy the data back into the internal FFTW object array
         internal_array = FFTW_object.input_array
@@ -377,11 +379,11 @@ class _FFTWWrapper(pyfftw.FFTW):
         if ortho is None:
             ortho = self._ortho
 
-        output = super(_FFTWWrapper, self).__call__(input_array=None,
-                                                    output_array=output_array,
-                                                    normalise_idft=normalise_idft,
-                                                    ortho=ortho)
-
+        output = super(_FFTWWrapper,
+                       self).__call__(input_array=None,
+                                      output_array=output_array,
+                                      normalise_idft=normalise_idft,
+                                      ortho=ortho)
         return output
 
 

--- a/pyfftw/builders/_utils.py
+++ b/pyfftw/builders/_utils.py
@@ -123,6 +123,11 @@ def _norm_args(norm):
     """
     Returns the proper normalization parameter values.
 
+    Possible `norm` values are "backward" (alias of None), "ortho",
+    "forward".
+
+    This function is used both by the builders and by the interfaces.
+
     """
     if norm == "ortho":
         ortho = True
@@ -155,7 +160,7 @@ def _Xfftn(a, s, axes, overwrite_input,
     are ignored.
 
     """
-    # a_orig = a
+    # a_orig = a  # a_orig doesn't appear to be used
     invreal = inverse and real
 
     if real_direction_flag is not None:

--- a/pyfftw/builders/_utils.py
+++ b/pyfftw/builders/_utils.py
@@ -56,9 +56,9 @@ from .. import _threading_type
 from .. import config
 
 
-__all__ = ['_FFTWWrapper', '_rc_dtype_pairs', '_default_dtype', '_Xfftn',
-           '_setup_input_slicers', '_compute_array_shapes', '_precook_1d_args',
-           '_cook_nd_args']
+__all__ = ['_FFTWWrapper', '_rc_dtype_pairs', '_default_dtype',
+           '_Xfftn', '_setup_input_slicers', '_compute_array_shapes',
+           '_precook_1d_args', '_cook_nd_args']
 
 _valid_efforts = ('FFTW_ESTIMATE', 'FFTW_MEASURE',
                   'FFTW_PATIENT', 'FFTW_EXHAUSTIVE')
@@ -119,22 +119,23 @@ def _default_threads(threads):
         return threads
 
 
-def _unitary(norm):
-    """_unitary() utility copied from numpy"""
-    if norm not in (None, "ortho"):
-        raise ValueError("Invalid norm value %s, should be None or \"ortho\"."
-                         % norm)
-    return norm is not None
-
-
 def _norm_args(norm):
-    """ pass the proper normalization-related keyword arguments. """
-    if _unitary(norm):
+    """
+    Returns the proper normalization parameter values.
+
+    """
+    if norm == "ortho":
         ortho = True
         normalise_idft = False
-    else:
+    elif norm is None or norm == "backward":
         ortho = False
         normalise_idft = True
+    elif norm == "forward":
+        ortho = False
+        normalise_idft = False
+    else:
+        raise ValueError(f'Invalid norm value {norm}; should be \"ortho\", '
+                         '\"backward\" or \"forward\".')
     return dict(normalise_idft=normalise_idft, ortho=ortho)
 
 
@@ -154,7 +155,7 @@ def _Xfftn(a, s, axes, overwrite_input,
     are ignored.
 
     """
-    a_orig = a
+    # a_orig = a
     invreal = inverse and real
 
     if real_direction_flag is not None:

--- a/pyfftw/builders/builders.py
+++ b/pyfftw/builders/builders.py
@@ -91,8 +91,8 @@ not necessarily the case that the internal array *is* the input array.
 The actual internal input array can always be retrieved with
 :attr:`pyfftw.FFTW.input_array`.
 
-The behavior of the ``norm`` parameter in all builder routines matches that of
-the corresponding ``numpy.fft`` functions.  In particular, if
+The behavior of the ``norm`` parameter in all builder routines matches that
+of the corresponding ``numpy.fft`` functions.  In particular, if
 ``norm == "backward"`` (alias of ``None``) then the forward/direct FFT is
 unscaled and the backward/inverse is scaled by 1/N, where N is the length of
 the input array (for multidimensional FFTs it's the product of the lengths of

--- a/pyfftw/builders/builders.py
+++ b/pyfftw/builders/builders.py
@@ -374,7 +374,7 @@ def fftn(a, s=None, axes=None, overwrite_input=False,
          auto_align_input=True, auto_contiguous=True,
          avoid_copy=False, norm=None):
     """
-    Return a :class:`pyfftw.FFTW` object representing an n-D FFT.
+    Return a :class:`pyfftw.FFTW` object representing an nD FFT.
 
     The first three arguments are as per :func:`numpy.fft.fftn`; the rest of
     the arguments are documented :ref:`in the module docs <builders_args>`.
@@ -395,7 +395,7 @@ def ifftn(a, s=None, axes=None, overwrite_input=False,
           auto_align_input=True, auto_contiguous=True,
           avoid_copy=False, norm=None):
     """
-    Return a :class:`pyfftw.FFTW` object representing an n-D inverse FFT.
+    Return a :class:`pyfftw.FFTW` object representing an nD inverse FFT.
 
     The first three arguments are as per :func:`numpy.fft.ifftn`; the rest of
     the arguments are documented :ref:`in the module docs <builders_args>`.
@@ -440,7 +440,7 @@ def irfft(a, n=None, axis=-1, overwrite_input=False,
           auto_align_input=True, auto_contiguous=True,
           avoid_copy=False, norm=None):
     """
-    Return a :class:`pyfftw.FFTW` object representing an 1D real inverse FFT.
+    Return a :class:`pyfftw.FFTW` object representing an 1D inverse real FFT.
 
     The first three arguments are as per :func:`numpy.fft.irfft`; the rest of
     the arguments are documented :ref:`in the module docs <builders_args>`.
@@ -484,7 +484,7 @@ def irfft2(a, s=None, axes=(-2, -1),
            auto_align_input=True, auto_contiguous=True,
            avoid_copy=False, norm=None):
     """
-    Return a :class:`pyfftw.FFTW` object representing a 2D real inverse FFT.
+    Return a :class:`pyfftw.FFTW` object representing a 2D inverse real FFT.
 
     The first three arguments are as per :func:`numpy.fft.irfft2`; the rest of
     the arguments are documented :ref:`in the module docs <builders_args>`.
@@ -507,7 +507,7 @@ def rfftn(a, s=None, axes=None, overwrite_input=False,
           auto_align_input=True, auto_contiguous=True,
           avoid_copy=False, norm=None):
     """
-    Return a :class:`pyfftw.FFTW` object representing an n-D real FFT.
+    Return a :class:`pyfftw.FFTW` object representing an nD real FFT.
 
     The first three arguments are as per :func:`numpy.fft.rfftn`; the rest of
     the arguments are documented :ref:`in the module docs <builders_args>`.
@@ -528,7 +528,7 @@ def irfftn(a, s=None, axes=None,
            auto_align_input=True, auto_contiguous=True,
            avoid_copy=False, norm=None):
     """
-    Return a :class:`pyfftw.FFTW` object representing an n-D real inverse FFT.
+    Return a :class:`pyfftw.FFTW` object representing an nD inverse real FFT.
 
     The first three arguments are as per :func:`numpy.fft.rfftn`; the rest of
     the arguments are documented :ref:`in the module docs <builders_args>`.
@@ -553,15 +553,15 @@ def dct(a, n=None, axis=-1, overwrite_input=False,
     """
     Return a :class:`pyfftw.FFTW` object representing an 1D DCT.
 
-    The first three arguments and 'type' are as per :func:`scipy.fftpack.dct`;
-    the rest of the arguments are documented
-    :ref:`in the module docs <builders_args>`.
+    The first three arguments and 'type' are as per
+    :func:`scipy.fftpack.dct`; the rest of the arguments are
+    documented :ref:`in the module docs <builders_args>`.
 
     """
     dct_types = ['FFTW_REDFT00', 'FFTW_REDFT10', 'FFTW_REDFT01',
                  'FFTW_REDFT11', 1, 2, 3, 4]
     if type not in dct_types:
-        raise ValueError("Unrecognised DCT type {}".format(type))
+        raise ValueError(f"Unrecognised DCT type {type}")
 
     if n is not None and n != a.shape[axis]:
         raise NotImplementedError
@@ -580,7 +580,8 @@ def dct(a, n=None, axis=-1, overwrite_input=False,
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
                   threads, auto_align_input, auto_contiguous,
-                  avoid_copy, inverse, real, real_direction_flag=direction)
+                  avoid_copy, inverse, real,
+                  real_direction_flag=direction)
 
 
 def dst(a, n=None, axis=-1, overwrite_input=False,
@@ -590,15 +591,15 @@ def dst(a, n=None, axis=-1, overwrite_input=False,
     """
     Return a :class:`pyfftw.FFTW` object representing an 1D DST.
 
-    The first three arguments and 'type' are as per :func:`scipy.fftpack.dst`;
-    the rest of the arguments are documented
-    :ref:`in the module docs <builders_args>`.
+    The first three arguments and 'type' are as per
+    :func:`scipy.fftpack.dst`; the rest of the arguments are
+    documented :ref:`in the module docs <builders_args>`.
 
     """
     dst_types = ['FFTW_RODFT00', 'FFTW_RODFT10', 'FFTW_RODFT01',
                  'FFTW_RODFT11', 1, 2, 3, 4]
     if type not in dst_types:
-        raise ValueError("Unrecognised DST type {}".format(type))
+        raise ValueError(f"Unrecognised DST type {type}")
 
     if n is not None and n != a.shape[axis]:
         raise NotImplementedError
@@ -617,4 +618,5 @@ def dst(a, n=None, axis=-1, overwrite_input=False,
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
                   threads, auto_align_input, auto_contiguous,
-                  avoid_copy, inverse, real, real_direction_flag=direction)
+                  avoid_copy, inverse, real,
+                  real_direction_flag=direction)

--- a/pyfftw/builders/builders.py
+++ b/pyfftw/builders/builders.py
@@ -73,8 +73,7 @@ internal input array is then extracted using
 persistently fill the padding space with whatever the user desires, so
 subsequent calls with a new input only overwrite the values that aren't
 padding (even if the array that is used for the call is bigger than the
-original - see the point above about bigger arrays being sliced to
-fit).
+original - see the point above about bigger arrays being sliced to fit).
 
 The precision of the FFT operation is acquired from the input array.
 If an array is passed in that is not of float type, or is of an
@@ -92,12 +91,20 @@ not necessarily the case that the internal array *is* the input array.
 The actual internal input array can always be retrieved with
 :attr:`pyfftw.FFTW.input_array`.
 
-The behaviour of the ``norm`` option in all builder routines matches that of
-the corresponding numpy functions.  In short, if ``norm`` is ``None``, then the
-output from the forward DFT is unscaled and the inverse DFT is scaled by 1/N,
-where N is the product of the lengths of input array on which the FFT is taken.
-If ``norm == 'ortho'``, then the output of both forward and inverse DFT
-operations are scaled by 1/sqrt(N).
+The behavior of the ``norm`` parameter in all builder routines matches that of
+the corresponding ``numpy.fft`` functions.  In particular, if
+``norm == "backward"`` (alias of ``None``) then the forward/direct FFT is
+unscaled and the backward/inverse is scaled by 1/N, where N is the length of
+the input array (for multidimensional FFTs it's the product of the lengths of
+each dimension). If ``norm == "ortho"`` then both the forward and the backward
+FFTs are scaled by 1/sqrt(N). Finally, if ``norm == "forward"`` then the
+forward FFT is scaled by 1/N and the backward is unscaled (exact opposite of
+the ``"backward"`` case). The default case is ``norm == "backward"``.
+
+In all three cases, using the same ``norm`` value for both the forward and the
+backward FFT ensures *roundtrip equality*, i.e. that applying the forwad and
+then the backward FFT to an input array returns the original array (up to
+numerical accuracy).
 
 **Example:**
 

--- a/pyfftw/builders/builders.py
+++ b/pyfftw/builders/builders.py
@@ -35,9 +35,9 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
-'''
+"""
 Overview
-""""""""
+--------
 
 This module contains a set of functions that return
 :class:`pyfftw.FFTW` objects.
@@ -113,7 +113,7 @@ operations are scaled by 1/sqrt(N).
 More examples can be found in the :doc:`tutorial </source/tutorial>`.
 
 Supported Functions and Caveats
-"""""""""""""""""""""""""""""""
+-------------------------------
 
 The following functions are supported. They can be used with the
 same calling signature as their respective functions in
@@ -168,7 +168,7 @@ array is not already aligned correctly.
 .. _builders_args:
 
 Additional Arguments
-""""""""""""""""""""
+--------------------
 
 In addition to the arguments that are present with their complementary
 functions in :mod:`numpy.fft`, each of these functions also offers the
@@ -265,25 +265,26 @@ following additional keyword arguments:
 
 The exceptions raised by each of these functions are as per their
 equivalents in :mod:`numpy.fft`, or as documented above.
-'''
 
+"""
 from ._utils import (_precook_1d_args, _Xfftn, _norm_args, _default_effort,
                      _default_threads)
 
-__all__ = ['fft','ifft', 'fft2', 'ifft2', 'fftn',
-           'ifftn', 'rfft', 'irfft', 'rfft2', 'irfft2', 'rfftn',
-           'irfftn', 'dct', 'dst']
+__all__ = ['fft', 'ifft', 'fft2', 'ifft2', 'fftn', 'ifftn', 'rfft', 'irfft',
+           'rfft2', 'irfft2', 'rfftn', 'irfftn', 'dct', 'dst']
+
 
 def fft(a, n=None, axis=-1, overwrite_input=False,
         planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, norm=None):
-    '''Return a :class:`pyfftw.FFTW` object representing a 1D FFT.
+    """
+    Return a :class:`pyfftw.FFTW` object representing an 1D FFT.
 
-    The first three arguments are as per :func:`numpy.fft.fft`;
-    the rest of the arguments are documented
-    :ref:`in the module docs <builders_args>`.
-    '''
+    The first three arguments are as per :func:`numpy.fft.fft`; the rest of
+    the arguments are documented :ref:`in the module docs <builders_args>`.
+
+    """
     inverse = False
     real = False
 
@@ -292,21 +293,21 @@ def fft(a, n=None, axis=-1, overwrite_input=False,
     threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
-            threads, auto_align_input, auto_contiguous,
-            avoid_copy, inverse, real, **_norm_args(norm))
+                  threads, auto_align_input, auto_contiguous,
+                  avoid_copy, inverse, real, **_norm_args(norm))
+
 
 def ifft(a, n=None, axis=-1, overwrite_input=False,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True,
-        avoid_copy=False, norm=None):
-    '''Return a :class:`pyfftw.FFTW` object representing a 1D
-    inverse FFT.
+         planner_effort=None, threads=None,
+         auto_align_input=True, auto_contiguous=True,
+         avoid_copy=False, norm=None):
+    """
+    Return a :class:`pyfftw.FFTW` object representing an 1D inverse FFT.
 
-    The first three arguments are as per :func:`numpy.fft.ifft`;
-    the rest of the arguments are documented
-    :ref:`in the module docs <builders_args>`.
-    '''
+    The first three arguments are as per :func:`numpy.fft.ifft`; the rest of
+    the arguments are documented :ref:`in the module docs <builders_args>`.
 
+    """
     inverse = True
     real = False
 
@@ -315,109 +316,105 @@ def ifft(a, n=None, axis=-1, overwrite_input=False,
     threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
-            threads, auto_align_input, auto_contiguous,
-            avoid_copy, inverse, real, **_norm_args(norm))
+                  threads, auto_align_input, auto_contiguous,
+                  avoid_copy, inverse, real, **_norm_args(norm))
 
 
-def fft2(a, s=None, axes=(-2,-1), overwrite_input=False,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True,
-        avoid_copy=False, norm=None):
-    '''Return a :class:`pyfftw.FFTW` object representing a 2D FFT.
+def fft2(a, s=None, axes=(-2, -1), overwrite_input=False,
+         planner_effort=None, threads=None,
+         auto_align_input=True, auto_contiguous=True,
+         avoid_copy=False, norm=None):
+    """
+    Return a :class:`pyfftw.FFTW` object representing a 2D FFT.
 
-    The first three arguments are as per :func:`numpy.fft.fft2`;
-    the rest of the arguments are documented
-    :ref:`in the module docs <builders_args>`.
-    '''
+    The first three arguments are as per :func:`numpy.fft.fft2`; the rest of
+    the arguments are documented :ref:`in the module docs <builders_args>`.
 
-
+    """
     inverse = False
     real = False
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
-            threads, auto_align_input, auto_contiguous,
-            avoid_copy, inverse, real, **_norm_args(norm))
-
-def ifft2(a, s=None, axes=(-2,-1), overwrite_input=False,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True,
-        avoid_copy=False, norm=None):
-    '''Return a :class:`pyfftw.FFTW` object representing a
-    2D inverse FFT.
-
-    The first three arguments are as per :func:`numpy.fft.ifft2`;
-    the rest of the arguments are documented
-    :ref:`in the module docs <builders_args>`.
-    '''
+                  threads, auto_align_input, auto_contiguous,
+                  avoid_copy, inverse, real, **_norm_args(norm))
 
 
+def ifft2(a, s=None, axes=(-2, -1), overwrite_input=False,
+          planner_effort=None, threads=None,
+          auto_align_input=True, auto_contiguous=True,
+          avoid_copy=False, norm=None):
+    """
+    Return a :class:`pyfftw.FFTW` object representing a 2D inverse FFT.
+
+    The first three arguments are as per :func:`numpy.fft.ifft2`; the rest of
+    the arguments are documented :ref:`in the module docs <builders_args>`.
+
+    """
     inverse = True
     real = False
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
-            threads, auto_align_input, auto_contiguous,
-            avoid_copy, inverse, real, **_norm_args(norm))
+                  threads, auto_align_input, auto_contiguous,
+                  avoid_copy, inverse, real, **_norm_args(norm))
 
 
 def fftn(a, s=None, axes=None, overwrite_input=False,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True,
-        avoid_copy=False, norm=None):
-    '''Return a :class:`pyfftw.FFTW` object representing a n-D FFT.
+         planner_effort=None, threads=None,
+         auto_align_input=True, auto_contiguous=True,
+         avoid_copy=False, norm=None):
+    """
+    Return a :class:`pyfftw.FFTW` object representing an n-D FFT.
 
-    The first three arguments are as per :func:`numpy.fft.fftn`;
-    the rest of the arguments are documented
-    :ref:`in the module docs <builders_args>`.
-    '''
+    The first three arguments are as per :func:`numpy.fft.fftn`; the rest of
+    the arguments are documented :ref:`in the module docs <builders_args>`.
 
-
+    """
     inverse = False
     real = False
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
-            threads, auto_align_input, auto_contiguous,
-            avoid_copy, inverse, real, **_norm_args(norm))
+                  threads, auto_align_input, auto_contiguous,
+                  avoid_copy, inverse, real, **_norm_args(norm))
+
 
 def ifftn(a, s=None, axes=None, overwrite_input=False,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True,
-        avoid_copy=False, norm=None):
-    '''Return a :class:`pyfftw.FFTW` object representing an n-D
-    inverse FFT.
+          planner_effort=None, threads=None,
+          auto_align_input=True, auto_contiguous=True,
+          avoid_copy=False, norm=None):
+    """
+    Return a :class:`pyfftw.FFTW` object representing an n-D inverse FFT.
 
-    The first three arguments are as per :func:`numpy.fft.ifftn`;
-    the rest of the arguments are documented
-    :ref:`in the module docs <builders_args>`.
-    '''
+    The first three arguments are as per :func:`numpy.fft.ifftn`; the rest of
+    the arguments are documented :ref:`in the module docs <builders_args>`.
 
-
+    """
     inverse = True
     real = False
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
-            threads, auto_align_input, auto_contiguous,
-            avoid_copy, inverse, real, **_norm_args(norm))
+                  threads, auto_align_input, auto_contiguous,
+                  avoid_copy, inverse, real, **_norm_args(norm))
+
 
 def rfft(a, n=None, axis=-1, overwrite_input=False,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True,
-        avoid_copy=False, norm=None):
-    '''Return a :class:`pyfftw.FFTW` object representing a 1D
-    real FFT.
+         planner_effort=None, threads=None,
+         auto_align_input=True, auto_contiguous=True,
+         avoid_copy=False, norm=None):
+    """
+    Return a :class:`pyfftw.FFTW` object representing an 1D real FFT.
 
     The first three arguments are as per :func:`numpy.fft.rfft`;
     the rest of the arguments are documented
     :ref:`in the module docs <builders_args>`.
-    '''
-
+    """
 
     inverse = False
     real = True
@@ -427,22 +424,21 @@ def rfft(a, n=None, axis=-1, overwrite_input=False,
     threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
-            threads, auto_align_input, auto_contiguous,
-            avoid_copy, inverse, real, **_norm_args(norm))
+                  threads, auto_align_input, auto_contiguous,
+                  avoid_copy, inverse, real, **_norm_args(norm))
+
 
 def irfft(a, n=None, axis=-1, overwrite_input=False,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True,
-        avoid_copy=False, norm=None):
-    '''Return a :class:`pyfftw.FFTW` object representing a 1D
-    real inverse FFT.
+          planner_effort=None, threads=None,
+          auto_align_input=True, auto_contiguous=True,
+          avoid_copy=False, norm=None):
+    """
+    Return a :class:`pyfftw.FFTW` object representing an 1D real inverse FFT.
 
-    The first three arguments are as per :func:`numpy.fft.irfft`;
-    the rest of the arguments are documented
-    :ref:`in the module docs <builders_args>`.
-    '''
+    The first three arguments are as per :func:`numpy.fft.irfft`; the rest of
+    the arguments are documented :ref:`in the module docs <builders_args>`.
 
-
+    """
     inverse = True
     real = True
 
@@ -451,43 +447,42 @@ def irfft(a, n=None, axis=-1, overwrite_input=False,
     threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
-            threads, auto_align_input, auto_contiguous,
-            avoid_copy, inverse, real, **_norm_args(norm))
+                  threads, auto_align_input, auto_contiguous,
+                  avoid_copy, inverse, real, **_norm_args(norm))
 
-def rfft2(a, s=None, axes=(-2,-1), overwrite_input=False,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True,
-        avoid_copy=False, norm=None):
-    '''Return a :class:`pyfftw.FFTW` object representing a 2D
-    real FFT.
 
-    The first three arguments are as per :func:`numpy.fft.rfft2`;
-    the rest of the arguments are documented
-    :ref:`in the module docs <builders_args>`.
-    '''
+def rfft2(a, s=None, axes=(-2, -1), overwrite_input=False,
+          planner_effort=None, threads=None,
+          auto_align_input=True, auto_contiguous=True,
+          avoid_copy=False, norm=None):
+    """
+    Return a :class:`pyfftw.FFTW` object representing a 2D real FFT.
 
+    The first three arguments are as per :func:`numpy.fft.rfft2`; the rest of
+    the arguments are documented :ref:`in the module docs <builders_args>`.
+
+    """
     inverse = False
     real = True
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
-            threads, auto_align_input, auto_contiguous,
-            avoid_copy, inverse, real, **_norm_args(norm))
-
-def irfft2(a, s=None, axes=(-2,-1),
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True,
-        avoid_copy=False, norm=None):
-    '''Return a :class:`pyfftw.FFTW` object representing a 2D
-    real inverse FFT.
-
-    The first three arguments are as per :func:`numpy.fft.irfft2`;
-    the rest of the arguments are documented
-    :ref:`in the module docs <builders_args>`.
-    '''
+                  threads, auto_align_input, auto_contiguous,
+                  avoid_copy, inverse, real, **_norm_args(norm))
 
 
+def irfft2(a, s=None, axes=(-2, -1),
+           planner_effort=None, threads=None,
+           auto_align_input=True, auto_contiguous=True,
+           avoid_copy=False, norm=None):
+    """
+    Return a :class:`pyfftw.FFTW` object representing a 2D real inverse FFT.
+
+    The first three arguments are as per :func:`numpy.fft.irfft2`; the rest of
+    the arguments are documented :ref:`in the module docs <builders_args>`.
+
+    """
     inverse = True
     real = True
 
@@ -496,46 +491,42 @@ def irfft2(a, s=None, axes=(-2,-1),
     threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
-            threads, auto_align_input, auto_contiguous,
-            avoid_copy, inverse, real, **_norm_args(norm))
+                  threads, auto_align_input, auto_contiguous,
+                  avoid_copy, inverse, real, **_norm_args(norm))
 
 
 def rfftn(a, s=None, axes=None, overwrite_input=False,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True,
-        avoid_copy=False, norm=None):
-    '''Return a :class:`pyfftw.FFTW` object representing an n-D
-    real FFT.
+          planner_effort=None, threads=None,
+          auto_align_input=True, auto_contiguous=True,
+          avoid_copy=False, norm=None):
+    """
+    Return a :class:`pyfftw.FFTW` object representing an n-D real FFT.
 
-    The first three arguments are as per :func:`numpy.fft.rfftn`;
-    the rest of the arguments are documented
-    :ref:`in the module docs <builders_args>`.
-    '''
+    The first three arguments are as per :func:`numpy.fft.rfftn`; the rest of
+    the arguments are documented :ref:`in the module docs <builders_args>`.
 
-
+    """
     inverse = False
     real = True
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
-            threads, auto_align_input, auto_contiguous,
-            avoid_copy, inverse, real, **_norm_args(norm))
+                  threads, auto_align_input, auto_contiguous,
+                  avoid_copy, inverse, real, **_norm_args(norm))
 
 
 def irfftn(a, s=None, axes=None,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True,
-        avoid_copy=False, norm=None):
-    '''Return a :class:`pyfftw.FFTW` object representing an n-D
-    real inverse FFT.
+           planner_effort=None, threads=None,
+           auto_align_input=True, auto_contiguous=True,
+           avoid_copy=False, norm=None):
+    """
+    Return a :class:`pyfftw.FFTW` object representing an n-D real inverse FFT.
 
-    The first three arguments are as per :func:`numpy.fft.rfftn`;
-    the rest of the arguments are documented
-    :ref:`in the module docs <builders_args>`.
-    '''
+    The first three arguments are as per :func:`numpy.fft.rfftn`; the rest of
+    the arguments are documented :ref:`in the module docs <builders_args>`.
 
-
+    """
     inverse = True
     real = True
 
@@ -544,20 +535,22 @@ def irfftn(a, s=None, axes=None,
     threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
-            threads, auto_align_input, auto_contiguous,
-            avoid_copy, inverse, real, **_norm_args(norm))
+                  threads, auto_align_input, auto_contiguous,
+                  avoid_copy, inverse, real, **_norm_args(norm))
 
 
 def dct(a, n=None, axis=-1, overwrite_input=False,
         planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, type=2):
-    '''Return a :class:`pyfftw.FFTW` object representing a 1D DCT.
+    """
+    Return a :class:`pyfftw.FFTW` object representing an 1D DCT.
 
-    The first three arguments and 'type' are as per
-    :func:`scipy.fftpack.dct`; the rest of the arguments are documented
+    The first three arguments and 'type' are as per :func:`scipy.fftpack.dct`;
+    the rest of the arguments are documented
     :ref:`in the module docs <builders_args>`.
-    '''
+
+    """
     dct_types = ['FFTW_REDFT00', 'FFTW_REDFT10', 'FFTW_REDFT01',
                  'FFTW_REDFT11', 1, 2, 3, 4]
     if type not in dct_types:
@@ -587,12 +580,14 @@ def dst(a, n=None, axis=-1, overwrite_input=False,
         planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True,
         avoid_copy=False, type=2):
-    '''Return a :class:`pyfftw.FFTW` object representing a 1D DST.
+    """
+    Return a :class:`pyfftw.FFTW` object representing an 1D DST.
 
-    The first three arguments and 'type' are as per
-    :func:`scipy.fftpack.dst`; the rest of the arguments are documented
+    The first three arguments and 'type' are as per :func:`scipy.fftpack.dst`;
+    the rest of the arguments are documented
     :ref:`in the module docs <builders_args>`.
-    '''
+
+    """
     dst_types = ['FFTW_RODFT00', 'FFTW_RODFT10', 'FFTW_RODFT01',
                  'FFTW_RODFT11', 1, 2, 3, 4]
     if type not in dst_types:

--- a/pyfftw/config.py
+++ b/pyfftw/config.py
@@ -72,6 +72,7 @@ class _EnvReloader(object):
             if name.isupper():
                 globals()[name] = value
 
+
 _env_reloader = _EnvReloader()
 
 

--- a/pyfftw/interfaces/_utils.py
+++ b/pyfftw/interfaces/_utils.py
@@ -38,10 +38,10 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
-'''
+"""
 Utility functions for the interfaces routines.
 
-'''
+"""
 import pyfftw.builders as builders
 import pyfftw
 import numpy as np

--- a/pyfftw/interfaces/_utils.py
+++ b/pyfftw/interfaces/_utils.py
@@ -39,23 +39,23 @@
 #
 
 '''
-Utility functions for the interfaces routines
-'''
+Utility functions for the interfaces routines.
 
+'''
 import pyfftw.builders as builders
 import pyfftw
-import numpy
+import numpy as np
 from . import cache
 
 
 def _Xfftn(a, s, axes, overwrite_input, planner_effort,
-        threads, auto_align_input, auto_contiguous,
-        calling_func, normalise_idft=True, ortho=False,
-        real_direction_flag=None):
+           threads, auto_align_input, auto_contiguous,
+           calling_func, normalise_idft=True, ortho=False,
+           real_direction_flag=None):
 
     work_with_copy = False
 
-    a = numpy.asanyarray(a)
+    a = np.asanyarray(a)
 
     try:
         s = tuple(s)
@@ -143,7 +143,8 @@ def _Xfftn(a, s, axes, overwrite_input, planner_effort,
         if cache.is_enabled():
             cache._fftw_cache.insert(FFTW_object, key)
 
-        output_array = FFTW_object(normalise_idft=normalise_idft, ortho=ortho)
+        output_array = FFTW_object(normalise_idft=normalise_idft,
+                                   ortho=ortho)
 
     else:
         orig_output_array = FFTW_object.output_array
@@ -155,6 +156,6 @@ def _Xfftn(a, s, axes, overwrite_input, planner_effort,
             output_shape, output_dtype, n=output_alignment)
 
         FFTW_object(input_array=a, output_array=output_array,
-                normalise_idft=normalise_idft, ortho=ortho)
+                    normalise_idft=normalise_idft, ortho=ortho)
 
     return output_array

--- a/pyfftw/interfaces/_utils.py
+++ b/pyfftw/interfaces/_utils.py
@@ -92,7 +92,7 @@ def _Xfftn(a, s, axes, overwrite_input, planner_effort,
             work_with_copy = True
 
             if overwrite_input:
-                raise ValueError('overwrite_input cannot be True when the ' +
+                raise ValueError('overwrite_input cannot be True when the '
                                  'input array flags.writeable is False')
 
     if work_with_copy:

--- a/pyfftw/interfaces/dask_fft.py
+++ b/pyfftw/interfaces/dask_fft.py
@@ -32,7 +32,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
-'''
+"""
 This module implements those functions that replace aspects of the
 :mod:`dask.fft` module. This module *provides* the entire documented
 namespace of :mod:`dask.fft`, but those functions that are not included
@@ -51,16 +51,14 @@ required, the default will be double precision.
 The exceptions raised by each of these functions are mostly as per their
 equivalents in :mod:`dask.fft`, though there are some corner cases in
 which this may not be true.
-'''
+"""
 
 from . import numpy_fft as _numpy_fft
-from dask.array.fft import (
-    fft_wrap,
-    fftfreq,
-    rfftfreq,
-    fftshift,
-    ifftshift,
-)
+from dask.array.fft import (fft_wrap,
+                            fftfreq,
+                            rfftfreq,
+                            fftshift,
+                            ifftshift)
 
 fft = fft_wrap(_numpy_fft.fft)
 ifft = fft_wrap(_numpy_fft.ifft)

--- a/pyfftw/interfaces/dask_fft.py
+++ b/pyfftw/interfaces/dask_fft.py
@@ -38,8 +38,7 @@ This module implements those functions that replace aspects of the
 namespace of :mod:`dask.fft`, but those functions that are not included
 here are imported directly from :mod:`dask.fft`.
 
-
-It is notable that unlike :mod:`numpy.fftpack`, which :mod:`dask.fft`
+It is notable that unlike :mod:`numpy.fft`, which :mod:`dask.fft`
 wraps, these functions will generally return an output array with the
 same precision as the input array, and the transform that is chosen is
 chosen based on the precision of the input array. That is, if the input
@@ -51,14 +50,11 @@ required, the default will be double precision.
 The exceptions raised by each of these functions are mostly as per their
 equivalents in :mod:`dask.fft`, though there are some corner cases in
 which this may not be true.
-"""
 
+"""
 from . import numpy_fft as _numpy_fft
-from dask.array.fft import (fft_wrap,
-                            fftfreq,
-                            rfftfreq,
-                            fftshift,
-                            ifftshift)
+from dask.array.fft import (fft_wrap, fftfreq, rfftfreq,
+                            fftshift, ifftshift)
 
 fft = fft_wrap(_numpy_fft.fft)
 ifft = fft_wrap(_numpy_fft.ifft)

--- a/pyfftw/interfaces/numpy_fft.py
+++ b/pyfftw/interfaces/numpy_fft.py
@@ -34,9 +34,9 @@
 
 '''
 This module implements those functions that replace aspects of the
-:mod:`numpy.fft` module. This module *provides* the entire documented namespace
-of :mod:`numpy.fft`, but those functions that are not included here are imported
-directly from :mod:`numpy.fft`.
+:mod:`numpy.fft` module. This module *provides* the entire documented
+namespace of :mod:`numpy.fft`, but those functions that are not included
+here are imported directly from :mod:`numpy.fft`.
 
 
 It is notable that unlike :mod:`numpy.fftpack`, these functions will generally
@@ -46,8 +46,8 @@ That is, if the input array is 32-bit floating point, then the transform will
 be 32-bit floating point and so will the returned array. Half precision input
 will be converted to single precision. Otherwise, if any type conversion is
 required, the default will be double precision. If pyFFTW was not built with
-support for double precision, the default is long double precision. If that is not
-available, it defaults to single precision.
+support for double precision, the default is long double precision. If that
+is not available, it defaults to single precision.
 
 One known caveat is that repeated axes are handled differently to
 :mod:`numpy.fft`; axes that are repeated in the axes argument are considered
@@ -57,16 +57,17 @@ the DFT being taken along that axes as many times as the axis occurs.
 The exceptions raised by each of these functions are mostly as per their
 equivalents in :mod:`numpy.fft`, though there are some corner cases in
 which this may not be true.
-'''
 
+'''
 from ._utils import _Xfftn
-from ..builders._utils import (_norm_args, _unitary, _default_effort,
+
+from ..builders._utils import (_norm_args, _default_effort,
                                _default_threads)
 
 # Complete the namespace (these are not actually used in this module)
 from numpy.fft import fftfreq, fftshift, ifftshift
 
-import numpy
+import numpy as np
 
 __all__ = ['fft', 'ifft', 'fft2', 'ifft2', 'fftn', 'ifftn',
            'rfft', 'irfft', 'rfft2', 'irfft2', 'rfftn', 'irfftn',
@@ -80,288 +81,316 @@ except ImportError:
     pass
 
 
+_swap_direction_dict = {"backward": "forward", None: "forward",
+                        "ortho": "ortho", "forward": "backward"}
+
+
+def _swap_direction(norm):
+    try:
+        return _swap_direction_dict[norm]
+    except KeyError:
+        raise ValueError(f'Invalid norm value {norm}; should be "backward", '
+                         '"ortho" or "forward".')
+
+
 def fft(a, n=None, axis=-1, norm=None, overwrite_input=False,
         planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
-    '''Perform a 1D FFT.
+    '''
+    Perform an 1D FFT.
 
     The first four arguments are as per :func:`numpy.fft.fft`;
-    the rest of the arguments are documented
-    in the :ref:`additional arguments docs<interfaces_additional_args>`.
-    '''
+    the rest of the arguments are documented in the
+    :ref:`additional arguments docs<interfaces_additional_args>`.
 
+    '''
     calling_func = 'fft'
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
 
     return _Xfftn(a, n, axis, overwrite_input, planner_effort,
-            threads, auto_align_input, auto_contiguous,
-            calling_func, **_norm_args(norm))
+                  threads, auto_align_input, auto_contiguous,
+                  calling_func, **_norm_args(norm))
+
 
 def ifft(a, n=None, axis=-1, norm=None, overwrite_input=False,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True):
-    '''Perform a 1D inverse FFT.
+         planner_effort=None, threads=None,
+         auto_align_input=True, auto_contiguous=True):
+    '''
+    Perform an 1D inverse FFT.
 
     The first four arguments are as per :func:`numpy.fft.ifft`;
-    the rest of the arguments are documented
-    in the :ref:`additional arguments docs<interfaces_additional_args>`.
+    the rest of the arguments are documented in the
+    :ref:`additional arguments docs<interfaces_additional_args>`.
+
     '''
     calling_func = 'ifft'
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
 
     return _Xfftn(a, n, axis, overwrite_input, planner_effort,
-            threads, auto_align_input, auto_contiguous,
-            calling_func, **_norm_args(norm))
+                  threads, auto_align_input, auto_contiguous,
+                  calling_func, **_norm_args(norm))
 
 
-def fft2(a, s=None, axes=(-2,-1), norm=None, overwrite_input=False,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True):
-    '''Perform a 2D FFT.
+def fft2(a, s=None, axes=(-2, -1), norm=None, overwrite_input=False,
+         planner_effort=None, threads=None,
+         auto_align_input=True, auto_contiguous=True):
+    '''
+    Perform a 2D FFT.
 
     The first four arguments are as per :func:`numpy.fft.fft2`;
-    the rest of the arguments are documented
-    in the :ref:`additional arguments docs<interfaces_additional_args>`.
+    the rest of the arguments are documented in the
+    :ref:`additional arguments docs<interfaces_additional_args>`.
+
     '''
     calling_func = 'fft2'
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
-            threads, auto_align_input, auto_contiguous,
-            calling_func, **_norm_args(norm))
+                  threads, auto_align_input, auto_contiguous,
+                  calling_func, **_norm_args(norm))
 
-def ifft2(a, s=None, axes=(-2,-1), norm=None, overwrite_input=False,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True):
-    '''Perform a 2D inverse FFT.
+
+def ifft2(a, s=None, axes=(-2, -1), norm=None, overwrite_input=False,
+          planner_effort=None, threads=None,
+          auto_align_input=True, auto_contiguous=True):
+    '''
+    Perform a 2D inverse FFT.
 
     The first four arguments are as per :func:`numpy.fft.ifft2`;
-    the rest of the arguments are documented
-    in the :ref:`additional arguments docs<interfaces_additional_args>`.
+    the rest of the arguments are documented in the
+    :ref:`additional arguments docs<interfaces_additional_args>`.
+
     '''
     calling_func = 'ifft2'
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
-            threads, auto_align_input, auto_contiguous,
-            calling_func, **_norm_args(norm))
+                  threads, auto_align_input, auto_contiguous,
+                  calling_func, **_norm_args(norm))
 
 
 def fftn(a, s=None, axes=None, norm=None, overwrite_input=False,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True):
-    '''Perform an n-D FFT.
+         planner_effort=None, threads=None,
+         auto_align_input=True, auto_contiguous=True):
+    '''
+    Perform an nD FFT.
 
     The first four arguments are as per :func:`numpy.fft.fftn`;
-    the rest of the arguments are documented
-    in the :ref:`additional arguments docs<interfaces_additional_args>`.
+    the rest of the arguments are documented in the
+    :ref:`additional arguments docs<interfaces_additional_args>`.
+
     '''
     calling_func = 'fftn'
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
-            threads, auto_align_input, auto_contiguous,
-            calling_func, **_norm_args(norm))
+                  threads, auto_align_input, auto_contiguous,
+                  calling_func, **_norm_args(norm))
 
 
 def ifftn(a, s=None, axes=None, norm=None, overwrite_input=False,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True):
-    '''Perform an n-D inverse FFT.
+          planner_effort=None, threads=None,
+          auto_align_input=True, auto_contiguous=True):
+    '''
+    Perform an nD inverse FFT.
 
     The first four arguments are as per :func:`numpy.fft.ifftn`;
-    the rest of the arguments are documented
-    in the :ref:`additional arguments docs<interfaces_additional_args>`.
+    the rest of the arguments are documented in the
+    :ref:`additional arguments docs<interfaces_additional_args>`.
+
     '''
     calling_func = 'ifftn'
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
-            threads, auto_align_input, auto_contiguous,
-            calling_func, **_norm_args(norm))
+                  threads, auto_align_input, auto_contiguous,
+                  calling_func, **_norm_args(norm))
 
 
 def rfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True):
-    '''Perform a 1D real FFT.
+         planner_effort=None, threads=None,
+         auto_align_input=True, auto_contiguous=True):
+    '''
+    Perform an 1D real FFT.
 
     The first four arguments are as per :func:`numpy.fft.rfft`;
-    the rest of the arguments are documented
-    in the :ref:`additional arguments docs<interfaces_additional_args>`.
+    the rest of the arguments are documented in the
+    :ref:`additional arguments docs<interfaces_additional_args>`.
+
     '''
     calling_func = 'rfft'
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
 
     return _Xfftn(a, n, axis, overwrite_input, planner_effort,
-            threads, auto_align_input, auto_contiguous,
-            calling_func, **_norm_args(norm))
+                  threads, auto_align_input, auto_contiguous,
+                  calling_func, **_norm_args(norm))
 
 
 def irfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True):
-    '''Perform a 1D real inverse FFT.
+          planner_effort=None, threads=None,
+          auto_align_input=True, auto_contiguous=True):
+    '''
+    Perform an 1D real inverse FFT.
 
     The first four arguments are as per :func:`numpy.fft.irfft`;
-    the rest of the arguments are documented
-    in the :ref:`additional arguments docs<interfaces_additional_args>`.
+    the rest of the arguments are documented in the
+    :ref:`additional arguments docs<interfaces_additional_args>`.
+
     '''
     calling_func = 'irfft'
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
 
     return _Xfftn(a, n, axis, overwrite_input, planner_effort,
-            threads, auto_align_input, auto_contiguous,
-            calling_func, **_norm_args(norm))
+                  threads, auto_align_input, auto_contiguous,
+                  calling_func, **_norm_args(norm))
 
 
-def rfft2(a, s=None, axes=(-2,-1), norm=None, overwrite_input=False,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True):
-    '''Perform a 2D real FFT.
+def rfft2(a, s=None, axes=(-2, -1), norm=None, overwrite_input=False,
+          planner_effort=None, threads=None,
+          auto_align_input=True, auto_contiguous=True):
+    '''
+    Perform a 2D real FFT.
 
     The first four arguments are as per :func:`numpy.fft.rfft2`;
-    the rest of the arguments are documented
-    in the :ref:`additional arguments docs<interfaces_additional_args>`.
+    the rest of the arguments are documented in the
+    :ref:`additional arguments docs<interfaces_additional_args>`.
+
     '''
     calling_func = 'rfft2'
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
-            threads, auto_align_input, auto_contiguous,
-            calling_func, **_norm_args(norm))
+                  threads, auto_align_input, auto_contiguous,
+                  calling_func, **_norm_args(norm))
 
 
-def irfft2(a, s=None, axes=(-2,-1), norm=None, overwrite_input=False,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True):
-    '''Perform a 2D real inverse FFT.
+def irfft2(a, s=None, axes=(-2, -1), norm=None, overwrite_input=False,
+           planner_effort=None, threads=None,
+           auto_align_input=True, auto_contiguous=True):
+    '''
+    Perform a 2D real inverse FFT.
 
     The first four arguments are as per :func:`numpy.fft.irfft2`;
-    the rest of the arguments are documented
-    in the :ref:`additional arguments docs<interfaces_additional_args>`.
+    the rest of the arguments are documented in the
+    :ref:`additional arguments docs<interfaces_additional_args>`.
+
     '''
     calling_func = 'irfft2'
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
-            threads, auto_align_input, auto_contiguous,
-            calling_func, **_norm_args(norm))
+                  threads, auto_align_input, auto_contiguous,
+                  calling_func, **_norm_args(norm))
 
 
 def rfftn(a, s=None, axes=None, norm=None, overwrite_input=False,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True):
-    '''Perform an n-D real FFT.
+          planner_effort=None, threads=None,
+          auto_align_input=True, auto_contiguous=True):
+    '''
+    Perform an nD real FFT.
 
     The first four arguments are as per :func:`numpy.fft.rfftn`;
-    the rest of the arguments are documented
-    in the :ref:`additional arguments docs<interfaces_additional_args>`.
+    the rest of the arguments are documented in the
+    :ref:`additional arguments docs<interfaces_additional_args>`.
+
     '''
     calling_func = 'rfftn'
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
-            threads, auto_align_input, auto_contiguous,
-            calling_func, **_norm_args(norm))
+                  threads, auto_align_input, auto_contiguous,
+                  calling_func, **_norm_args(norm))
 
 
 def irfftn(a, s=None, axes=None, norm=None, overwrite_input=False,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True):
-    '''Perform an n-D real inverse FFT.
+           planner_effort=None, threads=None,
+           auto_align_input=True, auto_contiguous=True):
+    '''
+    Perform an nD real inverse FFT.
 
     The first four arguments are as per :func:`numpy.fft.rfftn`;
     the rest of the arguments are documented
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
+
     '''
     calling_func = 'irfftn'
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
 
     return _Xfftn(a, s, axes, overwrite_input, planner_effort,
-            threads, auto_align_input, auto_contiguous,
-            calling_func, **_norm_args(norm))
+                  threads, auto_align_input, auto_contiguous,
+                  calling_func, **_norm_args(norm))
 
 
 def hfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
          planner_effort=None, threads=None,
          auto_align_input=True, auto_contiguous=True):
-    '''Perform a 1D FFT of a signal with hermitian symmetry.
+    '''
+    Perform an 1D FFT of a hermitian input array (conjugate symmetric).
     This yields a real output spectrum. See :func:`numpy.fft.hfft`
     for more information.
 
     The first four arguments are as per :func:`numpy.fft.hfft`;
-    the rest of the arguments are documented
-    in the :ref:`additional arguments docs<interfaces_additional_args>`.
+    the rest of the arguments are documented in the
+    :ref:`additional arguments docs<interfaces_additional_args>`.
+
     '''
-
-    # The hermitian symmetric transform is equivalent to the
-    # irfft of the conjugate of the input (do the maths!) without
-    # any normalisation of the result (so normalise_idft is set to
-    # False).
-    a = numpy.conjugate(a)
-    if a.size < 2:
-        raise ValueError("hfft requires input with length >= 2")
-
+    # hfft(a) is equivalent to irfft(conjugate(a))
     calling_func = 'irfft'
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
 
-    if _unitary(norm):
-        if n is None:
-            if not isinstance(a, numpy.ndarray):
-                a = numpy.asarray(a)
-            n = (a.shape[axis] - 1)*2
-        if a.dtype == numpy.float16:
-            # FFT will be in float32 so perform normalization in this dtype too
-            a = a.astype(numpy.float32)
-        a /= numpy.sqrt(n)
+    a = np.asarray(a)
+    if a.size < 2:
+        raise ValueError("hfft requires input with length >= 2")
+    if a.dtype == np.float16:
+        a = a.astype(np.float32)
 
-    return _Xfftn(a, n, axis, overwrite_input, planner_effort,
-            threads, auto_align_input, auto_contiguous,
-            calling_func, normalise_idft=False)
+    if n is None:
+        n = (a.shape[axis] - 1)*2
+
+    new_norm = _swap_direction(norm)
+
+    return _Xfftn(np.conjugate(a), n, axis, overwrite_input, planner_effort,
+                  threads, auto_align_input, auto_contiguous,
+                  calling_func, **_norm_args(new_norm))
 
 
 def ihfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True):
-    '''Perform a 1D inverse FFT of a real-spectrum, yielding
-    a signal with hermitian symmetry. See :func:`numpy.fft.ihfft`
-    for more information.
+          planner_effort=None, threads=None,
+          auto_align_input=True, auto_contiguous=True):
+    '''
+    Perform an 1D inverse FFT of a real-spectrum, yielding
+    a hermitian output array (conjugate symmetric).
+    See :func:`numpy.fft.ihfft` for more information.
 
     The first four arguments are as per :func:`numpy.fft.ihfft`;
-    the rest of the arguments are documented
-    in the :ref:`additional arguments docs<interfaces_additional_args>`.
+    the rest of the arguments are documented in the
+    :ref:`additional arguments docs<interfaces_additional_args>`.
+
     '''
-
-    # Result is equivalent to the conjugate of the output of
-    # the rfft of a.
-    # It is necessary to perform the inverse scaling, as this
-    # is not done by rfft.
-    if n is None:
-        if not isinstance(a, numpy.ndarray):
-            a = numpy.asarray(a)
-        n = a.shape[axis]
-
-    if _unitary(norm):
-        scaling = 1.0/numpy.sqrt(n)
-    else:
-        scaling = 1.0/n
-
+    # ihfft(a) is equivalent to conjugate(rfft(a))
+    calling_func = 'rfft'
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
 
-    return scaling * rfft(a, n, axis, None, overwrite_input, planner_effort,
-            threads, auto_align_input, auto_contiguous).conj()
+    a = np.asarray(a)
+    if n is None:
+        n = a.shape[axis]
+
+    new_norm = _swap_direction(norm)
+
+    return np.conjugate(_Xfftn(a, n, axis, overwrite_input, planner_effort,
+                               threads, auto_align_input, auto_contiguous,
+                               calling_func, **_norm_args(new_norm)))

--- a/pyfftw/interfaces/numpy_fft.py
+++ b/pyfftw/interfaces/numpy_fft.py
@@ -32,7 +32,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
-'''
+"""
 This module implements those functions that replace aspects of the
 :mod:`numpy.fft` module. This module *provides* the entire documented
 namespace of :mod:`numpy.fft`, but those functions that are not included
@@ -58,7 +58,7 @@ The exceptions raised by each of these functions are mostly as per their
 equivalents in :mod:`numpy.fft`, though there are some corner cases in
 which this may not be true.
 
-'''
+"""
 from ._utils import _Xfftn
 
 from ..builders._utils import (_norm_args, _default_effort,
@@ -96,14 +96,14 @@ def _swap_direction(norm):
 def fft(a, n=None, axis=-1, norm=None, overwrite_input=False,
         planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
-    '''
+    """
     Perform an 1D FFT.
 
     The first four arguments are as per :func:`numpy.fft.fft`;
     the rest of the arguments are documented in the
     :ref:`additional arguments docs<interfaces_additional_args>`.
 
-    '''
+    """
     calling_func = 'fft'
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
@@ -116,14 +116,14 @@ def fft(a, n=None, axis=-1, norm=None, overwrite_input=False,
 def ifft(a, n=None, axis=-1, norm=None, overwrite_input=False,
          planner_effort=None, threads=None,
          auto_align_input=True, auto_contiguous=True):
-    '''
+    """
     Perform an 1D inverse FFT.
 
     The first four arguments are as per :func:`numpy.fft.ifft`;
     the rest of the arguments are documented in the
     :ref:`additional arguments docs<interfaces_additional_args>`.
 
-    '''
+    """
     calling_func = 'ifft'
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
@@ -136,14 +136,14 @@ def ifft(a, n=None, axis=-1, norm=None, overwrite_input=False,
 def fft2(a, s=None, axes=(-2, -1), norm=None, overwrite_input=False,
          planner_effort=None, threads=None,
          auto_align_input=True, auto_contiguous=True):
-    '''
+    """
     Perform a 2D FFT.
 
     The first four arguments are as per :func:`numpy.fft.fft2`;
     the rest of the arguments are documented in the
     :ref:`additional arguments docs<interfaces_additional_args>`.
 
-    '''
+    """
     calling_func = 'fft2'
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
@@ -156,14 +156,14 @@ def fft2(a, s=None, axes=(-2, -1), norm=None, overwrite_input=False,
 def ifft2(a, s=None, axes=(-2, -1), norm=None, overwrite_input=False,
           planner_effort=None, threads=None,
           auto_align_input=True, auto_contiguous=True):
-    '''
+    """
     Perform a 2D inverse FFT.
 
     The first four arguments are as per :func:`numpy.fft.ifft2`;
     the rest of the arguments are documented in the
     :ref:`additional arguments docs<interfaces_additional_args>`.
 
-    '''
+    """
     calling_func = 'ifft2'
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
@@ -176,14 +176,14 @@ def ifft2(a, s=None, axes=(-2, -1), norm=None, overwrite_input=False,
 def fftn(a, s=None, axes=None, norm=None, overwrite_input=False,
          planner_effort=None, threads=None,
          auto_align_input=True, auto_contiguous=True):
-    '''
+    """
     Perform an nD FFT.
 
     The first four arguments are as per :func:`numpy.fft.fftn`;
     the rest of the arguments are documented in the
     :ref:`additional arguments docs<interfaces_additional_args>`.
 
-    '''
+    """
     calling_func = 'fftn'
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
@@ -196,14 +196,14 @@ def fftn(a, s=None, axes=None, norm=None, overwrite_input=False,
 def ifftn(a, s=None, axes=None, norm=None, overwrite_input=False,
           planner_effort=None, threads=None,
           auto_align_input=True, auto_contiguous=True):
-    '''
+    """
     Perform an nD inverse FFT.
 
     The first four arguments are as per :func:`numpy.fft.ifftn`;
     the rest of the arguments are documented in the
     :ref:`additional arguments docs<interfaces_additional_args>`.
 
-    '''
+    """
     calling_func = 'ifftn'
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
@@ -216,14 +216,14 @@ def ifftn(a, s=None, axes=None, norm=None, overwrite_input=False,
 def rfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
          planner_effort=None, threads=None,
          auto_align_input=True, auto_contiguous=True):
-    '''
+    """
     Perform an 1D real FFT.
 
     The first four arguments are as per :func:`numpy.fft.rfft`;
     the rest of the arguments are documented in the
     :ref:`additional arguments docs<interfaces_additional_args>`.
 
-    '''
+    """
     calling_func = 'rfft'
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
@@ -236,14 +236,14 @@ def rfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
 def irfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
           planner_effort=None, threads=None,
           auto_align_input=True, auto_contiguous=True):
-    '''
-    Perform an 1D real inverse FFT.
+    """
+    Perform an 1D inverse real FFT.
 
     The first four arguments are as per :func:`numpy.fft.irfft`;
     the rest of the arguments are documented in the
     :ref:`additional arguments docs<interfaces_additional_args>`.
 
-    '''
+    """
     calling_func = 'irfft'
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
@@ -256,14 +256,14 @@ def irfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
 def rfft2(a, s=None, axes=(-2, -1), norm=None, overwrite_input=False,
           planner_effort=None, threads=None,
           auto_align_input=True, auto_contiguous=True):
-    '''
+    """
     Perform a 2D real FFT.
 
     The first four arguments are as per :func:`numpy.fft.rfft2`;
     the rest of the arguments are documented in the
     :ref:`additional arguments docs<interfaces_additional_args>`.
 
-    '''
+    """
     calling_func = 'rfft2'
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
@@ -276,14 +276,14 @@ def rfft2(a, s=None, axes=(-2, -1), norm=None, overwrite_input=False,
 def irfft2(a, s=None, axes=(-2, -1), norm=None, overwrite_input=False,
            planner_effort=None, threads=None,
            auto_align_input=True, auto_contiguous=True):
-    '''
-    Perform a 2D real inverse FFT.
+    """
+    Perform a 2D inverse real FFT.
 
     The first four arguments are as per :func:`numpy.fft.irfft2`;
     the rest of the arguments are documented in the
     :ref:`additional arguments docs<interfaces_additional_args>`.
 
-    '''
+    """
     calling_func = 'irfft2'
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
@@ -296,14 +296,14 @@ def irfft2(a, s=None, axes=(-2, -1), norm=None, overwrite_input=False,
 def rfftn(a, s=None, axes=None, norm=None, overwrite_input=False,
           planner_effort=None, threads=None,
           auto_align_input=True, auto_contiguous=True):
-    '''
+    """
     Perform an nD real FFT.
 
     The first four arguments are as per :func:`numpy.fft.rfftn`;
     the rest of the arguments are documented in the
     :ref:`additional arguments docs<interfaces_additional_args>`.
 
-    '''
+    """
     calling_func = 'rfftn'
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
@@ -316,14 +316,14 @@ def rfftn(a, s=None, axes=None, norm=None, overwrite_input=False,
 def irfftn(a, s=None, axes=None, norm=None, overwrite_input=False,
            planner_effort=None, threads=None,
            auto_align_input=True, auto_contiguous=True):
-    '''
-    Perform an nD real inverse FFT.
+    """
+    Perform an nD inverse real FFT.
 
     The first four arguments are as per :func:`numpy.fft.rfftn`;
     the rest of the arguments are documented
     in the :ref:`additional arguments docs<interfaces_additional_args>`.
 
-    '''
+    """
     calling_func = 'irfftn'
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
@@ -336,16 +336,14 @@ def irfftn(a, s=None, axes=None, norm=None, overwrite_input=False,
 def hfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
          planner_effort=None, threads=None,
          auto_align_input=True, auto_contiguous=True):
-    '''
-    Perform an 1D FFT of a hermitian input array (conjugate symmetric).
-    This yields a real output spectrum. See :func:`numpy.fft.hfft`
-    for more information.
+    """
+    Perform an 1D hermitian FFT.
 
     The first four arguments are as per :func:`numpy.fft.hfft`;
     the rest of the arguments are documented in the
     :ref:`additional arguments docs<interfaces_additional_args>`.
 
-    '''
+    """
     # hfft(a) is equivalent to irfft(conjugate(a))
     calling_func = 'irfft'
     planner_effort = _default_effort(planner_effort)
@@ -370,16 +368,14 @@ def hfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
 def ihfft(a, n=None, axis=-1, norm=None, overwrite_input=False,
           planner_effort=None, threads=None,
           auto_align_input=True, auto_contiguous=True):
-    '''
-    Perform an 1D inverse FFT of a real-spectrum, yielding
-    a hermitian output array (conjugate symmetric).
-    See :func:`numpy.fft.ihfft` for more information.
+    """
+    Perform an 1D inverse hermitian FFT.
 
     The first four arguments are as per :func:`numpy.fft.ihfft`;
     the rest of the arguments are documented in the
     :ref:`additional arguments docs<interfaces_additional_args>`.
 
-    '''
+    """
     # ihfft(a) is equivalent to conjugate(rfft(a))
     calling_func = 'rfft'
     planner_effort = _default_effort(planner_effort)

--- a/pyfftw/interfaces/scipy_fft.py
+++ b/pyfftw/interfaces/scipy_fft.py
@@ -31,11 +31,11 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
-'''
+"""
 This module implements those functions that replace aspects of the
-:mod:`scipy.fft` module. This module *provides* the entire documented namespace
-of :mod:`scipy.fft`, but those functions that are not included here are
-imported directly from :mod:`scipy.fft`.
+:mod:`scipy.fft` module. This module *provides* the entire documented
+namespace of :mod:`scipy.fft`, but those functions that are not included
+here are imported directly from :mod:`scipy.fft`.
 
 The exceptions raised by each of these functions are mostly as per their
 equivalents in :mod:`scipy.fft`, though there are some corner cases in which
@@ -46,7 +46,7 @@ For example, using :func:`scipy.fft.fft2` with a non 1D array and
 a 2D `s` argument will return without exception whereas
 :func:`pyfftw.interfaces.scipy_fft.fft2` will raise a `ValueError`.
 
-'''
+"""
 import os
 
 from . import numpy_fft
@@ -74,11 +74,8 @@ __all__ = ['fft', 'ifft', 'fft2', 'ifft2', 'fftn', 'ifftn',
 
 
 # Backend support for scipy.fft
-
 _implemented = {}
-
 __ua_domain__ = 'numpy.scipy.fft'
-
 _cpu_count = os.cpu_count()
 
 
@@ -90,7 +87,10 @@ def __ua_function__(method, args, kwargs):
 
 
 def _implements(scipy_func):
-    '''Decorator adds function to the dictionary of implemented functions'''
+    """
+    Decorator adds function to the dictionary of implemented functions
+
+    """
     def inner(func):
         _implemented[scipy_func] = func
         return func
@@ -99,8 +99,10 @@ def _implements(scipy_func):
 
 
 def _workers_to_threads(workers):
-    """Handle conversion of workers to a positive number of threads in the
+    """
+    Handle conversion of workers to a positive number of threads in the
     same way as scipy.fft.helpers._workers.
+
     """
     if workers is None:
         return get_workers()
@@ -109,8 +111,8 @@ def _workers_to_threads(workers):
         if workers >= -_cpu_count:
             workers += 1 + _cpu_count
         else:
-            raise ValueError("workers value out of range; got {}, must not be"
-                             " less than {}".format(workers, -_cpu_count))
+            raise ValueError(f"workers value out of range; got {workers}, "
+                             f"must not be less than {-_cpu_count}")
     elif workers == 0:
         raise ValueError("workers must not be zero")
     return workers
@@ -119,12 +121,14 @@ def _workers_to_threads(workers):
 @_implements(_fft.fft)
 def fft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None,
         planner_effort=None, auto_align_input=True, auto_contiguous=True):
-    '''Perform a 1D FFT.
+    """
+    Perform an 1D FFT.
 
     The first six arguments are as per :func:`scipy.fft.fft`;
-    the rest of the arguments are documented
-    in the :ref:`additional argument docs<interfaces_additional_args>`.
-    '''
+    the rest of the arguments are documented in the
+    :ref:`additional argument docs<interfaces_additional_args>`.
+
+    """
     threads = _workers_to_threads(workers)
     return numpy_fft.fft(x, n, axis, norm, overwrite_x, planner_effort,
                          threads, auto_align_input, auto_contiguous)
@@ -133,12 +137,14 @@ def fft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None,
 @_implements(_fft.ifft)
 def ifft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None,
          planner_effort=None, auto_align_input=True, auto_contiguous=True):
-    '''Perform a 1D inverse FFT.
+    """
+    Perform an 1D inverse FFT.
 
     The first six arguments are as per :func:`scipy.fft.ifft`;
-    the rest of the arguments are documented
-    in the :ref:`additional argument docs<interfaces_additional_args>`.
-    '''
+    the rest of the arguments are documented in the
+    :ref:`additional argument docs<interfaces_additional_args>`.
+
+    """
     threads = _workers_to_threads(workers)
     return numpy_fft.ifft(x, n, axis, norm, overwrite_x,
                           planner_effort, threads, auto_align_input,
@@ -148,12 +154,14 @@ def ifft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None,
 @_implements(_fft.fft2)
 def fft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None,
          planner_effort=None, auto_align_input=True, auto_contiguous=True):
-    '''Perform a 2D FFT.
+    """
+    Perform a 2D FFT.
 
     The first six arguments are as per :func:`scipy.fft.fft2`;
-    the rest of the arguments are documented
-    in the :ref:`additional argument docs<interfaces_additional_args>`.
-    '''
+    the rest of the arguments are documented in the
+    :ref:`additional argument docs<interfaces_additional_args>`.
+
+    """
     threads = _workers_to_threads(workers)
     return numpy_fft.fft2(x, s, axes, norm, overwrite_x, planner_effort,
                           threads, auto_align_input, auto_contiguous)
@@ -162,12 +170,14 @@ def fft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None,
 @_implements(_fft.ifft2)
 def ifft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None,
           planner_effort=None, auto_align_input=True, auto_contiguous=True):
-    '''Perform a 2D inverse FFT.
+    """
+    Perform a 2D inverse FFT.
 
     The first six arguments are as per :func:`scipy.fft.ifft2`;
     the rest of the arguments are documented in the
     :ref:`additional argument docs <interfaces_additional_args>`.
-    '''
+
+    """
     threads = _workers_to_threads(workers)
     return numpy_fft.ifft2(x, s, axes, norm, overwrite_x, planner_effort,
                            threads, auto_align_input, auto_contiguous)
@@ -176,12 +186,14 @@ def ifft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None,
 @_implements(_fft.fftn)
 def fftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None,
          planner_effort=None, auto_align_input=True, auto_contiguous=True):
-    '''Perform an n-D FFT.
+    """
+    Perform an nD FFT.
 
     The first six arguments are as per :func:`scipy.fft.fftn`;
-    the rest of the arguments are documented
-    in the :ref:`additional argument docs<interfaces_additional_args>`.
-    '''
+    the rest of the arguments are documented in the
+    :ref:`additional argument docs<interfaces_additional_args>`.
+
+    """
     threads = _workers_to_threads(workers)
     return numpy_fft.fftn(x, s, axes, norm, overwrite_x, planner_effort,
                           threads, auto_align_input, auto_contiguous)
@@ -190,12 +202,14 @@ def fftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None,
 @_implements(_fft.ifftn)
 def ifftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None,
           planner_effort=None, auto_align_input=True, auto_contiguous=True):
-    '''Perform an n-D inverse FFT.
+    """
+    Perform an nD inverse FFT.
 
     The first six arguments are as per :func:`scipy.fft.ifftn`;
-    the rest of the arguments are documented
-    in the :ref:`additional argument docs<interfaces_additional_args>`.
-    '''
+    the rest of the arguments are documented in the
+    :ref:`additional argument docs<interfaces_additional_args>`.
+
+    """
     threads = _workers_to_threads(workers)
     return numpy_fft.ifftn(x, s, axes, norm, overwrite_x, planner_effort,
                            threads, auto_align_input, auto_contiguous)
@@ -204,12 +218,14 @@ def ifftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None,
 @_implements(_fft.rfft)
 def rfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None,
          planner_effort=None, auto_align_input=True, auto_contiguous=True):
-    '''Perform a 1D real FFT.
+    """
+    Perform an 1D real FFT.
 
     The first six arguments are as per :func:`scipy.fft.rfft`;
-    the rest of the arguments are documented
-    in the :ref:`additional argument docs<interfaces_additional_args>`.
-    '''
+    the rest of the arguments are documented in the
+    :ref:`additional argument docs<interfaces_additional_args>`.
+
+    """
     x = np.asanyarray(x)
     if x.dtype.kind == 'c':
         raise TypeError('x must be a real sequence')
@@ -221,12 +237,14 @@ def rfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None,
 @_implements(_fft.irfft)
 def irfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None,
           planner_effort=None, auto_align_input=True, auto_contiguous=True):
-    '''Perform a 1D real inverse FFT.
+    """
+    Perform an 1D real inverse FFT.
 
     The first six arguments are as per :func:`scipy.fft.irfft`;
-    the rest of the arguments are documented
-    in the :ref:`additional argument docs<interfaces_additional_args>`.
-    '''
+    the rest of the arguments are documented in the
+    :ref:`additional argument docs<interfaces_additional_args>`.
+
+    """
     threads = _workers_to_threads(workers)
     return numpy_fft.irfft(x, n, axis, norm, overwrite_x, planner_effort,
                            threads, auto_align_input, auto_contiguous)
@@ -235,12 +253,14 @@ def irfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None,
 @_implements(_fft.rfft2)
 def rfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None,
           planner_effort=None, auto_align_input=True, auto_contiguous=True):
-    '''Perform a 2D real FFT.
+    """
+    Perform a 2D real FFT.
 
     The first six arguments are as per :func:`scipy.fft.rfft2`;
-    the rest of the arguments are documented
-    in the :ref:`additional argument docs<interfaces_additional_args>`.
-    '''
+    the rest of the arguments are documented in the
+    :ref:`additional argument docs<interfaces_additional_args>`.
+
+    """
     x = np.asanyarray(x)
     if x.dtype.kind == 'c':
         raise TypeError('x must be a real sequence')
@@ -253,12 +273,14 @@ def rfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None,
 def irfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False,
            workers=None, planner_effort=None, auto_align_input=True,
            auto_contiguous=True):
-    '''Perform a 2D real inverse FFT.
+    """
+    Perform a 2D real inverse FFT.
 
     The first six arguments are as per :func:`scipy.fft.irfft2`;
     the rest of the arguments are documented in the
     :ref:`additional argument docs <interfaces_additional_args>`.
-    '''
+
+    """
     threads = _workers_to_threads(workers)
     return numpy_fft.irfft2(x, s, axes, norm, overwrite_x, planner_effort,
                             threads, auto_align_input, auto_contiguous)
@@ -267,12 +289,14 @@ def irfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False,
 @_implements(_fft.rfftn)
 def rfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None,
           planner_effort=None, auto_align_input=True, auto_contiguous=True):
-    '''Perform an n-D real FFT.
+    """
+    Perform an nD real FFT.
 
     The first six arguments are as per :func:`scipy.fft.rfftn`;
-    the rest of the arguments are documented
-    in the :ref:`additional argument docs<interfaces_additional_args>`.
-    '''
+    the rest of the arguments are documented in the
+    :ref:`additional argument docs<interfaces_additional_args>`.
+
+    """
     x = np.asanyarray(x)
     if x.dtype.kind == 'c':
         raise TypeError('x must be a real sequence')
@@ -284,12 +308,14 @@ def rfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None,
 @_implements(_fft.irfftn)
 def irfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None,
            planner_effort=None, auto_align_input=True, auto_contiguous=True):
-    '''Perform an n-D real inverse FFT.
+    """
+    Perform an nD real inverse FFT.
 
     The first six arguments are as per :func:`scipy.fft.irfftn`;
-    the rest of the arguments are documented
-    in the :ref:`additional argument docs<interfaces_additional_args>`.
-    '''
+    the rest of the arguments are documented in the
+    :ref:`additional argument docs<interfaces_additional_args>`.
+
+    """
     threads = _workers_to_threads(workers)
     return numpy_fft.irfftn(x, s, axes, norm, overwrite_x, planner_effort,
                             threads, auto_align_input, auto_contiguous)
@@ -298,12 +324,14 @@ def irfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None,
 @_implements(_fft.hfft)
 def hfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None,
          planner_effort=None, auto_align_input=True, auto_contiguous=True):
-    '''Perform a 1D Hermitian FFT.
+    """
+    Perform an 1D hermitian FFT.
 
     The first six arguments are as per :func:`scipy.fft.hfft`;
-    the rest of the arguments are documented
-    in the :ref:`additional argument docs<interfaces_additional_args>`.
-    '''
+    the rest of the arguments are documented in the
+    :ref:`additional argument docs<interfaces_additional_args>`.
+
+    """
     threads = _workers_to_threads(workers)
     return numpy_fft.hfft(x, n, axis, norm, overwrite_x, planner_effort,
                           threads, auto_align_input, auto_contiguous)
@@ -312,12 +340,14 @@ def hfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None,
 @_implements(_fft.ihfft)
 def ihfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None,
           planner_effort=None, auto_align_input=True, auto_contiguous=True):
-    '''Perform a 1D Hermitian inverse FFT.
+    """
+    Perform an 1D hermitian inverse FFT.
 
     The first six arguments are as per :func:`scipy.fft.ihfft`;
-    the rest of the arguments are documented
-    in the :ref:`additional argument docs<interfaces_additional_args>`.
-    '''
+    the rest of the arguments are documented in the
+    :ref:`additional argument docs<interfaces_additional_args>`.
+
+    """
     x = np.asanyarray(x)
     if x.dtype.kind == 'c':
         raise TypeError('x must be a real sequence')
@@ -331,12 +361,14 @@ def ihfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None,
 def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
         workers=None, planner_effort=None, auto_align_input=True,
         auto_contiguous=True):
-    '''Perform a 1D discrete cosine transform.
+    """
+    Perform an 1D discrete cosine transform.
 
     The first seven arguments are as per :func:`scipy.fft.dct`;
-    the rest of the arguments are documented
-    in the :ref:`additional arguments docs<interfaces_additional_args>`.
-    '''
+    the rest of the arguments are documented in the
+    :ref:`additional arguments docs<interfaces_additional_args>`.
+
+    """
     threads = _workers_to_threads(workers)
     if norm is None:
         norm = 'backward'
@@ -351,12 +383,14 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
 def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
          workers=None, planner_effort=None, auto_align_input=True,
          auto_contiguous=True):
-    '''Perform an inverse 1D discrete cosine transform.
+    """
+    Perform an inverse 1D discrete cosine transform.
 
     The first seven arguments are as per :func:`scipy.fft.idct`;
-    the rest of the arguments are documented
-    in the :ref:`additional arguments docs<interfaces_additional_args>`.
-    '''
+    the rest of the arguments are documented in the
+    :ref:`additional arguments docs<interfaces_additional_args>`.
+
+    """
     threads = _workers_to_threads(workers)
     if norm is None:
         norm = 'backward'
@@ -371,12 +405,14 @@ def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
 def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
         workers=None, planner_effort=None, auto_align_input=True,
         auto_contiguous=True):
-    '''Perform a 1D discrete sine transform.
+    """
+    Perform an 1D discrete sine transform.
 
     The first seven arguments are as per :func:`scipy.fft.dst`;
-    the rest of the arguments are documented
-    in the :ref:`additional arguments docs<interfaces_additional_args>`.
-    '''
+    the rest of the arguments are documented in the
+    :ref:`additional arguments docs<interfaces_additional_args>`.
+
+    """
     threads = _workers_to_threads(workers)
     if norm is None:
         norm = 'backward'
@@ -391,12 +427,14 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
 def idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
          workers=None, planner_effort=None, auto_align_input=True,
          auto_contiguous=True):
-    '''Perform an inverse 1D discrete sine transform.
+    """
+    Perform an inverse 1D discrete sine transform.
 
     The first seven arguments are as per :func:`scipy.fft.idst`;
-    the rest of the arguments are documented
-    in the :ref:`additional arguments docs<interfaces_additional_args>`.
-    '''
+    the rest of the arguments are documented in the
+    :ref:`additional arguments docs<interfaces_additional_args>`.
+
+    """
     threads = _workers_to_threads(workers)
     if norm is None:
         norm = 'backward'
@@ -406,15 +444,18 @@ def idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
                  auto_align_input=auto_align_input,
                  auto_contiguous=auto_contiguous)
 
+
 @_implements(_fft.dctn)
 def dctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
          workers=None, planner_effort=None, auto_align_input=True,
          auto_contiguous=True):
-    """Performan a multidimensional Discrete Cosine Transform.
+    """
+    Performan an nD discrete cosine transform.
 
     The first seven arguments are as per :func:`scipy.fft.dctn`;
-    the rest of the arguments are documented
-    in the :ref:`additional arguments docs<interfaces_additional_args>`.
+    the rest of the arguments are documented in the
+    :ref:`additional arguments docs<interfaces_additional_args>`.
+
     """
     threads = _workers_to_threads(workers)
     if norm is None:
@@ -430,11 +471,13 @@ def dctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
 def idctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
           workers=None, planner_effort=None, auto_align_input=True,
           auto_contiguous=True):
-    """Performan a multidimensional inverse Discrete Cosine Transform.
+    """
+    Performan an nD inverse discrete cosine transform.
 
     The first seven arguments are as per :func:`scipy.fft.idctn`;
-    the rest of the arguments are documented
-    in the :ref:`additional arguments docs<interfaces_additional_args>`.
+    the rest of the arguments are documented in the
+    :ref:`additional arguments docs<interfaces_additional_args>`.
+
     """
     threads = _workers_to_threads(workers)
     if norm is None:
@@ -450,11 +493,13 @@ def idctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
 def dstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
          workers=None, planner_effort=None, auto_align_input=True,
          auto_contiguous=True):
-    """Performan a multidimensional Discrete Sine Transform.
+    """
+    Performan an nD discrete sine transform.
 
     The first seven arguments are as per :func:`scipy.fft.dstn`;
-    the rest of the arguments are documented
-    in the :ref:`additional arguments docs<interfaces_additional_args>`.
+    the rest of the arguments are documented in the
+    :ref:`additional arguments docs<interfaces_additional_args>`.
+
     """
     threads = _workers_to_threads(workers)
     if norm is None:
@@ -470,11 +515,12 @@ def dstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
 def idstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
           workers=None, planner_effort=None, auto_align_input=True,
           auto_contiguous=True):
-    """Performan a multidimensional inverse Discrete Sine Transform.
+    """Performan an nD inverse discrete sine transform.
 
     The first seven arguments are as per :func:`scipy.fft.idstn`;
-    the rest of the arguments are documented
-    in the :ref:`additional arguments docs<interfaces_additional_args>`.
+    the rest of the arguments are documented in the
+    :ref:`additional arguments docs<interfaces_additional_args>`.
+
     """
     threads = _workers_to_threads(workers)
     if norm is None:

--- a/pyfftw/interfaces/scipy_fft.py
+++ b/pyfftw/interfaces/scipy_fft.py
@@ -64,14 +64,12 @@ from ..pyfftw import next_fast_len
 import scipy.fft as _fft
 import numpy as np
 
-
 __all__ = ['fft', 'ifft', 'fft2', 'ifft2', 'fftn', 'ifftn',
            'rfft', 'irfft', 'rfft2', 'irfft2', 'rfftn', 'irfftn',
            'hfft', 'ihfft', 'hfft2', 'ihfft2', 'hfftn', 'ihfftn',
            'dct', 'idct', 'dst', 'idst', 'dctn', 'idctn', 'dstn', 'idstn',
            'fftshift', 'ifftshift', 'fftfreq', 'rfftfreq', 'get_workers',
            'set_workers', 'next_fast_len']
-
 
 # Backend support for scipy.fft
 _implemented = {}
@@ -114,7 +112,7 @@ def _workers_to_threads(workers):
             raise ValueError(f"workers value out of range; got {workers}, "
                              f"must not be less than {-_cpu_count}")
     elif workers == 0:
-        raise ValueError("workers must not be zero")
+        raise ValueError("workers cannot be zero")
     return workers
 
 
@@ -238,7 +236,7 @@ def rfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None,
 def irfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None,
           planner_effort=None, auto_align_input=True, auto_contiguous=True):
     """
-    Perform an 1D real inverse FFT.
+    Perform an 1D inverse real FFT.
 
     The first six arguments are as per :func:`scipy.fft.irfft`;
     the rest of the arguments are documented in the
@@ -274,7 +272,7 @@ def irfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False,
            workers=None, planner_effort=None, auto_align_input=True,
            auto_contiguous=True):
     """
-    Perform a 2D real inverse FFT.
+    Perform a 2D inverse real FFT.
 
     The first six arguments are as per :func:`scipy.fft.irfft2`;
     the rest of the arguments are documented in the
@@ -309,7 +307,7 @@ def rfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None,
 def irfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None,
            planner_effort=None, auto_align_input=True, auto_contiguous=True):
     """
-    Perform an nD real inverse FFT.
+    Perform an nD inverse real FFT.
 
     The first six arguments are as per :func:`scipy.fft.irfftn`;
     the rest of the arguments are documented in the
@@ -341,7 +339,7 @@ def hfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None,
 def ihfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None,
           planner_effort=None, auto_align_input=True, auto_contiguous=True):
     """
-    Perform an 1D hermitian inverse FFT.
+    Perform an 1D inverse hermitian FFT.
 
     The first six arguments are as per :func:`scipy.fft.ihfft`;
     the rest of the arguments are documented in the
@@ -370,8 +368,10 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
 
     """
     threads = _workers_to_threads(workers)
+    # not sure why's that if-clause necessary, but some `scipy_fft`
+    # tests fail otherwise
     if norm is None:
-        norm = 'backward'
+        norm = "backward"
     return _dct(x, type=type, n=n, axis=axis, norm=norm,
                 overwrite_x=overwrite_x,
                 planner_effort=planner_effort, threads=threads,
@@ -384,7 +384,7 @@ def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
          workers=None, planner_effort=None, auto_align_input=True,
          auto_contiguous=True):
     """
-    Perform an inverse 1D discrete cosine transform.
+    Perform an 1D inverse discrete cosine transform.
 
     The first seven arguments are as per :func:`scipy.fft.idct`;
     the rest of the arguments are documented in the
@@ -392,8 +392,10 @@ def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
 
     """
     threads = _workers_to_threads(workers)
+    # not sure why's that if-clause necessary, but some `scipy_fft`
+    # tests fail otherwise
     if norm is None:
-        norm = 'backward'
+        norm = "backward"
     return _idct(x, type=type, n=n, axis=axis, norm=norm,
                  overwrite_x=overwrite_x,
                  planner_effort=planner_effort, threads=threads,
@@ -414,8 +416,10 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
 
     """
     threads = _workers_to_threads(workers)
+    # not sure why's that if-clause necessary, but some `scipy_fft`
+    # tests fail otherwise
     if norm is None:
-        norm = 'backward'
+        norm = "backward"
     return _dst(x, type=type, n=n, axis=axis, norm=norm,
                 overwrite_x=overwrite_x,
                 planner_effort=planner_effort, threads=threads,
@@ -428,7 +432,7 @@ def idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
          workers=None, planner_effort=None, auto_align_input=True,
          auto_contiguous=True):
     """
-    Perform an inverse 1D discrete sine transform.
+    Perform an 1D inverse discrete sine transform.
 
     The first seven arguments are as per :func:`scipy.fft.idst`;
     the rest of the arguments are documented in the
@@ -436,8 +440,10 @@ def idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
 
     """
     threads = _workers_to_threads(workers)
+    # not sure why's that if-clause necessary, but some `scipy_fft`
+    # tests fail otherwise
     if norm is None:
-        norm = 'backward'
+        norm = "backward"
     return _idst(x, type=type, n=n, axis=axis, norm=norm,
                  overwrite_x=overwrite_x,
                  planner_effort=planner_effort, threads=threads,
@@ -450,7 +456,7 @@ def dctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
          workers=None, planner_effort=None, auto_align_input=True,
          auto_contiguous=True):
     """
-    Performan an nD discrete cosine transform.
+    Perform an nD discrete cosine transform.
 
     The first seven arguments are as per :func:`scipy.fft.dctn`;
     the rest of the arguments are documented in the
@@ -458,8 +464,10 @@ def dctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
 
     """
     threads = _workers_to_threads(workers)
+    # not sure why's that if-clause necessary, but some `scipy_fft`
+    # tests fail otherwise
     if norm is None:
-        norm = 'backward'
+        norm = "backward"
     return _dctn(x, type=type, shape=s, axes=axes, norm=norm,
                  overwrite_x=overwrite_x,
                  planner_effort=planner_effort, threads=threads,
@@ -472,7 +480,7 @@ def idctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
           workers=None, planner_effort=None, auto_align_input=True,
           auto_contiguous=True):
     """
-    Performan an nD inverse discrete cosine transform.
+    Perform an nD inverse discrete cosine transform.
 
     The first seven arguments are as per :func:`scipy.fft.idctn`;
     the rest of the arguments are documented in the
@@ -480,8 +488,10 @@ def idctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
 
     """
     threads = _workers_to_threads(workers)
+    # not sure why's that if-clause necessary, but some `scipy_fft`
+    # tests fail otherwise
     if norm is None:
-        norm = 'backward'
+        norm = "backward"
     return _idctn(x, type=type, shape=s, axes=axes, norm=norm,
                   overwrite_x=overwrite_x,
                   planner_effort=planner_effort, threads=threads,
@@ -494,7 +504,7 @@ def dstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
          workers=None, planner_effort=None, auto_align_input=True,
          auto_contiguous=True):
     """
-    Performan an nD discrete sine transform.
+    Perform an nD discrete sine transform.
 
     The first seven arguments are as per :func:`scipy.fft.dstn`;
     the rest of the arguments are documented in the
@@ -502,8 +512,10 @@ def dstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
 
     """
     threads = _workers_to_threads(workers)
+    # not sure why's that if-clause necessary, but some `scipy_fft`
+    # tests fail otherwise
     if norm is None:
-        norm = 'backward'
+        norm = "backward"
     return _dstn(x, type=type, shape=s, axes=axes, norm=norm,
                  overwrite_x=overwrite_x,
                  planner_effort=planner_effort, threads=threads,
@@ -515,7 +527,8 @@ def dstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
 def idstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
           workers=None, planner_effort=None, auto_align_input=True,
           auto_contiguous=True):
-    """Performan an nD inverse discrete sine transform.
+    """
+    Perform an nD inverse discrete sine transform.
 
     The first seven arguments are as per :func:`scipy.fft.idstn`;
     the rest of the arguments are documented in the
@@ -523,8 +536,10 @@ def idstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
 
     """
     threads = _workers_to_threads(workers)
+    # not sure why's that if-clause necessary, but some `scipy_fft`
+    # tests fail otherwise
     if norm is None:
-        norm = 'backward'
+        norm = "backward"
     return _idstn(x, type=type, shape=s, axes=axes, norm=norm,
                   overwrite_x=overwrite_x,
                   planner_effort=planner_effort, threads=threads,

--- a/pyfftw/interfaces/scipy_fftpack.py
+++ b/pyfftw/interfaces/scipy_fftpack.py
@@ -35,7 +35,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
-'''
+"""
 This module implements those functions that replace aspects of the
 :mod:`scipy.fftpack` module. This module *provides* the entire documented
 namespace of :mod:`scipy.fftpack`, but those functions that are not included
@@ -49,8 +49,8 @@ Some corner (mis)usages of :mod:`scipy.fftpack` may not transfer neatly.
 For example, using :func:`scipy.fftpack.fft2` with a non 1D array and
 a 2D `shape` argument will return without exception whereas
 :func:`pyfftw.interfaces.scipy_fftpack.fft2` will raise a `ValueError`.
-'''
 
+"""
 import itertools as it
 import math
 from numbers import Number
@@ -64,9 +64,9 @@ import numpy
 
 # Complete the namespace (these are not actually used in this module)
 from scipy.fftpack import (diff, tilbert, itilbert,
-        hilbert, ihilbert, cs_diff, sc_diff, ss_diff, cc_diff,
-        shift, fftshift, ifftshift, fftfreq, rfftfreq,
-        convolve)
+                           hilbert, ihilbert, cs_diff, sc_diff, ss_diff,
+                           cc_diff, shift, fftshift, ifftshift, fftfreq,
+                           rfftfreq, convolve)
 
 # a next_fast_len specific to pyFFTW is used in place of the scipy.fftpack one
 from ..pyfftw import next_fast_len
@@ -79,8 +79,8 @@ __all__ = ['fft', 'ifft', 'fftn', 'ifftn', 'rfft', 'irfft', 'fft2', 'ifft2',
 
 
 def _iterable_of_int(x, name=None):
-    """Convert ``x`` to an iterable sequence of int
-
+    """
+    Convert ``x`` to an iterable sequence of int
     vendored from scipy.fft._pocketfft.helper
 
     Parameters
@@ -92,6 +92,7 @@ def _iterable_of_int(x, name=None):
     Returns
     -------
     y : ``List[int]``
+
     """
     if isinstance(x, Number):
         x = (x,)
@@ -102,14 +103,15 @@ def _iterable_of_int(x, name=None):
         name = name or "value"
         raise ValueError("{} must be a scalar or iterable of integers"
                          .format(name)) from e
-
     return x
 
 
 def _good_shape(x, shape, axes):
-    """Ensure that shape argument is valid for scipy.fftpack
+    """
+    Ensure that shape argument is valid for scipy.fftpack
 
-    scipy.fftpack does not support len(shape) < x.ndim when axes is not given.
+    scipy.fftpack does not support len(shape) < x.ndim when axes not given.
+
     """
     if shape is not None and axes is None:
         shape = _iterable_of_int(shape, 'shape')
@@ -120,9 +122,11 @@ def _good_shape(x, shape, axes):
 
 
 def _init_nd_shape_and_axes(x, shape, axes):
-    """Handles shape and axes arguments for nd transforms
+    """
+    Handles shape and axes arguments for nd transforms
 
     vendored from scipy.fft._pocketfft.helper
+
     """
     noshape = shape is None
     noaxes = axes is None
@@ -146,7 +150,7 @@ def _init_nd_shape_and_axes(x, shape, axes):
         if noaxes:
             if len(shape) > x.ndim:
                 raise ValueError("Shape error: shape requires more axes than "
-                                  "are present")
+                                 "are present")
             axes = range(x.ndim - len(shape), x.ndim)
 
         shape = [x.shape[a] if s == -1 else s for s, a in zip(shape, axes)]
@@ -157,8 +161,7 @@ def _init_nd_shape_and_axes(x, shape, axes):
         shape = [x.shape[a] for a in axes]
 
     if any(s < 1 for s in shape):
-        raise ValueError(
-            "invalid number of data points ({0}) specified".format(shape))
+        raise ValueError(f"invalid number of data points ({shape}) specified")
 
     return shape, axes
 
@@ -166,100 +169,119 @@ def _init_nd_shape_and_axes(x, shape, axes):
 def fft(x, n=None, axis=-1, overwrite_x=False,
         planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
-    '''Perform a 1D FFT.
+    """
+    Perform an 1D FFT.
 
     The first three arguments are as per :func:`scipy.fftpack.fft`;
-    the rest of the arguments are documented
-    in the :ref:`additional argument docs<interfaces_additional_args>`.
-    '''
+    the rest of the arguments are documented in the
+    :ref:`additional argument docs<interfaces_additional_args>`.
+
+    """
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
     return numpy_fft.fft(x, n, axis, None, overwrite_x, planner_effort,
-            threads, auto_align_input, auto_contiguous)
+                         threads, auto_align_input, auto_contiguous)
+
 
 def ifft(x, n=None, axis=-1, overwrite_x=False,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True):
-    '''Perform a 1D inverse FFT.
+         planner_effort=None, threads=None,
+         auto_align_input=True, auto_contiguous=True):
+    """
+    Perform an 1D inverse FFT.
 
     The first three arguments are as per :func:`scipy.fftpack.ifft`;
-    the rest of the arguments are documented
-    in the :ref:`additional argument docs<interfaces_additional_args>`.
-    '''
+    the rest of the arguments are documented in the
+    :ref:`additional argument docs<interfaces_additional_args>`.
+
+    """
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
     return numpy_fft.ifft(x, n, axis, None, overwrite_x,
-            planner_effort, threads, auto_align_input, auto_contiguous)
+                          planner_effort, threads, auto_align_input,
+                          auto_contiguous)
 
 
-def fft2(x, shape=None, axes=(-2,-1), overwrite_x=False,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True):
-    '''Perform a 2D FFT.
+def fft2(x, shape=None, axes=(-2, -1), overwrite_x=False,
+         planner_effort=None, threads=None,
+         auto_align_input=True, auto_contiguous=True):
+    """
+    Perform a 2D FFT.
 
     The first three arguments are as per :func:`scipy.fftpack.fft2`;
-    the rest of the arguments are documented
-    in the :ref:`additional argument docs<interfaces_additional_args>`.
-    '''
+    the rest of the arguments are documented in the
+    :ref:`additional argument docs<interfaces_additional_args>`.
+
+    """
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
     shape = _good_shape(x, shape, axes)
     return numpy_fft.fft2(x, shape, axes, None, overwrite_x,
-            planner_effort, threads, auto_align_input, auto_contiguous)
+                          planner_effort, threads, auto_align_input,
+                          auto_contiguous)
 
 
-def ifft2(x, shape=None, axes=(-2,-1), overwrite_x=False,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True):
-    '''Perform a 2D inverse FFT.
+def ifft2(x, shape=None, axes=(-2, -1), overwrite_x=False,
+          planner_effort=None, threads=None,
+          auto_align_input=True, auto_contiguous=True):
+    """
+    Perform a 2D inverse FFT.
 
     The first three arguments are as per :func:`scipy.fftpack.ifft2`;
     the rest of the arguments are documented in the
     :ref:`additional argument docs <interfaces_additional_args>`.
-    '''
+    """
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
     shape = _good_shape(x, shape, axes)
     return numpy_fft.ifft2(x, shape, axes, None, overwrite_x,
-            planner_effort, threads, auto_align_input, auto_contiguous)
+                           planner_effort, threads, auto_align_input,
+                           auto_contiguous)
 
 
 def fftn(x, shape=None, axes=None, overwrite_x=False,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True):
-    '''Perform an n-D FFT.
+         planner_effort=None, threads=None,
+         auto_align_input=True, auto_contiguous=True):
+    """
+    Perform an nD FFT.
 
     The first three arguments are as per :func:`scipy.fftpack.fftn`;
-    the rest of the arguments are documented
-    in the :ref:`additional argument docs<interfaces_additional_args>`.
-    '''
+    the rest of the arguments are documented in the
+    :ref:`additional argument docs<interfaces_additional_args>`.
+
+    """
     shape = _good_shape(x, shape, axes)
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
     return numpy_fft.fftn(x, shape, axes, None, overwrite_x,
-            planner_effort, threads, auto_align_input, auto_contiguous)
+                          planner_effort, threads, auto_align_input,
+                          auto_contiguous)
 
 
 def ifftn(x, shape=None, axes=None, overwrite_x=False,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True):
-    '''Perform an n-D inverse FFT.
+          planner_effort=None, threads=None,
+          auto_align_input=True, auto_contiguous=True):
+    """
+    Perform an nD inverse FFT.
 
     The first three arguments are as per :func:`scipy.fftpack.ifftn`;
-    the rest of the arguments are documented
-    in the :ref:`additional argument docs<interfaces_additional_args>`.
-    '''
+    the rest of the arguments are documented in the
+    :ref:`additional argument docs<interfaces_additional_args>`.
+
+    """
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
     shape = _good_shape(x, shape, axes)
     return numpy_fft.ifftn(x, shape, axes, None, overwrite_x,
-            planner_effort, threads, auto_align_input, auto_contiguous)
+                           planner_effort, threads, auto_align_input,
+                           auto_contiguous)
+
 
 def _complex_to_rfft_output(complex_output, output_shape, axis):
-    '''Convert the complex output from pyfftw to the real output expected
+    """
+    Convert the complex output from pyfftw to the real output expected
     from :func:`scipy.fftpack.rfft`.
-    '''
 
+    """
     rfft_output = numpy.empty(output_shape, dtype=complex_output.real.dtype)
     source_slicer = [slice(None)] * complex_output.ndim
     target_slicer = [slice(None)] * complex_output.ndim
@@ -267,12 +289,14 @@ def _complex_to_rfft_output(complex_output, output_shape, axis):
     # First element
     source_slicer[axis] = slice(0, 1)
     target_slicer[axis] = slice(0, 1)
-    rfft_output[tuple(target_slicer)] = complex_output[tuple(source_slicer)].real
+    rfft_output[tuple(target_slicer)] = complex_output[
+                                            tuple(source_slicer)].real
 
     # Real part
     source_slicer[axis] = slice(1, None)
     target_slicer[axis] = slice(1, None, 2)
-    rfft_output[tuple(target_slicer)] = complex_output[tuple(source_slicer)].real
+    rfft_output[tuple(target_slicer)] = complex_output[
+                                            tuple(source_slicer)].real
 
     # Imaginary part
     if output_shape[axis] % 2 == 0:
@@ -282,15 +306,18 @@ def _complex_to_rfft_output(complex_output, output_shape, axis):
 
     source_slicer[axis] = slice(1, end_val, None)
     target_slicer[axis] = slice(2, None, 2)
-    rfft_output[tuple(target_slicer)] = complex_output[tuple(source_slicer)].imag
+    rfft_output[tuple(target_slicer)] = complex_output[
+                                            tuple(source_slicer)].imag
 
     return rfft_output
 
 
 def _irfft_input_to_complex(irfft_input, axis):
-    '''Convert the expected real input to :func:`scipy.fftpack.irfft` to
-    the complex input needed by pyfftw.
-    '''
+    """
+    Convert the expected real input to :func:`scipy.fftpack.irfft`
+    to the complex input needed by pyfftw.
+
+    """
     complex_dtype = numpy.result_type(irfft_input, 1j)
 
     input_shape = list(irfft_input.shape)
@@ -308,7 +335,8 @@ def _irfft_input_to_complex(irfft_input, axis):
     # Real part
     source_slicer[axis] = slice(1, None, 2)
     target_slicer[axis] = slice(1, None)
-    complex_input[tuple(target_slicer)].real = irfft_input[tuple(source_slicer)]
+    complex_input[tuple(target_slicer)].real = irfft_input[
+                                                    tuple(source_slicer)]
 
     # Imaginary part
     if irfft_input.shape[axis] % 2 == 0:
@@ -320,49 +348,55 @@ def _irfft_input_to_complex(irfft_input, axis):
 
     source_slicer[axis] = slice(2, None, 2)
     target_slicer[axis] = slice(1, end_val)
-    complex_input[tuple(target_slicer)].imag = irfft_input[tuple(source_slicer)]
+    complex_input[tuple(target_slicer)].imag = irfft_input[
+                                                    tuple(source_slicer)]
 
     return complex_input
 
 
 def rfft(x, n=None, axis=-1, overwrite_x=False,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True):
-    '''Perform a 1D real FFT.
+         planner_effort=None, threads=None,
+         auto_align_input=True, auto_contiguous=True):
+    """
+    Perform an 1D real FFT.
 
     The first three arguments are as per :func:`scipy.fftpack.rfft`;
-    the rest of the arguments are documented
-    in the :ref:`additional argument docs<interfaces_additional_args>`.
-    '''
+    the rest of the arguments are documented in the
+    :ref:`additional argument docs<interfaces_additional_args>`.
+
+    """
     if not numpy.isrealobj(x):
         raise TypeError('Input array must be real to maintain '
-                'compatibility with scipy.fftpack.rfft.')
+                        'compatibility with scipy.fftpack.rfft.')
 
     x = numpy.asanyarray(x)
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
 
     complex_output = numpy_fft.rfft(x, n, axis, None, overwrite_x,
-            planner_effort, threads, auto_align_input, auto_contiguous)
-
+                                    planner_effort, threads,
+                                    auto_align_input, auto_contiguous)
     output_shape = list(x.shape)
     if n is not None:
         output_shape[axis] = n
 
     return _complex_to_rfft_output(complex_output, output_shape, axis)
 
+
 def irfft(x, n=None, axis=-1, overwrite_x=False,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True):
-    '''Perform a 1D real inverse FFT.
+          planner_effort=None, threads=None,
+          auto_align_input=True, auto_contiguous=True):
+    """
+    Perform an 1D inverse real FFT.
 
     The first three arguments are as per :func:`scipy.fftpack.irfft`;
-    the rest of the arguments are documented
-    in the :ref:`additional argument docs<interfaces_additional_args>`.
-    '''
+    the rest of the arguments are documented in the
+    :ref:`additional argument docs<interfaces_additional_args>`.
+
+    """
     if not numpy.isrealobj(x):
         raise TypeError('Input array must be real to maintain '
-                'compatibility with scipy.fftpack.irfft.')
+                        'compatibility with scipy.fftpack.irfft.')
 
     x = numpy.asanyarray(x)
     planner_effort = _default_effort(planner_effort)
@@ -374,7 +408,8 @@ def irfft(x, n=None, axis=-1, overwrite_x=False,
     complex_input = _irfft_input_to_complex(x, axis)
 
     return numpy_fft.irfft(complex_input, n, axis, None, overwrite_x,
-            planner_effort, threads, auto_align_input, auto_contiguous)
+                           planner_effort, threads, auto_align_input,
+                           auto_contiguous)
 
 
 def _dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
@@ -390,7 +425,8 @@ def _dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
         raise NotImplementedError("Padding/truncating not yet implemented")
 
     if norm not in [None, 'forward', 'backward', 'ortho']:
-        raise ValueError("Unknown normalize mode %s" % norm)
+        raise ValueError(f'Invalid norm value {norm}; should be "backward", '
+                         '"ortho" or "forward".')
 
     if norm == 'ortho':
         if type == 1:
@@ -417,7 +453,7 @@ def _dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
     try:
         type_flag = type_flag_lookup[type]
     except KeyError:
-        raise ValueError("Type %d not understood" % type)
+        raise ValueError(f"Type {type} not understood")
 
     calling_func = 'dct'
     planner_effort = _default_effort(planner_effort)
@@ -456,20 +492,22 @@ def _dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
 def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
         planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
-    '''Perform a 1D discrete cosine transform.
+    """
+    Perform an 1D discrete cosine transform.
 
     The first three arguments are as per :func:`scipy.fftpack.dct`;
-    the rest of the arguments are documented
-    in the :ref:`additional arguments docs<interfaces_additional_args>`.
-    '''
+    the rest of the arguments are documented in the
+    :ref:`additional arguments docs<interfaces_additional_args>`.
+
+    """
     if norm not in [None, 'ortho']:
-        raise ValueError("unrecognized norm: {}".format(norm))
+        raise ValueError(f"Invalid norm value {norm}")
     return _dct(x, type, n, axis, norm, overwrite_x, planner_effort, threads,
                 auto_align_input, auto_contiguous)
 
 
 inverse_dct_norm = {None: None, 'ortho': 'ortho', 'backward': 'forward',
-                   'forward': 'backward'}
+                    'forward': 'backward'}
 
 
 def _idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
@@ -478,12 +516,12 @@ def _idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
     try:
         inverse_type = {1: 1, 2: 3, 3: 2, 4: 4}[type]
     except KeyError:
-        raise ValueError("Type %d not understood" % type)
+        raise ValueError(f"Type {type} not understood")
 
     try:
         norm = inverse_dct_norm[norm]
     except KeyError:
-        raise ValueError("Norm type {} not understood".format(norm))
+        raise ValueError(f"Invalid norm value {norm}")
 
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
@@ -497,14 +535,16 @@ def _idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
 def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
          planner_effort=None, threads=None,
          auto_align_input=True, auto_contiguous=True):
-    '''Perform an inverse 1D discrete cosine transform.
+    """
+    Perform an inverse 1D discrete cosine transform.
 
     The first three arguments are as per :func:`scipy.fftpack.idct`;
-    the rest of the arguments are documented
-    in the :ref:`additional arguments docs<interfaces_additional_args>`.
-    '''
+    the rest of the arguments are documented in the
+    :ref:`additional arguments docs<interfaces_additional_args>`.
+
+    """
     if norm not in [None, 'ortho']:
-        raise ValueError("unrecognized norm: {}".format(norm))
+        raise ValueError(f"Invalid norm value {norm}")
     return _idct(x, type, n, axis, norm, overwrite_x, planner_effort, threads,
                  auto_align_input, auto_contiguous)
 
@@ -522,7 +562,7 @@ def _dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
         raise NotImplementedError("Padding/truncating not yet implemented")
 
     if norm not in [None, 'forward', 'backward', 'ortho']:
-        raise ValueError("Unknown normalize mode %s" % norm)
+        raise ValueError(f"Invalid norm value {norm}")
 
     if type == 3 and norm == 'ortho':
         x = numpy.copy(x)
@@ -541,7 +581,7 @@ def _dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
     try:
         type_flag = type_flag_lookup[type]
     except KeyError:
-        raise ValueError("Type %d not understood" % type)
+        raise ValueError(f"Type {type} not understood")
 
     calling_func = 'dst'
     planner_effort = _default_effort(planner_effort)
@@ -574,14 +614,16 @@ def _dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
 def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
         planner_effort=None, threads=None,
         auto_align_input=True, auto_contiguous=True):
-    '''Perform a 1D discrete sine transform.
+    """
+    Perform an 1D discrete sine transform.
 
     The first three arguments are as per :func:`scipy.fftpack.dst`;
-    the rest of the arguments are documented
-    in the :ref:`additional arguments docs<interfaces_additional_args>`.
-    '''
+    the rest of the arguments are documented in the
+    :ref:`additional arguments docs<interfaces_additional_args>`.
+
+    """
     if norm not in [None, 'ortho']:
-        raise ValueError("unrecognized norm: {}".format(norm))
+        raise ValueError(f"Invalid norm value {norm}")
     return _dst(x, type, n, axis, norm, overwrite_x, planner_effort, threads,
                 auto_align_input, auto_contiguous)
 
@@ -591,14 +633,14 @@ def _idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
           auto_align_input=True, auto_contiguous=True):
 
     try:
-        inverse_type = {1: 1, 2: 3, 3:2, 4: 4}[type]
+        inverse_type = {1: 1, 2: 3, 3: 2, 4: 4}[type]
     except KeyError:
-        raise ValueError("Type %d not understood" % type)
+        raise ValueError(f"Type {type} not understood")
 
     try:
         norm = inverse_dct_norm[norm]
     except KeyError:
-        raise ValueError("Norm type {} not understood".format(norm))
+        raise ValueError(f"Invalid norm value {norm}")
 
     planner_effort = _default_effort(planner_effort)
     threads = _default_threads(threads)
@@ -610,18 +652,20 @@ def _idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
 
 
 def idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
-        planner_effort=None, threads=None,
-        auto_align_input=True, auto_contiguous=True):
-    '''Perform an inverse 1D discrete sine transform.
+         planner_effort=None, threads=None,
+         auto_align_input=True, auto_contiguous=True):
+    """
+    Perform an inverse 1D discrete sine transform.
 
     The first three arguments are as per :func:`scipy.fftpack.idst`;
-    the rest of the arguments are documented
-    in the :ref:`additional arguments docs<interfaces_additional_args>`.
-    '''
+    the rest of the arguments are documented in the
+    :ref:`additional arguments docs<interfaces_additional_args>`.
+
+    """
     if norm not in [None, 'ortho']:
-        raise ValueError("unrecognized norm: {}".format(norm))
+        raise ValueError(f"Invalid norm value {norm}")
     return _idst(x, type, n, axis, norm, overwrite_x, planner_effort, threads,
-                auto_align_input, auto_contiguous)
+                 auto_align_input, auto_contiguous)
 
 
 def _dctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False,
@@ -640,15 +684,17 @@ def _dctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False,
 def dctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False,
          planner_effort=None, threads=None, auto_align_input=True,
          auto_contiguous=True):
-    """Perform a multidimensional Discrete Cosine Transform.
+    """
+    Perform an nD discrete cosine transform.
 
     The first six arguments are as per :func:`scipy.fftpack.dctn`;
-    the rest of the arguments are documented
-    in the :ref:`additional arguments docs<interfaces_additional_args>`.
+    the rest of the arguments are documented in the
+    :ref:`additional arguments docs<interfaces_additional_args>`.
+
     """
     shape = _good_shape(x, shape, axes)
     if norm not in [None, 'ortho']:
-        raise ValueError("unrecognized norm: {}".format(norm))
+        raise ValueError(f"Invalid norm value {norm}")
     return _dctn(x, type, shape, axes, norm, overwrite_x, planner_effort,
                  threads, auto_align_input, auto_contiguous)
 
@@ -669,15 +715,17 @@ def _idctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False,
 def idctn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False,
           planner_effort=None, threads=None, auto_align_input=True,
           auto_contiguous=True):
-    """Perform a multidimensional inverse Discrete Cosine Transform.
+    """
+    Perform an nD inverse discrete cosine transform.
 
     The first six arguments are as per :func:`scipy.fftpack.idctn`;
-    the rest of the arguments are documented
-    in the :ref:`additional arguments docs<interfaces_additional_args>`.
+    the rest of the arguments are documented in the
+    :ref:`additional arguments docs<interfaces_additional_args>`.
+
     """
     shape = _good_shape(x, shape, axes)
     if norm not in [None, 'ortho']:
-        raise ValueError("unrecognized norm: {}".format(norm))
+        raise ValueError(f"Invalid norm value {norm}")
     return _idctn(x, type, shape, axes, norm, overwrite_x, planner_effort,
                   threads, auto_align_input, auto_contiguous)
 
@@ -696,19 +744,20 @@ def _dstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False,
     return x
 
 
-
 def dstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False,
          planner_effort=None, threads=None, auto_align_input=True,
          auto_contiguous=True):
-    """Perform a multidimensional Discrete Sine Transform.
+    """
+    Perform an nD discrete sine transform.
 
     The first six arguments are as per :func:`scipy.fftpack.dstn`;
-    the rest of the arguments are documented
-    in the :ref:`additional arguments docs<interfaces_additional_args>`.
+    the rest of the arguments are documented in the
+    :ref:`additional arguments docs<interfaces_additional_args>`.
+
     """
     shape = _good_shape(x, shape, axes)
     if norm not in [None, 'ortho']:
-        raise ValueError("unrecognized norm: {}".format(norm))
+        raise ValueError(f"Invalid norm value {norm}")
     return _dstn(x, type, shape, axes, norm, overwrite_x, planner_effort,
                  threads, auto_align_input, auto_contiguous)
 
@@ -731,14 +780,16 @@ def _idstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False,
 def idstn(x, type=2, shape=None, axes=None, norm=None, overwrite_x=False,
           planner_effort=None, threads=None, auto_align_input=True,
           auto_contiguous=True):
-    """Perform a multidimensional inverse Discrete Sine Transform.
+    """
+    Perform an nD inverse discrete sine transform.
 
     The first six arguments are as per :func:`scipy.fftpack.idstn`;
-    the rest of the arguments are documented
-    in the :ref:`additional arguments docs<interfaces_additional_args>`.
+    the rest of the arguments are documented in the
+    :ref:`additional arguments docs<interfaces_additional_args>`.
+
     """
     shape = _good_shape(x, shape, axes)
     if norm not in [None, 'ortho']:
-        raise ValueError("unrecognized norm: {}".format(norm))
+        raise ValueError(f"Invalid norm value {norm}")
     return _idstn(x, type, shape, axes, norm, overwrite_x, planner_effort,
                   threads, auto_align_input, auto_contiguous)

--- a/pyfftw/pyfftw.pyx
+++ b/pyfftw/pyfftw.pyx
@@ -855,6 +855,7 @@ cdef class FFTW:
 
     See the documentation on the :meth:`~pyfftw.FFTW.__call__` method
     for more information.
+
     '''
     # Each of these function pointers simply
     # points to a chosen fftw wrapper function
@@ -908,6 +909,7 @@ cdef class FFTW:
         The product of the lengths of the DFT over all DFT axes.
         1/N is the normalisation constant. For any input array A,
         and for any set of axes, 1/N * ifft(fft(A)) = A
+
         '''
         return self._total_size
 
@@ -1061,7 +1063,9 @@ cdef class FFTW:
 
     def _get_normalise_idft(self):
         '''
-        If ``normalise_idft=True``, the inverse transform is scaled by 1/N.
+        If ``normalise_idft=True``, the backward transform is
+        scaled by 1/N.
+
         '''
         return self._normalise_idft
 
@@ -1069,8 +1073,9 @@ cdef class FFTW:
 
     def _get_ortho(self):
         '''
-        If ``ortho=True`` both the forward and inverse transforms are scaled by
-        1/sqrt(N).
+        If ``ortho=True`` both the forward and backward
+        transforms are scaled by 1/sqrt(N).
+
         '''
         return self._ortho
 
@@ -1276,8 +1281,9 @@ cdef class FFTW:
                     total_N *= 2*(self._input_shape[self._axes[n]] + 1)
                 elif self._direction[n] == FFTW_REDFT00:
                     if (self._input_shape[self._axes[n]] < 2):
-                        raise ValueError('FFTW_REDFT00 (also known as DCT-1) is'
-                                ' not defined for inputs of length less than two.')
+                        raise ValueError('FFTW_REDFT00 (also known as DCT-1) '
+                                         'is not defined for inputs of '
+                                         'length less than two.')
                     total_N *= 2*(self._input_shape[self._axes[n]] - 1)
                 else:
                     total_N *= 2*self._input_shape[self._axes[n]]
@@ -1692,8 +1698,8 @@ cdef class FFTW:
         array, and then rely on the array being copied in before the
         transform (which :class:`pyfftw.FFTW` will handle for you when
         accessed through :meth:`~pyfftw.FFTW.__call__`).
-        '''
 
+        '''
     def __dealloc__(self):
 
         if not self._axes == NULL:
@@ -1715,8 +1721,9 @@ cdef class FFTW:
             free(self._direction)
 
     def __call__(self, input_array=None, output_array=None,
-            normalise_idft=None, ortho=None):
-        '''__call__(input_array=None, output_array=None, normalise_idft=True,
+                 normalise_idft=None, ortho=None):
+        '''
+        __call__(input_array=None, output_array=None, normalise_idft=True,
                     ortho=False)
 
         Calling the class instance (optionally) updates the arrays, then
@@ -1782,16 +1789,16 @@ cdef class FFTW:
         internally and will be overwritten again on subsequent calls. If you
         need the data to persist longer than a subsequent call, you should
         copy the returned array.
-        '''
 
+        '''
         if ortho is None:
             ortho = self._ortho
         if normalise_idft is None:
             normalise_idft = self._normalise_idft
 
         if ortho and normalise_idft:
-            raise ValueError('Invalid options: ortho and normalise_idft cannot'
-                             ' both be True.')
+            raise ValueError('Invalid options: ortho and normalise_idft '
+                             'cannot both be True.')
 
         if input_array is not None or output_array is not None:
 
@@ -1837,6 +1844,7 @@ cdef class FFTW:
 
         self.execute()
 
+        # after executing, optionally normalize output array
         if ortho:
             self._output_array *= self._sqrt_normalisation_scaling
         elif normalise_idft and self._direction[0] == FFTW_BACKWARD:
@@ -1848,7 +1856,8 @@ cdef class FFTW:
 
     cpdef update_arrays(self,
             new_input_array, new_output_array):
-        '''update_arrays(new_input_array, new_output_array)
+        '''
+        update_arrays(new_input_array, new_output_array)
 
         Update the arrays upon which the DFT is taken.
 
@@ -1868,6 +1877,7 @@ cdef class FFTW:
         If all these conditions are not met, a ``ValueError`` will
         be raised and the data will *not* be updated (though the
         object will still be in a sane state).
+
         '''
         if not isinstance(new_input_array, np.ndarray):
             raise ValueError('Invalid input array: '
@@ -1970,12 +1980,13 @@ cdef class FFTW:
         return self._output_array
 
     cpdef execute(self):
-        '''execute()
+        '''
+        execute()
 
         Execute the planned operation, taking the correct kind of FFT of
-        the input array (i.e. :attr:`FFTW.input_array`),
-        and putting the result in the output array (i.e.
-        :attr:`FFTW.output_array`).
+        the input array (i.e. :attr:`FFTW.input_array`), and putting the
+        result in the output array (i.e. :attr:`FFTW.output_array`).
+
         '''
         cdef void *input_pointer = (
                 <void *>np.PyArray_DATA(self._input_array))

--- a/pyfftw/pyfftw.pyx
+++ b/pyfftw/pyfftw.pyx
@@ -1837,10 +1837,11 @@ cdef class FFTW:
 
         self.execute()
 
-        if ortho == True:
+        if ortho:
             self._output_array *= self._sqrt_normalisation_scaling
-
-        if self._direction[0] == FFTW_BACKWARD and normalise_idft:
+        elif normalise_idft and self._direction[0] == FFTW_BACKWARD:
+            self._output_array *= self._normalisation_scaling
+        elif not normalise_idft and self._direction[0] == FFTW_FORWARD:
             self._output_array *= self._normalisation_scaling
 
         return self._output_array

--- a/pyfftw/pyfftw.pyx
+++ b/pyfftw/pyfftw.pyx
@@ -1062,21 +1062,21 @@ cdef class FFTW:
     axes = property(_get_axes)
 
     def _get_normalise_idft(self):
-        '''
+        """
         If ``normalise_idft=True``, the backward transform is
         scaled by 1/N.
 
-        '''
+        """
         return self._normalise_idft
 
     normalise_idft = property(_get_normalise_idft)
 
     def _get_ortho(self):
-        '''
+        """
         If ``ortho=True`` both the forward and backward
         transforms are scaled by 1/sqrt(N).
 
-        '''
+        """
         return self._ortho
 
     ortho = property(_get_ortho)

--- a/test/test_pyfftw_builders.py
+++ b/test/test_pyfftw_builders.py
@@ -50,9 +50,11 @@ warnings.filterwarnings('always')
 complex_dtypes = _supported_nptypes_complex
 real_dtypes = _supported_nptypes_real
 
+
 def make_complex_data(shape, dtype):
     ar, ai = numpy.random.randn(2, *shape).astype(dtype)
     return ar + 1j*ai
+
 
 def make_real_data(shape, dtype):
     return numpy.random.randn(*shape).astype(dtype)
@@ -94,6 +96,9 @@ class BuildersTestFFT(unittest.TestCase):
             ((59, 100), {}),
             ((32, 32, 4), {'axis': 1}),
             ((32, 32, 4), {'axis': 1, 'norm': 'ortho'}),
+            ((32, 32, 4), {'axis': 1, 'norm': None}),
+            ((32, 32, 4), {'axis': 1, 'norm': 'backward'}),
+            ((32, 32, 4), {'axis': 1, 'norm': 'forward'}),
             ((64, 128, 16), {}),
             )
 
@@ -132,7 +137,7 @@ class BuildersTestFFT(unittest.TestCase):
             yield test_shape, s, kwargs
 
     def validate_pyfftw_object(self, array_type, test_shape, dtype,
-            s, kwargs):
+                               s, kwargs):
 
         input_array = array_type(test_shape, dtype)
 
@@ -181,11 +186,11 @@ class BuildersTestFFT(unittest.TestCase):
 
         self.assertTrue(
                 numpy.allclose(output_array, test_out_array,
-                    rtol=1e-2, atol=1e-4))
+                               rtol=1e-2, atol=1e-4))
 
         self.assertTrue(
                 numpy.allclose(output_array_2, test_out_array,
-                    rtol=1e-2, atol=1e-4))
+                               rtol=1e-2, atol=1e-4))
 
         return FFTW_object
 
@@ -261,7 +266,8 @@ class BuildersTestFFT(unittest.TestCase):
                 s = None
 
                 FFTW_object = self.validate_pyfftw_object(dtype_tuple[1],
-                        test_shape, dtype, s, kwargs)
+                                                          test_shape, dtype,
+                                                          s, kwargs)
 
                 self.assertTrue(type(FFTW_object) == FFTW)
 
@@ -299,7 +305,6 @@ class BuildersTestFFT(unittest.TestCase):
                 self.assertRaisesRegex(exception, e_str,
                         getattr(builders, self.func),
                         *((input_array,) + args))
-
 
     def test_same_sized_s(self):
         dtype_tuple = input_dtypes[functions[self.func]]
@@ -416,7 +421,6 @@ class BuildersTestFFT(unittest.TestCase):
                 self.assertFalse(input_array.flags['C_CONTIGUOUS'] or
                     input_array.flags['F_CONTIGUOUS'])
 
-
                 # Firstly check the non-contiguous case (for both
                 # FFTW and _FFTWWrapper)
                 _kwargs['auto_contiguous'] = False
@@ -460,7 +464,6 @@ class BuildersTestFFT(unittest.TestCase):
                 flags = internal_input_array.flags
                 # as above
                 self.assertTrue(flags['C_CONTIGUOUS'])
-
 
     def test_auto_align_input(self):
         dtype_tuple = input_dtypes[functions[self.func]]
@@ -619,7 +622,6 @@ class BuildersTestFFT(unittest.TestCase):
                     self.validate_pyfftw_object,
                     *(dtype_tuple[1], test_shape, dtype, s, kwargs))
 
-
     def test_overwrite_input(self):
         '''Test the overwrite_input flag
         '''
@@ -643,7 +645,6 @@ class BuildersTestFFT(unittest.TestCase):
                             dtype_tuple[1], test_shape, dtype, s, kwargs)
 
                 self.assertTrue('FFTW_DESTROY_INPUT' in FFTW_object.flags)
-
 
     def test_input_maintained(self):
         '''Test to make sure the input is maintained
@@ -727,12 +728,15 @@ class BuildersTestFFT(unittest.TestCase):
 class BuildersTestIFFT(BuildersTestFFT):
     func = 'ifft'
 
+
 class BuildersTestRFFT(BuildersTestFFT):
     func = 'rfft'
+
 
 class BuildersTestIRFFT(BuildersTestFFT):
     func = 'irfft'
     realinv = True
+
 
 class BuildersTestFFT2(BuildersTestFFT):
     axes_kw = 'axes'
@@ -743,6 +747,9 @@ class BuildersTestFFT2(BuildersTestFFT):
             ((128, 32, 4), {'axes': (0, 2)}),
             ((59, 100), {'axes': (-2, -1)}),
             ((59, 100), {'axes': (-2, -1), 'norm': 'ortho'}),
+            ((59, 100), {'axes': (-2, -1), 'norm': None}),
+            ((59, 100), {'axes': (-2, -1), 'norm': 'backward'}),
+            ((59, 100), {'axes': (-2, -1), 'norm': 'forward'}),
             ((64, 128, 16), {'axes': (0, 2)}),
             ((4, 6, 8, 4), {'axes': (0, 3)}),
             )
@@ -759,12 +766,15 @@ class BuildersTestFFT2(BuildersTestFFT):
 class BuildersTestIFFT2(BuildersTestFFT2):
     func = 'ifft2'
 
+
 class BuildersTestRFFT2(BuildersTestFFT2):
     func = 'rfft2'
+
 
 class BuildersTestIRFFT2(BuildersTestFFT2):
     func = 'irfft2'
     realinv = True
+
 
 class BuildersTestFFTN(BuildersTestFFT2):
     func = 'ifftn'
@@ -773,14 +783,20 @@ class BuildersTestFFTN(BuildersTestFFT2):
             ((64, 128, 16), {'axes': (0, 1, 2)}),
             ((4, 6, 8, 4), {'axes': (0, 3, 1)}),
             ((4, 6, 8, 4), {'axes': (0, 3, 1), 'norm': 'ortho'}),
+            ((4, 6, 8, 4), {'axes': (0, 3, 1), 'norm': None}),
+            ((4, 6, 8, 4), {'axes': (0, 3, 1), 'norm': 'backward'}),
+            ((4, 6, 8, 4), {'axes': (0, 3, 1), 'norm': 'forward'}),
             ((4, 6, 8, 4), {'axes': (0, 3, 1, 2)}),
             )
+
 
 class BuildersTestIFFTN(BuildersTestFFTN):
     func = 'ifftn'
 
+
 class BuildersTestRFFTN(BuildersTestFFTN):
     func = 'rfftn'
+
 
 class BuildersTestIRFFTN(BuildersTestFFTN):
     func = 'irfftn'
@@ -788,10 +804,11 @@ class BuildersTestIRFFTN(BuildersTestFFTN):
 
 
 class BuildersTestFFTWWrapper(unittest.TestCase):
-    '''This basically reimplements the FFTW.__call__ tests, with
-    a few tweaks.
     '''
+    This basically reimplements the FFTW.__call__ tests
+    with a few tweaks.
 
+    '''
     def __init__(self, *args, **kwargs):
 
         super(BuildersTestFFTWWrapper, self).__init__(*args, **kwargs)
@@ -846,7 +863,6 @@ class BuildersTestFFTWWrapper(unittest.TestCase):
 
         self.assertTrue(numpy.alltrue(output_array == self.output_array))
 
-
     def test_call_with_positional_input_update(self):
         '''Test the class call with a positional input update.
         '''
@@ -863,7 +879,6 @@ class BuildersTestFFTWWrapper(unittest.TestCase):
 
         self.assertTrue(numpy.alltrue(output_array == self.output_array))
 
-
     def test_call_with_keyword_input_update(self):
         '''Test the class call with a keyword input update.
         '''
@@ -878,7 +893,6 @@ class BuildersTestFFTWWrapper(unittest.TestCase):
         self.fft.execute()
 
         self.assertTrue(numpy.alltrue(output_array == self.output_array))
-
 
     def test_call_with_keyword_output_update(self):
         '''Test the class call with a keyword output update.
@@ -964,23 +978,21 @@ class BuildersTestFFTWWrapper(unittest.TestCase):
 
         self.assertTrue(numpy.alltrue(output_array == test_output_array))
 
-
     def test_call_with_invalid_update(self):
         '''Test the class call with an invalid update.
         '''
 
         new_shape = self.input_array.shape + (2, )
         invalid_array = (numpy.random.randn(*new_shape)
-                + 1j*numpy.random.randn(*new_shape))
+                         + 1j*numpy.random.randn(*new_shape))
 
         self.assertRaises(ValueError, self.fft,
-                *(),
-                **{'output_array':invalid_array})
+                          *(),
+                          **{'output_array': invalid_array})
 
         self.assertRaises(ValueError, self.fft,
-                *(),
-                **{'input_array':invalid_array})
-
+                          *(),
+                          **{'input_array': invalid_array})
 
     def test_call_with_invalid_output_striding(self):
         '''Test the class call with an invalid strided output update.
@@ -1003,7 +1015,7 @@ class BuildersTestFFTWWrapper(unittest.TestCase):
                 numpy.random.randn(*internal_array_shape)
                 + 1j*numpy.random.randn(*internal_array_shape))
 
-        fft =  utils._FFTWWrapper(internal_array, self.output_array,
+        fft = utils._FFTWWrapper(internal_array, self.output_array,
                 input_array_slicer=self.input_array_slicer,
                 FFTW_array_slicer=self.FFTW_array_slicer)
 
@@ -1013,14 +1025,14 @@ class BuildersTestFFTWWrapper(unittest.TestCase):
                                         dtype=internal_array.dtype)
         new_input_array[:] = 0
 
-        new_input_array[:,:,0][self.input_array_slicer] = (
+        new_input_array[:, :, 0][self.input_array_slicer] = (
                 internal_array[self.FFTW_array_slicer])
 
-        new_output = fft(new_input_array[:,:,0]).copy()
+        new_output = fft(new_input_array[:, :, 0]).copy()
 
         # Test the test!
         self.assertTrue(
-                new_input_array[:,:,0].strides != internal_array.strides)
+                new_input_array[:, :, 0].strides != internal_array.strides)
 
         self.assertTrue(numpy.alltrue(test_output_array == new_output))
 
@@ -1031,21 +1043,21 @@ class BuildersTestFFTWWrapper(unittest.TestCase):
         shape[0] += 1
 
         input_array = byte_align(numpy.random.randn(*shape)
-                + 1j*numpy.random.randn(*shape))
+                                 + 1j*numpy.random.randn(*shape))
 
         self.assertRaisesRegex(ValueError, 'Invalid input shape',
-                self.fft, **{'input_array': input_array[:,:,0]})
+                self.fft, **{'input_array': input_array[:, :, 0]})
 
     def test_call_with_normalisation_on(self):
         _input_array = empty_aligned(self.internal_array.shape,
                                      dtype='complex128')
 
         ifft = utils._FFTWWrapper(self.output_array, _input_array,
-                direction='FFTW_BACKWARD',
-                input_array_slicer=slice(None),
-                FFTW_array_slicer=slice(None))
+                                  direction='FFTW_BACKWARD',
+                                  input_array_slicer=slice(None),
+                                  FFTW_array_slicer=slice(None))
 
-        self.fft(normalise_idft=True) # Shouldn't make any difference
+        self.fft(normalise_idft=True)
         ifft(normalise_idft=True)
 
         self.assertTrue(numpy.allclose(
@@ -1053,37 +1065,113 @@ class BuildersTestFFTWWrapper(unittest.TestCase):
             _input_array[self.FFTW_array_slicer]))
 
     def test_call_with_normalisation_off(self):
-
         _input_array = empty_aligned(self.internal_array.shape,
                                      dtype='complex128')
 
         ifft = utils._FFTWWrapper(self.output_array, _input_array,
-                direction='FFTW_BACKWARD',
-                input_array_slicer=slice(None),
-                FFTW_array_slicer=slice(None))
+                                  direction='FFTW_BACKWARD',
+                                  input_array_slicer=slice(None),
+                                  FFTW_array_slicer=slice(None))
 
-        self.fft(normalise_idft=True) # Shouldn't make any difference
+        self.fft(normalise_idft=True)
         ifft(normalise_idft=False)
-
         _input_array /= ifft.N
 
         self.assertTrue(numpy.allclose(
-            self.input_array[self.input_array_slicer],
-            _input_array[self.FFTW_array_slicer]))
+                self.input_array[self.input_array_slicer],
+                _input_array[self.FFTW_array_slicer]))
 
     def test_call_with_normalisation_default(self):
         _input_array = empty_aligned(self.internal_array.shape,
                                      dtype='complex128')
 
         ifft = utils._FFTWWrapper(self.output_array, _input_array,
-                direction='FFTW_BACKWARD',
-                input_array_slicer=slice(None),
-                FFTW_array_slicer=slice(None))
-
+                                  direction='FFTW_BACKWARD',
+                                  input_array_slicer=slice(None),
+                                  FFTW_array_slicer=slice(None))
         self.fft()
         ifft()
-
         # Scaling is performed by default
+        self.assertTrue(numpy.allclose(
+            self.input_array[self.input_array_slicer],
+            _input_array[self.FFTW_array_slicer]))
+
+    def test_call_norm_ortho(self):
+        _input_array = empty_aligned(self.internal_array.shape,
+                                     dtype='complex128')
+
+        normdict = utils._norm_args("ortho")
+
+        ifft = utils._FFTWWrapper(self.output_array, _input_array,
+                                  direction='FFTW_BACKWARD',
+                                  input_array_slicer=slice(None),
+                                  FFTW_array_slicer=slice(None),
+                                  normalise_idft=normdict["normalise_idft"],
+                                  ortho=normdict["ortho"])
+
+        self.fft(normalise_idft=normdict["normalise_idft"],
+                 ortho=normdict["ortho"])
+        ifft()
+        self.assertTrue(numpy.allclose(
+            self.input_array[self.input_array_slicer],
+            _input_array[self.FFTW_array_slicer]))
+
+    def test_call_norm_backward(self):
+        _input_array = empty_aligned(self.internal_array.shape,
+                                     dtype='complex128')
+
+        normdict = utils._norm_args("backward")
+
+        ifft = utils._FFTWWrapper(self.output_array, _input_array,
+                                  direction='FFTW_BACKWARD',
+                                  input_array_slicer=slice(None),
+                                  FFTW_array_slicer=slice(None),
+                                  normalise_idft=normdict["normalise_idft"],
+                                  ortho=normdict["ortho"])
+
+        self.fft(normalise_idft=normdict["normalise_idft"],
+                 ortho=normdict["ortho"])
+        ifft()
+        self.assertTrue(numpy.allclose(
+            self.input_array[self.input_array_slicer],
+            _input_array[self.FFTW_array_slicer]))
+
+    def test_call_norm_none(self):
+        _input_array = empty_aligned(self.internal_array.shape,
+                                     dtype='complex128')
+
+        normdict = utils._norm_args(None)
+
+        ifft = utils._FFTWWrapper(self.output_array, _input_array,
+                                  direction='FFTW_BACKWARD',
+                                  input_array_slicer=slice(None),
+                                  FFTW_array_slicer=slice(None),
+                                  normalise_idft=normdict["normalise_idft"],
+                                  ortho=normdict["ortho"])
+
+        self.fft(normalise_idft=normdict["normalise_idft"],
+                 ortho=normdict["ortho"])
+        ifft()
+        self.assertTrue(numpy.allclose(
+            self.input_array[self.input_array_slicer],
+            _input_array[self.FFTW_array_slicer]))
+
+    def test_call_norm_forward(self):
+        _input_array = empty_aligned(self.internal_array.shape,
+                                     dtype='complex128')
+
+        normdict = utils._norm_args("forward")
+
+        ifft = utils._FFTWWrapper(self.output_array, _input_array,
+                                  direction='FFTW_BACKWARD',
+                                  input_array_slicer=slice(None),
+                                  FFTW_array_slicer=slice(None),
+                                  normalise_idft=normdict["normalise_idft"],
+                                  ortho=normdict["ortho"])
+
+        self.fft(normalise_idft=normdict["normalise_idft"],
+                 ortho=normdict["ortho"])
+        ifft()
         self.assertTrue(numpy.allclose(
             self.input_array[self.input_array_slicer],
             _input_array[self.FFTW_array_slicer]))
@@ -1115,8 +1203,6 @@ class BuildersTestUtilities(unittest.TestCase):
             self.assertEqual(
                     utils._setup_input_slicers(*_input),
                     _output)
-
-
 
     def test_compute_array_shapes(self):
         # inputs are:
@@ -1215,7 +1301,7 @@ class BuildersTestUtilities(unittest.TestCase):
 
         for each_input, each_output in zip(inputs, outputs):
             self.assertEqual(self._call_cook_nd_args(each_input),
-                    each_output)
+                             each_output)
 
     def test_cook_nd_args_invreal(self):
 
@@ -1244,8 +1330,7 @@ class BuildersTestUtilities(unittest.TestCase):
 
         for each_input, each_output in zip(inputs, outputs):
             self.assertEqual(self._call_cook_nd_args(each_input),
-                    each_output)
-
+                             each_output)
 
     def test_cook_nd_args_invalid_inputs(self):
         # inputs are (a.shape, s, axes, invreal)
@@ -1258,7 +1343,9 @@ class BuildersTestUtilities(unittest.TestCase):
         # all the inputs should yield an error
         for each_input in inputs:
             self.assertRaisesRegex(ValueError, 'Shape error',
-                    self._call_cook_nd_args, *(each_input,))
+                                   self._call_cook_nd_args,
+                                   *(each_input,))
+
 
 test_cases = (
         BuildersTestFFTWWrapper,
@@ -1276,10 +1363,8 @@ test_cases = (
         BuildersTestRFFTN,
         BuildersTestIRFFTN)
 
-#test_set = {'BuildersTestRFFTN': ['test_dtype_coercian']}
+# test_set = {'BuildersTestRFFTN': ['test_dtype_coercian']}
 test_set = None
 
-
 if __name__ == '__main__':
-
     run_test_suites(test_cases, test_set)

--- a/test/test_pyfftw_builders.py
+++ b/test/test_pyfftw_builders.py
@@ -89,7 +89,8 @@ class BuildersTestFFT(unittest.TestCase):
 
     func = 'fft'
     axes_kw = 'axis'
-    test_shapes = (
+    if numpy.__version__ >= '1.20.0':
+        test_shapes = (
             ((100,), {}),
             ((128, 64), {'axis': 0}),
             ((128, 32), {'axis': -1}),
@@ -99,6 +100,17 @@ class BuildersTestFFT(unittest.TestCase):
             ((32, 32, 4), {'axis': 1, 'norm': None}),
             ((32, 32, 4), {'axis': 1, 'norm': 'backward'}),
             ((32, 32, 4), {'axis': 1, 'norm': 'forward'}),
+            ((64, 128, 16), {}),
+            )
+    else:
+        test_shapes = (
+            ((100,), {}),
+            ((128, 64), {'axis': 0}),
+            ((128, 32), {'axis': -1}),
+            ((59, 100), {}),
+            ((32, 32, 4), {'axis': 1}),
+            ((32, 32, 4), {'axis': 1, 'norm': 'ortho'}),
+            ((32, 32, 4), {'axis': 1, 'norm': None}),
             ((64, 128, 16), {}),
             )
 
@@ -741,7 +753,8 @@ class BuildersTestIRFFT(BuildersTestFFT):
 class BuildersTestFFT2(BuildersTestFFT):
     axes_kw = 'axes'
     func = 'ifft2'
-    test_shapes = (
+    if numpy.__version__ >= '1.20.0':
+        test_shapes = (
             ((128, 64), {'axes': None}),
             ((128, 32), {'axes': None}),
             ((128, 32, 4), {'axes': (0, 2)}),
@@ -750,6 +763,17 @@ class BuildersTestFFT2(BuildersTestFFT):
             ((59, 100), {'axes': (-2, -1), 'norm': None}),
             ((59, 100), {'axes': (-2, -1), 'norm': 'backward'}),
             ((59, 100), {'axes': (-2, -1), 'norm': 'forward'}),
+            ((64, 128, 16), {'axes': (0, 2)}),
+            ((4, 6, 8, 4), {'axes': (0, 3)}),
+            )
+    else:
+        test_shapes = (
+            ((128, 64), {'axes': None}),
+            ((128, 32), {'axes': None}),
+            ((128, 32, 4), {'axes': (0, 2)}),
+            ((59, 100), {'axes': (-2, -1)}),
+            ((59, 100), {'axes': (-2, -1), 'norm': 'ortho'}),
+            ((59, 100), {'axes': (-2, -1), 'norm': None}),
             ((64, 128, 16), {'axes': (0, 2)}),
             ((4, 6, 8, 4), {'axes': (0, 3)}),
             )
@@ -778,7 +802,8 @@ class BuildersTestIRFFT2(BuildersTestFFT2):
 
 class BuildersTestFFTN(BuildersTestFFT2):
     func = 'ifftn'
-    test_shapes = (
+    if numpy.__version__ >= '1.20.0':
+        test_shapes = (
             ((128, 32, 4), {'axes': None}),
             ((64, 128, 16), {'axes': (0, 1, 2)}),
             ((4, 6, 8, 4), {'axes': (0, 3, 1)}),
@@ -786,6 +811,15 @@ class BuildersTestFFTN(BuildersTestFFT2):
             ((4, 6, 8, 4), {'axes': (0, 3, 1), 'norm': None}),
             ((4, 6, 8, 4), {'axes': (0, 3, 1), 'norm': 'backward'}),
             ((4, 6, 8, 4), {'axes': (0, 3, 1), 'norm': 'forward'}),
+            ((4, 6, 8, 4), {'axes': (0, 3, 1, 2)}),
+            )
+    else:
+        test_shapes = (
+            ((128, 32, 4), {'axes': None}),
+            ((64, 128, 16), {'axes': (0, 1, 2)}),
+            ((4, 6, 8, 4), {'axes': (0, 3, 1)}),
+            ((4, 6, 8, 4), {'axes': (0, 3, 1), 'norm': 'ortho'}),
+            ((4, 6, 8, 4), {'axes': (0, 3, 1), 'norm': None}),
             ((4, 6, 8, 4), {'axes': (0, 3, 1, 2)}),
             )
 

--- a/test/test_pyfftw_dask_interface.py
+++ b/test/test_pyfftw_dask_interface.py
@@ -67,49 +67,53 @@ import warnings
 import copy
 warnings.filterwarnings('always')
 
+
 def make_complex_data(shape, dtype):
     ar, ai = dtype(numpy.random.randn(2, *shape))
     ac = ar + 1j*ai
-
     return da.from_array(ac, chunks=shape)
+
 
 def make_real_data(shape, dtype):
     ar = dtype(numpy.random.randn(*shape))
-
     return da.from_array(ar, chunks=shape)
 
-def _dask_array_fft_has_norm_kwarg():
-    """returns True if dask.array's fft supports the norm keyword argument
-    """
 
+def _dask_array_fft_has_norm_kwarg():
+    """
+    Returns True if dask.array's fft supports the
+    norm keyword argument.
+
+    """
     return False
 
-functions = {
-        'fft': 'complex',
-        'fft2': 'complex',
-        'fftn': 'complex',
-        'ifft': 'complex',
-        'ifft2': 'complex',
-        'ifftn': 'complex',
-        'rfft': 'r2c',
-        'rfft2': 'r2c',
-        'rfftn': 'r2c',
-        'irfft': 'c2r',
-        'irfft2': 'c2r',
-        'irfftn': 'c2r',
-        'hfft': 'c2r',
-        'ihfft': 'r2c'}
 
-acquired_names = ('fft_wrap', 'fftfreq', 'rfftfreq', 'fftshift', 'ifftshift')
+functions = {'fft': 'complex',
+             'fft2': 'complex',
+             'fftn': 'complex',
+             'ifft': 'complex',
+             'ifft2': 'complex',
+             'ifftn': 'complex',
+             'rfft': 'r2c',
+             'rfft2': 'r2c',
+             'rfftn': 'r2c',
+             'irfft': 'c2r',
+             'irfft2': 'c2r',
+             'irfftn': 'c2r',
+             'hfft': 'c2r',
+             'ihfft': 'r2c'}
 
-@unittest.skipIf(
-    not interfaces.dask_fft,
-    "dask interface is not available, so skipping tests."
-)
+acquired_names = ('fft_wrap', 'fftfreq', 'rfftfreq',
+                  'fftshift', 'ifftshift')
+
+
+@unittest.skipIf(not interfaces.dask_fft,
+                 "dask interface not available, skipping tests.")
 class InterfacesDaskFFTTestModule(unittest.TestCase):
-    ''' A really simple test suite to check the module works as expected.
-    '''
+    """
+    A really simple test suite to check the module works as expected.
 
+    """
     def test_acquired_names(self):
         for each_name in acquired_names:
 
@@ -119,16 +123,13 @@ class InterfacesDaskFFTTestModule(unittest.TestCase):
             self.assertIs(da_fft_attr, acquired_attr)
 
 
-@unittest.skipIf(
-    not interfaces.dask_fft,
-    "dask interface is not available, so skipping tests."
-)
+@unittest.skipIf(not interfaces.dask_fft,
+                 "dask interface not available, skipping tests.")
 class InterfacesDaskFFTTestFFT(unittest.TestCase):
 
-    io_dtypes = {
-            'complex': (complex_dtypes, make_complex_data),
-            'r2c': (real_dtypes, make_real_data),
-            'c2r': (complex_dtypes, make_complex_data)}
+    io_dtypes = {'complex': (complex_dtypes, make_complex_data),
+                 'r2c': (real_dtypes, make_real_data),
+                 'c2r': (complex_dtypes, make_complex_data)}
 
     validator_module = da_fft
     test_wrapped_interface = interfaces.numpy_fft
@@ -146,6 +147,9 @@ class InterfacesDaskFFTTestFFT(unittest.TestCase):
             ((59, 99), {'axis': 0}),
             ((32, 32, 4), {'axis': 1}),
             ((32, 32, 2), {'axis': 1, 'norm': 'ortho'}),
+            ((32, 32, 2), {'axis': 1, 'norm': None}),
+            ((32, 32, 2), {'axis': 1, 'norm': 'backward'}),
+            ((32, 32, 2), {'axis': 1, 'norm': 'forward'}),
             ((64, 128, 16), {}),
             )
 
@@ -171,16 +175,13 @@ class InterfacesDaskFFTTestFFT(unittest.TestCase):
     def __init__(self, *args, **kwargs):
 
         super(InterfacesDaskFFTTestFFT, self).__init__(*args, **kwargs)
-
         # Assume python 3, but keep backwards compatibility
         if not hasattr(self, 'assertRaisesRegex'):
             self.assertRaisesRegex = self.assertRaisesRegexp
 
     def validate(self, array_type, test_shape, dtype,
                  s, kwargs):
-
         # Do it without the cache
-
         # without:
         interfaces.cache.disable()
         self._validate(array_type, test_shape, dtype, s, kwargs)
@@ -206,7 +207,6 @@ class InterfacesDaskFFTTestFFT(unittest.TestCase):
 
         da_input_array = da.from_array(np_input_array,
                                        chunks=np_input_array.shape)
-
 
         with warnings.catch_warnings(record=True) as w:
             # We catch the warnings so as to pick up on when
@@ -239,8 +239,8 @@ class InterfacesDaskFFTTestFFT(unittest.TestCase):
 
                 # If the test interface raised, so must this.
                 self.assertEqual(type(interface_exception), type(e),
-                        msg='Interface exception raised. ' +
-                        'Testing for: ' + repr(e))
+                                 msg='Interface exception raised. ' +
+                                 'Testing for: ' + repr(e))
                 return
 
             output_array = getattr(self.test_interface, self.func)(
@@ -260,7 +260,7 @@ class InterfacesDaskFFTTestFFT(unittest.TestCase):
 
         self.assertTrue(
                 numpy.allclose(output_np, test_out_array,
-                    rtol=1e-2, atol=1e-4))
+                               rtol=1e-2, atol=1e-4))
 
         if input_np.real.dtype == numpy.float16:
             # FFTW output will never be single precision for half precision
@@ -270,10 +270,9 @@ class InterfacesDaskFFTTestFFT(unittest.TestCase):
             input_precision_dtype = input_np.real.dtype
 
         self.assertEqual(input_precision_dtype,
-                output_array.real.dtype)
+                         output_array.real.dtype)
 
-        self.assertTrue(numpy.allclose(input_array,
-                orig_input_array))
+        self.assertTrue(numpy.allclose(input_array, orig_input_array))
 
         return output_array
 
@@ -303,9 +302,11 @@ class InterfacesDaskFFTTestFFT(unittest.TestCase):
         return axes
 
     def s_from_kwargs(self, test_shape, kwargs):
-        ''' Return either a scalar s or a tuple depending on
+        """
+        Return either a scalar s or a tuple depending on
         whether axis or axes is specified
-        '''
+
+        """
         default_args = get_default_args(
             getattr(self.test_wrapped_interface, self.func))
 
@@ -354,18 +355,15 @@ class InterfacesDaskFFTTestFFT(unittest.TestCase):
         for dtype in dtype_tuple[0]:
             for test_shape, s, kwargs in self.test_data:
                 s = None
-
-                self.validate(dtype_tuple[1],
-                        test_shape, dtype, s, kwargs)
-
+                self.validate(dtype_tuple[1], test_shape,
+                              dtype, s, kwargs)
 
     def test_same_sized_s(self):
         dtype_tuple = self.io_dtypes[functions[self.func]]
         for dtype in dtype_tuple[0]:
             for test_shape, s, kwargs in self.test_data:
-
-                self.validate(dtype_tuple[1],
-                        test_shape, dtype, s, kwargs)
+                self.validate(dtype_tuple[1], test_shape,
+                              dtype, s, kwargs)
 
     def test_bigger_s(self):
         dtype_tuple = self.io_dtypes[functions[self.func]]
@@ -378,9 +376,8 @@ class InterfacesDaskFFTTestFFT(unittest.TestCase):
                 except TypeError:
                     s += 2
 
-                self.validate(dtype_tuple[1],
-                        test_shape, dtype, s, kwargs)
-
+                self.validate(dtype_tuple[1], test_shape,
+                              dtype, s, kwargs)
 
     def test_smaller_s(self):
         dtype_tuple = self.io_dtypes[functions[self.func]]
@@ -393,15 +390,17 @@ class InterfacesDaskFFTTestFFT(unittest.TestCase):
                 except TypeError:
                     s -= 2
 
-                self.validate(dtype_tuple[1],
-                        test_shape, dtype, s, kwargs)
+                self.validate(dtype_tuple[1], test_shape,
+                              dtype, s, kwargs)
 
     def check_arg(self, arg, arg_test_values, array_type, test_shape,
-            dtype, s, kwargs):
-        '''Check that the correct arg is passed to the builder'''
+                  dtype, s, kwargs):
+        """
+        Check that the correct arg is passed to the builder.
+
+        """
         # We trust the builders to work as expected when passed
         # the correct arg (the builders have their own unittests).
-
         return_values = []
         input_array = array_type(test_shape, dtype)
 
@@ -410,7 +409,6 @@ class InterfacesDaskFFTTestFFT(unittest.TestCase):
             return (args, kwargs)
 
         try:
-
             # Replace the function that is to be used
             real_fft = getattr(self.test_interface, self.func)
             setattr(self.test_interface, self.func, fake_fft)
@@ -420,12 +418,12 @@ class InterfacesDaskFFTTestFFT(unittest.TestCase):
             for each_value in arg_test_values:
                 _kwargs[arg] = each_value
                 builder_args = getattr(self.test_interface, self.func)(
-                input_array.copy(), s, **_kwargs)
-
+                        input_array.copy(), s, **_kwargs)
                 self.assertTrue(builder_args[1][arg] == each_value)
 
             # make sure it was called
             self.assertTrue(len(return_values) > 0)
+
         except:
             raise
 
@@ -437,17 +435,14 @@ class InterfacesDaskFFTTestFFT(unittest.TestCase):
         for each_value in arg_test_values:
             _kwargs[arg] = each_value
             builder_args = getattr(self.test_interface, self.func)(
-            input_array.copy(), s, **_kwargs)
-
+                    input_array.copy(), s, **_kwargs)
             self.validate(array_type, test_shape, dtype, s, _kwargs)
-
 
     def test_bigger_and_smaller_s(self):
         dtype_tuple = self.io_dtypes[functions[self.func]]
         for dtype in dtype_tuple[0]:
             i = -1
             for test_shape, s, kwargs in self.test_data:
-
                 try:
                     for each_axis, length in enumerate(s):
                         s[each_axis] += i * 2
@@ -455,10 +450,8 @@ class InterfacesDaskFFTTestFFT(unittest.TestCase):
                 except TypeError:
                     s += i * 2
                     i *= i
-
-                self.validate(dtype_tuple[1],
-                        test_shape, dtype, s, kwargs)
-
+                self.validate(dtype_tuple[1], test_shape,
+                              dtype, s, kwargs)
 
     def test_dtype_coercion(self):
         # Make sure we input a dtype that needs to be coerced
@@ -470,20 +463,18 @@ class InterfacesDaskFFTTestFFT(unittest.TestCase):
         for dtype in dtype_tuple[0]:
             for test_shape, s, kwargs in self.test_data:
                 s = None
-
-                self.validate(dtype_tuple[1],
-                        test_shape, dtype, s, kwargs)
-
+                self.validate(dtype_tuple[1], test_shape,
+                              dtype, s, kwargs)
 
     def test_input_maintained(self):
-        '''Test to make sure the input is maintained by default.
-        '''
+        """
+        Test to make sure the input is maintained by default.
+
+        """
         dtype_tuple = self.io_dtypes[functions[self.func]]
         for dtype in dtype_tuple[0]:
             for test_shape, s, kwargs in self.test_data:
-
                 input_array = dtype_tuple[1](test_shape, dtype)
-
                 orig_input_array = input_array.copy()
 
                 getattr(self.test_interface, self.func)(
@@ -503,6 +494,9 @@ class InterfacesDaskFFTTestFFT2(InterfacesDaskFFTTestFFT):
             ((128, 32, 4), {'axes': (0, 2)}),
             ((59, 100), {'axes': (-2, -1)}),
             ((32, 32), {'axes': (-2, -1), 'norm': 'ortho'}),
+            ((32, 32), {'axes': (-2, -1), 'norm': None}),
+            ((32, 32), {'axes': (-2, -1), 'norm': 'backward'}),
+            ((32, 32), {'axes': (-2, -1), 'norm': 'forward'}),
             ((64, 128, 16), {'axes': (0, 2)}),
             ((4, 6, 8, 4), {'axes': (0, 3)}),
             )
@@ -523,8 +517,8 @@ class InterfacesDaskFFTTestFFT2(InterfacesDaskFFTTestFFT):
                 s = s if s else None
 
                 del kwargs['axes']
-                self.validate(dtype_tuple[1],
-                        test_shape, dtype, s, kwargs)
+                self.validate(dtype_tuple[1], test_shape,
+                              dtype, s, kwargs)
 
 
 class InterfacesDaskFFTTestFFTN(InterfacesDaskFFTTestFFT2):
@@ -535,6 +529,9 @@ class InterfacesDaskFFTTestFFTN(InterfacesDaskFFTTestFFT2):
             ((64, 128, 16), {'axes': (0, 1, 2)}),
             ((4, 6, 8, 4), {'axes': (0, 3, 1)}),
             ((4, 6, 4, 4), {'axes': (0, 3, 1), 'norm': 'ortho'}),
+            ((4, 6, 4, 4), {'axes': (0, 3, 1), 'norm': None}),
+            ((4, 6, 4, 4), {'axes': (0, 3, 1), 'norm': 'backward'}),
+            ((4, 6, 4, 4), {'axes': (0, 3, 1), 'norm': 'forward'}),
             ((4, 6, 8, 4), {'axes': (0, 3, 1, 2)}),
             )
 
@@ -543,49 +540,60 @@ class InterfacesDaskFFTTestIFFT(InterfacesDaskFFTTestFFT):
     func = 'ifft'
     has_norm_kwarg = False
 
+
 class InterfacesDaskFFTTestIFFT2(InterfacesDaskFFTTestFFT2):
     func = 'ifft2'
     has_norm_kwarg = False
+
 
 class InterfacesDaskFFTTestIFFTN(InterfacesDaskFFTTestFFTN):
     func = 'ifftn'
     has_norm_kwarg = False
 
+
 class InterfacesDaskFFTTestRFFT(InterfacesDaskFFTTestFFT):
     func = 'rfft'
     has_norm_kwarg = False
+
 
 class InterfacesDaskFFTTestRFFT2(InterfacesDaskFFTTestFFT2):
     func = 'rfft2'
     has_norm_kwarg = False
 
+
 class InterfacesDaskFFTTestRFFTN(InterfacesDaskFFTTestFFTN):
     func = 'rfftn'
     has_norm_kwarg = False
+
 
 class InterfacesDaskFFTTestIRFFT(InterfacesDaskFFTTestFFT):
     func = 'irfft'
     realinv = True
     has_norm_kwarg = False
 
+
 class InterfacesDaskFFTTestIRFFT2(InterfacesDaskFFTTestFFT2):
     func = 'irfft2'
     has_norm_kwarg = False
     realinv = True
+
 
 class InterfacesDaskFFTTestIRFFTN(InterfacesDaskFFTTestFFTN):
     func = 'irfftn'
     has_norm_kwarg = False
     realinv = True
 
+
 class InterfacesDaskFFTTestHFFT(InterfacesDaskFFTTestFFT):
     func = 'hfft'
     realinv = True
     has_norm_kwarg = False
 
+
 class InterfacesDaskFFTTestIHFFT(InterfacesDaskFFTTestFFT):
     func = 'ihfft'
     has_norm_kwarg = False
+
 
 test_cases = (
         InterfacesDaskFFTTestModule,

--- a/test/test_pyfftw_interfaces_cache.py
+++ b/test/test_pyfftw_interfaces_cache.py
@@ -50,22 +50,27 @@ import time
 import os
 import hashlib
 
-'''Test the caching functionality of the interfaces package.
+'''
+Test the caching functionality of the interfaces package.
+
 '''
 
+
 def _check_n_cache_threads_running():
-    '''Return how many threads have the name 'PyFFTWCacheThread.
+    '''
+    Return how many threads have the name 'PyFFTWCacheThread.
 
     Obviously, this isn't production quality, but it should suffice for
     the tests here.
-    '''
 
+    '''
     cache_threads = 0
     for each_thread in threading.enumerate():
         if each_thread.name == 'PyFFTWCacheThread':
             cache_threads += 1
 
     return cache_threads
+
 
 @unittest.skipIf(*miss('64'))
 class InterfacesNumpyFFTCacheTestFFT(InterfacesNumpyFFTTestFFT):
@@ -91,17 +96,21 @@ class InterfacesNumpyFFTCacheTestFFT(InterfacesNumpyFFTTestFFT):
         # Turn it off to finish
         interfaces.cache.disable()
 
+
 @unittest.skipIf(*miss('64'))
 class CacheSpecificInterfacesUtils(unittest.TestCase):
 
     def test_slow_lookup_no_race_condition(self):
-        '''Checks that lookups in _utils longer than the keepalive time are ok.
+        '''
+        Checks that lookups in _utils longer than the keepalive time are ok.
+
         '''
         # Any old size, it doesn't matter
         data_shape = (128,)
 
         # Monkey patch the module with a custom _Cache object
         _Cache_class = interfaces.cache._Cache
+
         class _SlowLookupCache(_Cache_class):
 
             def _lookup(self, key):
@@ -364,12 +373,15 @@ class CacheTest(unittest.TestCase):
 class InterfacesNumpyFFTCacheTestIFFT(InterfacesNumpyFFTCacheTestFFT):
     func = 'ifft'
 
+
 class InterfacesNumpyFFTCacheTestRFFT(InterfacesNumpyFFTCacheTestFFT):
     func = 'rfft'
+
 
 class InterfacesNumpyFFTCacheTestIRFFT(InterfacesNumpyFFTCacheTestFFT):
     func = 'irfft'
     realinv = True
+
 
 class InterfacesNumpyFFTCacheTestFFT2(InterfacesNumpyFFTCacheTestFFT):
     axes_kw = 'axes'
@@ -393,12 +405,15 @@ class InterfacesNumpyFFTCacheTestFFT2(InterfacesNumpyFFTCacheTestFFT):
 class InterfacesNumpyFFTCacheTestIFFT2(InterfacesNumpyFFTCacheTestFFT2):
     func = 'ifft2'
 
+
 class InterfacesNumpyFFTCacheTestRFFT2(InterfacesNumpyFFTCacheTestFFT2):
     func = 'rfft2'
+
 
 class InterfacesNumpyFFTCacheTestIRFFT2(InterfacesNumpyFFTCacheTestFFT2):
     func = 'irfft2'
     realinv = True
+
 
 class InterfacesNumpyFFTCacheTestFFTN(InterfacesNumpyFFTCacheTestFFT2):
     func = 'ifftn'
@@ -409,15 +424,19 @@ class InterfacesNumpyFFTCacheTestFFTN(InterfacesNumpyFFTCacheTestFFT2):
             ((4, 6, 8, 4), {'axes': (0, 3, 1, 2)}),
             )
 
+
 class InterfacesNumpyFFTCacheTestIFFTN(InterfacesNumpyFFTCacheTestFFTN):
     func = 'ifftn'
+
 
 class InterfacesNumpyFFTCacheTestRFFTN(InterfacesNumpyFFTCacheTestFFTN):
     func = 'rfftn'
 
+
 class InterfacesNumpyFFTCacheTestIRFFTN(InterfacesNumpyFFTCacheTestFFTN):
     func = 'irfftn'
     realinv = True
+
 
 test_cases = (
         CacheTest,
@@ -439,5 +458,4 @@ test_cases = (
 test_set = None
 
 if __name__ == '__main__':
-
     run_test_suites(test_cases, test_set)

--- a/test/test_pyfftw_multithreaded.py
+++ b/test/test_pyfftw_multithreaded.py
@@ -37,18 +37,17 @@ import numpy
 from timeit import Timer
 
 from .test_pyfftw_base import run_test_suites, miss, np_fft
-
 import unittest
-
 from .test_pyfftw_base import FFTWBaseTest
+
 
 class Complex64MultiThreadedTest(FFTWBaseTest):
 
     def run_multithreaded_test(self, threads):
-        in_shape = self.input_shapes['2d'];
+        in_shape = self.input_shapes['2d']
         out_shape = self.output_shapes['2d']
 
-        axes=(-1,)
+        axes = (-1,)
         a, b = self.create_test_arrays(in_shape, out_shape)
 
         fft, ifft = self.run_validate_fft(a, b, axes, threads=threads)
@@ -56,9 +55,8 @@ class Complex64MultiThreadedTest(FFTWBaseTest):
         fft_, ifft_ = self.run_validate_fft(a, b, axes, threads=1)
 
         self.timer_routine(fft.execute, fft_.execute,
-                comparison_string='singled threaded')
+                           comparison_string='single threaded')
         self.assertTrue(True)
-
 
     def test_2_threads(self):
         self.run_multithreaded_test(2)
@@ -72,6 +70,7 @@ class Complex64MultiThreadedTest(FFTWBaseTest):
     def test_25_threads(self):
         self.run_multithreaded_test(25)
 
+
 @unittest.skipIf(*miss('64'))
 class Complex128MultiThreadedTest(Complex64MultiThreadedTest):
 
@@ -81,6 +80,7 @@ class Complex128MultiThreadedTest(Complex64MultiThreadedTest):
         self.output_dtype = numpy.complex128
         self.np_fft_comparison = np_fft.fft
         return
+
 
 @unittest.skipIf(*miss('ld'))
 class ComplexLongDoubleMultiThreadedTest(Complex64MultiThreadedTest):
@@ -99,6 +99,7 @@ class ComplexLongDoubleMultiThreadedTest(Complex64MultiThreadedTest):
         a = numpy.complex128(a)
         return np_fft.fftn(a, axes=axes)
 
+
 test_cases = (
         Complex64MultiThreadedTest,
         Complex128MultiThreadedTest,
@@ -107,5 +108,4 @@ test_cases = (
 test_set = None
 
 if __name__ == '__main__':
-
     run_test_suites(test_cases, test_set)

--- a/test/test_pyfftw_numpy_interface.py
+++ b/test/test_pyfftw_numpy_interface.py
@@ -167,7 +167,8 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
     overwrite_input_flag = 'overwrite_input'
     default_s_from_shape_slicer = slice(-1, None)
 
-    test_shapes = (
+    if numpy.__version__ >= '1.20.0':
+        test_shapes = (
             ((100,), {}),
             ((128, 64), {'axis': 0}),
             ((128, 32), {'axis': -1}),
@@ -179,6 +180,19 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
             ((32, 32, 2), {'axis': 1, 'norm': None}),
             ((32, 32, 2), {'axis': 1, 'norm': 'backward'}),
             ((32, 32, 2), {'axis': 1, 'norm': 'forward'}),
+            ((64, 128, 16), {}),
+            )
+    else:
+        test_shapes = (
+            ((100,), {}),
+            ((128, 64), {'axis': 0}),
+            ((128, 32), {'axis': -1}),
+            ((59, 100), {}),
+            ((59, 99), {'axis': -1}),
+            ((59, 99), {'axis': 0}),
+            ((32, 32, 4), {'axis': 1}),
+            ((32, 32, 2), {'axis': 1, 'norm': 'ortho'}),
+            ((32, 32, 2), {'axis': 1, 'norm': None}),
             ((64, 128, 16), {}),
             )
 
@@ -702,7 +716,8 @@ class InterfacesNumpyFFTTestIHFFT(InterfacesNumpyFFTTestFFT):
 class InterfacesNumpyFFTTestFFT2(InterfacesNumpyFFTTestFFT):
     axes_kw = 'axes'
     func = 'ifft2'
-    test_shapes = (
+    if numpy.__version__ >= '1.20.0':
+        test_shapes = (
             ((128, 64), {'axes': None}),
             ((128, 32), {'axes': None}),
             ((128, 32, 4), {'axes': (0, 2)}),
@@ -711,6 +726,17 @@ class InterfacesNumpyFFTTestFFT2(InterfacesNumpyFFTTestFFT):
             ((32, 32), {'axes': (-2, -1), 'norm': None}),
             ((32, 32), {'axes': (-2, -1), 'norm': 'backward'}),
             ((32, 32), {'axes': (-2, -1), 'norm': 'forward'}),
+            ((64, 128, 16), {'axes': (0, 2)}),
+            ((4, 6, 8, 4), {'axes': (0, 3)}),
+            )
+    else:
+        test_shapes = (
+            ((128, 64), {'axes': None}),
+            ((128, 32), {'axes': None}),
+            ((128, 32, 4), {'axes': (0, 2)}),
+            ((59, 100), {'axes': (-2, -1)}),
+            ((32, 32), {'axes': (-2, -1), 'norm': 'ortho'}),
+            ((32, 32), {'axes': (-2, -1), 'norm': None}),
             ((64, 128, 16), {'axes': (0, 2)}),
             ((4, 6, 8, 4), {'axes': (0, 3)}),
             )
@@ -755,7 +781,8 @@ class InterfacesNumpyFFTTestIRFFT2(InterfacesNumpyFFTTestFFT2):
 
 class InterfacesNumpyFFTTestFFTN(InterfacesNumpyFFTTestFFT2):
     func = 'ifftn'
-    test_shapes = (
+    if numpy.__version__ >= '1.20.0':
+        test_shapes = (
             ((128, 32, 4), {'axes': None}),
             ((64, 128, 16), {'axes': (0, 1, 2)}),
             ((4, 6, 8, 4), {'axes': (0, 3, 1)}),
@@ -763,6 +790,15 @@ class InterfacesNumpyFFTTestFFTN(InterfacesNumpyFFTTestFFT2):
             ((4, 6, 4, 4), {'axes': (0, 3, 1), 'norm': None}),
             ((4, 6, 4, 4), {'axes': (0, 3, 1), 'norm': 'backward'}),
             ((4, 6, 4, 4), {'axes': (0, 3, 1), 'norm': 'forward'}),
+            ((4, 6, 8, 4), {'axes': (0, 3, 1, 2)}),
+            )
+    else:
+        test_shapes = (
+            ((128, 32, 4), {'axes': None}),
+            ((64, 128, 16), {'axes': (0, 1, 2)}),
+            ((4, 6, 8, 4), {'axes': (0, 3, 1)}),
+            ((4, 6, 4, 4), {'axes': (0, 3, 1), 'norm': 'ortho'}),
+            ((4, 6, 4, 4), {'axes': (0, 3, 1), 'norm': None}),
             ((4, 6, 8, 4), {'axes': (0, 3, 1, 2)}),
             )
 

--- a/test/test_pyfftw_numpy_interface.py
+++ b/test/test_pyfftw_numpy_interface.py
@@ -61,12 +61,15 @@ if 'ld' in _supported_types:
     complex_dtypes.append(numpy.clongdouble)
     real_dtypes.append(numpy.longdouble)
 
+
 def make_complex_data(shape, dtype):
     ar, ai = dtype(numpy.random.randn(2, *shape))
     return ar + 1j*ai
 
+
 def make_real_data(shape, dtype):
     return dtype(numpy.random.randn(*shape))
+
 
 def _numpy_fft_has_norm_kwarg():
     """returns True if numpy's fft supports the norm keyword argument
@@ -79,6 +82,7 @@ def _numpy_fft_has_norm_kwarg():
         return True
     except TypeError:
         return False
+
 
 if _numpy_fft_has_norm_kwarg() and numpy.__version__ < '1.13':
     # use version of numpy.fft.rfft* with normalisation bug fixed
@@ -172,6 +176,9 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
             ((59, 99), {'axis': 0}),
             ((32, 32, 4), {'axis': 1}),
             ((32, 32, 2), {'axis': 1, 'norm': 'ortho'}),
+            ((32, 32, 2), {'axis': 1, 'norm': None}),
+            ((32, 32, 2), {'axis': 1, 'norm': 'backward'}),
+            ((32, 32, 2), {'axis': 1, 'norm': 'forward'}),
             ((64, 128, 16), {}),
             )
 
@@ -274,8 +281,8 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
 
                 # If the test interface raised, so must this.
                 self.assertEqual(type(interface_exception), type(e),
-                        msg='Interface exception raised. ' +
-                        'Testing for: ' + repr(e))
+                                 msg='Interface exception raised. ' +
+                                 'Testing for: ' + repr(e))
                 return
             try:
                 output_array = getattr(self.test_interface, self.func)(
@@ -297,7 +304,7 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
 
         self.assertTrue(
                 numpy.allclose(output_array, test_out_array,
-                    rtol=1e-2, atol=1e-4))
+                               rtol=1e-2, atol=1e-4))
 
         if _all_types_np.get(np_input_array.real.dtype, "") in _supported_types:
             # supported precisions should not be converted
@@ -307,7 +314,7 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
         if (not self.overwrite_input_flag in kwargs or
                 not kwargs[self.overwrite_input_flag]):
             self.assertTrue(numpy.allclose(input_array,
-                orig_input_array))
+                            orig_input_array))
 
         return output_array
 
@@ -390,21 +397,20 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
                 s = None
 
                 self.validate(dtype_tuple[1],
-                        test_shape, dtype, s, kwargs)
+                              test_shape, dtype, s, kwargs)
 
     def test_on_non_numpy_array(self):
         dtype_tuple = self.io_dtypes[functions[self.func]]
 
         array_type = (lambda test_shape, dtype:
-                dtype_tuple[1](test_shape, dtype).tolist())
+                      dtype_tuple[1](test_shape, dtype).tolist())
 
         for dtype in dtype_tuple[0]:
             for test_shape, s, kwargs in self.test_data:
                 s = None
 
                 self.validate(array_type,
-                        test_shape, dtype, s, kwargs)
-
+                              test_shape, dtype, s, kwargs)
 
     def test_fail_on_invalid_s_or_axes_or_norm(self):
         dtype_tuple = self.io_dtypes[functions[self.func]]
@@ -422,14 +428,13 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
                         getattr(self.test_interface, self.func),
                         *((input_array,) + args))
 
-
     def test_same_sized_s(self):
         dtype_tuple = self.io_dtypes[functions[self.func]]
         for dtype in dtype_tuple[0]:
             for test_shape, s, kwargs in self.test_data:
 
                 self.validate(dtype_tuple[1],
-                        test_shape, dtype, s, kwargs)
+                              test_shape, dtype, s, kwargs)
 
     def test_bigger_s(self):
         dtype_tuple = self.io_dtypes[functions[self.func]]
@@ -443,8 +448,7 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
                     s += 2
 
                 self.validate(dtype_tuple[1],
-                        test_shape, dtype, s, kwargs)
-
+                              test_shape, dtype, s, kwargs)
 
     def test_smaller_s(self):
         dtype_tuple = self.io_dtypes[functions[self.func]]
@@ -458,10 +462,10 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
                     s -= 2
 
                 self.validate(dtype_tuple[1],
-                        test_shape, dtype, s, kwargs)
+                              test_shape, dtype, s, kwargs)
 
     def check_arg(self, arg, arg_test_values, array_type, test_shape,
-            dtype, s, kwargs):
+                  dtype, s, kwargs):
         '''Check that the correct arg is passed to the builder'''
         # We trust the builders to work as expected when passed
         # the correct arg (the builders have their own unittests).
@@ -474,11 +478,9 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
             return (args, kwargs)
 
         try:
-
             # Replace the function that is to be used
             real_fft = getattr(self.test_interface, self.func)
             setattr(self.test_interface, self.func, fake_fft)
-
             _kwargs = kwargs.copy()
 
             for each_value in arg_test_values:
@@ -501,7 +503,7 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
         for each_value in arg_test_values:
             _kwargs[arg] = each_value
             builder_args = getattr(self.test_interface, self.func)(
-            input_array.copy(), s, **_kwargs)
+                                   input_array.copy(), s, **_kwargs)
 
             self.validate(array_type, test_shape, dtype, s, _kwargs)
 
@@ -511,7 +513,8 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
         for dtype in dtype_tuple[0]:
             for test_shape, s, kwargs in self.test_data:
                 self.check_arg('auto_align_input', (True, False),
-                        dtype_tuple[1], test_shape, dtype, s, kwargs)
+                               dtype_tuple[1], test_shape, dtype,
+                               s, kwargs)
 
     def test_auto_contiguous_input(self):
         dtype_tuple = self.io_dtypes[functions[self.func]]
@@ -519,7 +522,8 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
         for dtype in dtype_tuple[0]:
             for test_shape, s, kwargs in self.test_data:
                 self.check_arg('auto_contiguous', (True, False),
-                        dtype_tuple[1], test_shape, dtype, s, kwargs)
+                               dtype_tuple[1], test_shape, dtype,
+                               s, kwargs)
 
     def test_bigger_and_smaller_s(self):
         dtype_tuple = self.io_dtypes[functions[self.func]]
@@ -536,8 +540,7 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
                     i *= i
 
                 self.validate(dtype_tuple[1],
-                        test_shape, dtype, s, kwargs)
-
+                              test_shape, dtype, s, kwargs)
 
     def test_dtype_coercian(self):
         # Make sure we input a dtype that needs to be coerced
@@ -551,8 +554,7 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
                 s = None
 
                 self.validate(dtype_tuple[1],
-                        test_shape, dtype, s, kwargs)
-
+                              test_shape, dtype, s, kwargs)
 
     def test_planner_effort(self):
         '''Test the planner effort arg
@@ -568,7 +570,7 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
                 kwargs = {'axes': (-1,)}
 
             for each_effort in ('FFTW_ESTIMATE', 'FFTW_MEASURE',
-                    'FFTW_PATIENT', 'FFTW_EXHAUSTIVE'):
+                                'FFTW_PATIENT', 'FFTW_EXHAUSTIVE'):
 
                 kwargs['planner_effort'] = each_effort
 
@@ -578,8 +580,9 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
             kwargs['planner_effort'] = 'garbage'
 
             self.assertRaisesRegex(ValueError, 'Invalid planner effort',
-                    self.validate,
-                    *(dtype_tuple[1], test_shape, dtype, s, kwargs))
+                                   self.validate,
+                                   *(dtype_tuple[1], test_shape, dtype,
+                                     s, kwargs))
 
     def test_threads_arg(self):
         '''Test the threads argument
@@ -595,15 +598,14 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
                 kwargs = {'axes': (-1,)}
 
             self.check_arg(self.threads_arg_name, (1, 2, 5, 10),
-                        dtype_tuple[1], test_shape, dtype, s, kwargs)
+                           dtype_tuple[1], test_shape, dtype, s, kwargs)
 
             kwargs[self.threads_arg_name] = 'bleh'
 
             # Should not work
-            self.assertRaises(TypeError,
-                    self.validate,
-                    *(dtype_tuple[1], test_shape, dtype, s, kwargs))
-
+            self.assertRaises(TypeError, self.validate,
+                              *(dtype_tuple[1], test_shape, dtype,
+                                s, kwargs))
 
     def test_overwrite_input(self):
         '''Test the overwrite_input flag
@@ -618,7 +620,7 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
                 self.validate(dtype_tuple[1], test_shape, dtype, s, kwargs)
 
                 self.check_arg(self.overwrite_input_flag, (True, False),
-                        dtype_tuple[1], test_shape, dtype, s, kwargs)
+                               dtype_tuple[1], test_shape, dtype, s, kwargs)
 
     def test_input_maintained(self):
         '''Test to make sure the input is maintained by default.
@@ -678,19 +680,24 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
 class InterfacesNumpyFFTTestIFFT(InterfacesNumpyFFTTestFFT):
     func = 'ifft'
 
+
 class InterfacesNumpyFFTTestRFFT(InterfacesNumpyFFTTestFFT):
     func = 'rfft'
+
 
 class InterfacesNumpyFFTTestIRFFT(InterfacesNumpyFFTTestFFT):
     func = 'irfft'
     realinv = True
 
+
 class InterfacesNumpyFFTTestHFFT(InterfacesNumpyFFTTestFFT):
     func = 'hfft'
     realinv = True
 
+
 class InterfacesNumpyFFTTestIHFFT(InterfacesNumpyFFTTestFFT):
     func = 'ihfft'
+
 
 class InterfacesNumpyFFTTestFFT2(InterfacesNumpyFFTTestFFT):
     axes_kw = 'axes'
@@ -701,6 +708,9 @@ class InterfacesNumpyFFTTestFFT2(InterfacesNumpyFFTTestFFT):
             ((128, 32, 4), {'axes': (0, 2)}),
             ((59, 100), {'axes': (-2, -1)}),
             ((32, 32), {'axes': (-2, -1), 'norm': 'ortho'}),
+            ((32, 32), {'axes': (-2, -1), 'norm': None}),
+            ((32, 32), {'axes': (-2, -1), 'norm': 'backward'}),
+            ((32, 32), {'axes': (-2, -1), 'norm': 'forward'}),
             ((64, 128, 16), {'axes': (0, 2)}),
             ((4, 6, 8, 4), {'axes': (0, 3)}),
             )
@@ -727,18 +737,21 @@ class InterfacesNumpyFFTTestFFT2(InterfacesNumpyFFTTestFFT):
 
                 del kwargs['axes']
                 self.validate(dtype_tuple[1],
-                        test_shape, dtype, s, kwargs)
+                              test_shape, dtype, s, kwargs)
 
 
 class InterfacesNumpyFFTTestIFFT2(InterfacesNumpyFFTTestFFT2):
     func = 'ifft2'
 
+
 class InterfacesNumpyFFTTestRFFT2(InterfacesNumpyFFTTestFFT2):
     func = 'rfft2'
+
 
 class InterfacesNumpyFFTTestIRFFT2(InterfacesNumpyFFTTestFFT2):
     func = 'irfft2'
     realinv = True
+
 
 class InterfacesNumpyFFTTestFFTN(InterfacesNumpyFFTTestFFT2):
     func = 'ifftn'
@@ -747,18 +760,25 @@ class InterfacesNumpyFFTTestFFTN(InterfacesNumpyFFTTestFFT2):
             ((64, 128, 16), {'axes': (0, 1, 2)}),
             ((4, 6, 8, 4), {'axes': (0, 3, 1)}),
             ((4, 6, 4, 4), {'axes': (0, 3, 1), 'norm': 'ortho'}),
+            ((4, 6, 4, 4), {'axes': (0, 3, 1), 'norm': None}),
+            ((4, 6, 4, 4), {'axes': (0, 3, 1), 'norm': 'backward'}),
+            ((4, 6, 4, 4), {'axes': (0, 3, 1), 'norm': 'forward'}),
             ((4, 6, 8, 4), {'axes': (0, 3, 1, 2)}),
             )
+
 
 class InterfacesNumpyFFTTestIFFTN(InterfacesNumpyFFTTestFFTN):
     func = 'ifftn'
 
+
 class InterfacesNumpyFFTTestRFFTN(InterfacesNumpyFFTTestFFTN):
     func = 'rfftn'
+
 
 class InterfacesNumpyFFTTestIRFFTN(InterfacesNumpyFFTTestFFTN):
     func = 'irfftn'
     realinv = True
+
 
 test_cases = (
         InterfacesNumpyFFTTestModule,
@@ -777,9 +797,8 @@ test_cases = (
         InterfacesNumpyFFTTestRFFTN,
         InterfacesNumpyFFTTestIRFFTN,)
 
-#test_set = {'InterfacesNumpyFFTTestHFFT': ('test_valid',)}
+# test_set = {'InterfacesNumpyFFTTestHFFT': ('test_valid',)}
 test_set = None
 
 if __name__ == '__main__':
-
     run_test_suites(test_cases, test_set)

--- a/test/test_pyfftw_real_backward.py
+++ b/test/test_pyfftw_real_backward.py
@@ -39,10 +39,9 @@ from timeit import Timer
 import time
 
 from .test_pyfftw_base import run_test_suites, miss, require, np_fft
-
 import unittest
-
 from .test_pyfftw_complex import Complex64FFTWTest
+
 
 class RealBackwardDoubleFFTWTest(Complex64FFTWTest):
 
@@ -73,7 +72,7 @@ class RealBackwardDoubleFFTWTest(Complex64FFTWTest):
         in_shape = self.input_shapes['1d']
         out_shape = self.output_shapes['1d']
 
-        axes=(-1,)
+        axes = (-1,)
         a, b = self.create_test_arrays(in_shape, out_shape)
 
         # Note "thread" is incorrect, it should be "threads"
@@ -83,7 +82,7 @@ class RealBackwardDoubleFFTWTest(Complex64FFTWTest):
     def create_test_arrays(self, input_shape, output_shape, axes=None):
 
         a = self.input_dtype(numpy.random.randn(*input_shape)
-                +1j*numpy.random.randn(*input_shape))
+                             + 1j*numpy.random.randn(*input_shape))
 
         b = self.output_dtype(numpy.random.randn(*output_shape))
 
@@ -92,10 +91,10 @@ class RealBackwardDoubleFFTWTest(Complex64FFTWTest):
         # real will be (for example the zero freq component).
         # This is easier than writing a complicate system to work it out.
         try:
-            if axes == None:
-                fft = FFTW(b,a,direction='FFTW_FORWARD')
+            if axes is None:
+                fft = FFTW(b, a, direction='FFTW_FORWARD')
             else:
-                fft = FFTW(b,a,direction='FFTW_FORWARD', axes=axes)
+                fft = FFTW(b, a, direction='FFTW_FORWARD', axes=axes)
 
             b[:] = self.output_dtype(numpy.random.randn(*output_shape))
 
@@ -114,9 +113,10 @@ class RealBackwardDoubleFFTWTest(Complex64FFTWTest):
         return a, b
 
     def run_validate_fft(self, a, b, axes, fft=None, ifft=None,
-            force_unaligned_data=False, create_array_copies=True,
-            threads=1, flags=('FFTW_ESTIMATE',)):
-        ''' *** EVERYTHING IS FLIPPED AROUND BECAUSE WE ARE
+                         force_unaligned_data=False, create_array_copies=True,
+                         threads=1, flags=('FFTW_ESTIMATE',)):
+        '''
+        *** EVERYTHING IS FLIPPED AROUND BECAUSE WE ARE
         VALIDATING AN INVERSE FFT ***
 
         Run a validation of the FFTW routines for the passed pair
@@ -129,6 +129,7 @@ class RealBackwardDoubleFFTWTest(Complex64FFTWTest):
 
         If force_unaligned_data is True, the flag FFTW_UNALIGNED
         will be passed to the fftw routines.
+
         '''
         if create_array_copies:
             # Don't corrupt the original mutable arrays
@@ -142,18 +143,17 @@ class RealBackwardDoubleFFTWTest(Complex64FFTWTest):
         if force_unaligned_data:
             flags.append('FFTW_UNALIGNED')
 
-        if ifft == None:
+        if ifft is None:
             ifft = FFTW(a, b, axes=axes, direction='FFTW_BACKWARD',
-                    flags=flags, threads=threads)
+                        flags=flags, threads=threads)
         else:
-            ifft.update_arrays(a,b)
+            ifft.update_arrays(a, b)
 
-        if fft == None:
+        if fft is None:
             fft = FFTW(b, a, axes=axes, direction='FFTW_FORWARD',
-                    flags=flags, threads=threads)
+                       flags=flags, threads=threads)
         else:
-            fft.update_arrays(b,a)
-
+            fft.update_arrays(b, a)
 
         a[:] = a_orig
         # Test the inverse FFT by comparing it to the result from numpy.fft
@@ -171,30 +171,31 @@ class RealBackwardDoubleFFTWTest(Complex64FFTWTest):
         # This is actually quite a poor relative error, but it still
         # sometimes fails. I assume that numpy.fft has different internals
         # to fftw.
-        self.assertTrue(numpy.allclose(b/scaling, ref_b, rtol=1e-2, atol=1e-3))
-
+        self.assertTrue(numpy.allclose(b/scaling, ref_b, rtol=1e-2,
+                                       atol=1e-3))
         # Test the FFT by comparing the result to the starting
         # value (which is scaled as per FFTW being unnormalised).
         fft.execute()
 
-        self.assertTrue(numpy.allclose(a/scaling, a_orig, rtol=1e-2, atol=1e-3))
+        self.assertTrue(numpy.allclose(a/scaling, a_orig, rtol=1e-2,
+                                       atol=1e-3))
         return fft, ifft
 
     def test_time_with_array_update(self):
         in_shape = self.input_shapes['2d']
         out_shape = self.output_shapes['2d']
 
-        axes=(-1,)
+        axes = (-1,)
         a, b = self.create_test_arrays(in_shape, out_shape)
 
         fft, ifft = self.run_validate_fft(a, b, axes)
 
         def fftw_callable():
-            fft.update_arrays(b,a)
+            fft.update_arrays(b, a)
             fft.execute()
 
         self.timer_routine(fftw_callable,
-                lambda: self.np_fft_comparison(a))
+                           lambda: self.np_fft_comparison(a))
 
         self.assertTrue(True)
 
@@ -206,7 +207,7 @@ class RealBackwardDoubleFFTWTest(Complex64FFTWTest):
         in_shape = self.input_shapes['2d']
         out_shape = self.output_shapes['2d']
 
-        axes=(-1,)
+        axes = (-1,)
         a, b = self.create_test_arrays(in_shape, out_shape)
 
         with self.assertRaisesRegex(ValueError, 'Invalid direction'):
@@ -216,7 +217,7 @@ class RealBackwardDoubleFFTWTest(Complex64FFTWTest):
         in_shape = self.input_shapes['1d']
         out_shape = self.output_shapes['1d']
 
-        axes=(0,)
+        axes = (0,)
         a, b = self.create_test_arrays(in_shape, out_shape)
 
         # run this a few times
@@ -251,11 +252,12 @@ class RealBackwardDoubleFFTWTest(Complex64FFTWTest):
         in_shape = self.input_shapes['1d']
         out_shape = self.output_shapes['1d']
 
-        axes=(0,)
+        axes = (0,)
         a, b = self.create_test_arrays(in_shape, out_shape)
 
         self.assertRaisesRegex(TypeError, 'Invalid planning timelimit',
-                FFTW, *(b, a, axes), **{'planning_timelimit': 'foo'})
+                               FFTW, *(b, a, axes),
+                               **{'planning_timelimit': 'foo'})
 
     def test_default_args(self):
         in_shape = self.input_shapes['2d']
@@ -272,7 +274,7 @@ class RealBackwardDoubleFFTWTest(Complex64FFTWTest):
         in_shape = self.input_shapes['2d']
         out_shape = self.output_shapes['2d']
 
-        axes=(-2,-1)
+        axes = (-2, -1)
         a, b = self.create_test_arrays(in_shape, out_shape)
 
         # Some arbitrary and crazy slicing
@@ -280,12 +282,13 @@ class RealBackwardDoubleFFTWTest(Complex64FFTWTest):
         # b needs to be compatible
         b_sliced = b[12:200:3, 300:2041:9]
 
-        self.run_validate_fft(a_sliced, b_sliced, axes, create_array_copies=False)
+        self.run_validate_fft(a_sliced, b_sliced, axes,
+                              create_array_copies=False)
 
     def test_non_contiguous_2d_in_3d(self):
         in_shape = (256, 4, 1025)
         out_shape = (256, 4, 2048)
-        axes=(0,2)
+        axes = (0, 2)
         a, b = self.create_test_arrays(in_shape, out_shape)
 
         # Some arbitrary and crazy slicing
@@ -295,17 +298,20 @@ class RealBackwardDoubleFFTWTest(Complex64FFTWTest):
 
         # The data doesn't work, so we need to generate it for the
         # correct size
-        a_, b_ = self.create_test_arrays(a_sliced.shape, b_sliced.shape, axes=axes)
+        a_, b_ = self.create_test_arrays(a_sliced.shape, b_sliced.shape,
+                                         axes=axes)
 
         # And then copy it into the non contiguous array
         a_sliced[:] = a_
         b_sliced[:] = b_
 
-        self.run_validate_fft(a_sliced, b_sliced, axes, create_array_copies=False)
+        self.run_validate_fft(a_sliced, b_sliced, axes,
+                              create_array_copies=False)
 
     def test_non_monotonic_increasing_axes(self):
         super(RealBackwardDoubleFFTWTest,
-                self).test_non_monotonic_increasing_axes()
+              self).test_non_monotonic_increasing_axes()
+
 
 @unittest.skipIf(*miss('32'))
 class RealBackwardSingleFFTWTest(RealBackwardDoubleFFTWTest):
@@ -317,6 +323,7 @@ class RealBackwardSingleFFTWTest(RealBackwardDoubleFFTWTest):
         self.np_fft_comparison = np_fft.irfft
 
         self.direction = 'FFTW_BACKWARD'
+
 
 @unittest.skipIf(*miss('ld'))
 class RealBackwardLongDoubleFFTWTest(RealBackwardDoubleFFTWTest):
@@ -342,6 +349,7 @@ class RealBackwardLongDoubleFFTWTest(RealBackwardDoubleFFTWTest):
     def test_time_with_array_update(self):
         pass
 
+
 test_cases = (
         RealBackwardDoubleFFTWTest,
         RealBackwardSingleFFTWTest,
@@ -350,7 +358,6 @@ test_cases = (
 test_set = None
 
 if __name__ == '__main__':
-
     run_test_suites(test_cases, test_set)
 
 del Complex64FFTWTest

--- a/test/test_pyfftw_real_forward.py
+++ b/test/test_pyfftw_real_forward.py
@@ -37,10 +37,9 @@ import numpy
 from timeit import Timer
 
 from .test_pyfftw_base import run_test_suites, miss, require, np_fft
-
 import unittest
-
 from .test_pyfftw_complex import Complex64FFTWTest
+
 
 class RealForwardDoubleFFTWTest(Complex64FFTWTest):
 
@@ -70,19 +69,18 @@ class RealForwardDoubleFFTWTest(Complex64FFTWTest):
         a = self.input_dtype(numpy.random.randn(*input_shape))
 
         b = self.output_dtype(numpy.random.randn(*output_shape)
-                +1j*numpy.random.randn(*output_shape))
+                              + 1j*numpy.random.randn(*output_shape))
 
         return a, b
 
     def reference_fftn(self, a, axes):
-
         return np_fft.rfftn(a, axes=axes)
 
     def test_wrong_direction_fail(self):
         in_shape = self.input_shapes['2d']
         out_shape = self.output_shapes['2d']
 
-        axes=(-1,)
+        axes = (-1,)
         a, b = self.create_test_arrays(in_shape, out_shape)
 
         with self.assertRaisesRegex(ValueError, 'Invalid direction'):
@@ -92,7 +90,7 @@ class RealForwardDoubleFFTWTest(Complex64FFTWTest):
         in_shape = self.input_shapes['2d']
         out_shape = self.output_shapes['2d']
 
-        axes=(-2,-1)
+        axes = (-2, -1)
         a, b = self.create_test_arrays(in_shape, out_shape)
 
         # Some arbitrary and crazy slicing
@@ -100,12 +98,13 @@ class RealForwardDoubleFFTWTest(Complex64FFTWTest):
         # b needs to be compatible
         b_sliced = b[20:146:2, 100:786:7]
 
-        self.run_validate_fft(a_sliced, b_sliced, axes, create_array_copies=False)
+        self.run_validate_fft(a_sliced, b_sliced, axes,
+                              create_array_copies=False)
 
     def test_non_contiguous_2d_in_3d(self):
         in_shape = (256, 4, 2048)
         out_shape = in_shape
-        axes=(0,2)
+        axes = (0, 2)
         a, b = self.create_test_arrays(in_shape, out_shape)
 
         # Some arbitrary and crazy slicing
@@ -113,7 +112,9 @@ class RealForwardDoubleFFTWTest(Complex64FFTWTest):
         # b needs to be compatible
         b_sliced = b[20:146:2, :, 100:786:7]
 
-        self.run_validate_fft(a_sliced, b_sliced, axes, create_array_copies=False)
+        self.run_validate_fft(a_sliced, b_sliced, axes,
+                              create_array_copies=False)
+
 
 @unittest.skipIf(*miss('32'))
 class RealForwardSingleFFTWTest(RealForwardDoubleFFTWTest):
@@ -125,6 +126,7 @@ class RealForwardSingleFFTWTest(RealForwardDoubleFFTWTest):
         self.np_fft_comparison = np_fft.rfft
 
         self.direction = 'FFTW_FORWARD'
+
 
 @unittest.skipIf(*miss('ld'))
 class RealForwardLongDoubleFFTWTest(RealForwardDoubleFFTWTest):
@@ -150,6 +152,7 @@ class RealForwardLongDoubleFFTWTest(RealForwardDoubleFFTWTest):
         a = numpy.float64(a)
         return np_fft.rfftn(a, axes=axes)
 
+
 test_cases = (
         RealForwardDoubleFFTWTest,
         RealForwardSingleFFTWTest,
@@ -158,7 +161,6 @@ test_cases = (
 test_set = None
 
 if __name__ == '__main__':
-
     run_test_suites(test_cases, test_set)
 
 del Complex64FFTWTest

--- a/test/test_pyfftw_scipy_fft.py
+++ b/test/test_pyfftw_scipy_fft.py
@@ -137,9 +137,9 @@ transform_types = [1, 2, 3, 4]
 
 if LooseVersion(scipy_version) >= '1.6.0':
     # all norm options aside from None
-    scipy_norms = ['ortho', 'forward', 'backward']
+    scipy_norms = [None, 'ortho', 'forward', 'backward']
 else:
-    scipy_norms = ['ortho']
+    scipy_norms = [None, 'ortho']
 
 
 @unittest.skipIf(not has_scipy_fft, 'scipy.fft is unavailable')

--- a/test/test_pyfftw_scipy_fft.py
+++ b/test/test_pyfftw_scipy_fft.py
@@ -51,9 +51,11 @@ from pyfftw import _supported_types
 from .test_pyfftw_base import run_test_suites, miss
 from . import test_pyfftw_numpy_interface
 
-'''pyfftw.interfaces.scipy_fft just wraps pyfftw.interfaces.numpy_fft.
+'''
+pyfftw.interfaces.scipy_fft just wraps pyfftw.interfaces.numpy_fft.
 
 All the tests here just check that the call is made correctly.
+
 '''
 
 funcs = ('fft', 'ifft', 'fft2', 'ifft2', 'fftn', 'ifftn',
@@ -63,15 +65,19 @@ funcs = ('fft', 'ifft', 'fft2', 'ifft2', 'fftn', 'ifftn',
 acquired_names = ('hfft2', 'ihfft2', 'hfftn', 'ihfftn',
                   'fftshift', 'ifftshift', 'fftfreq', 'rfftfreq')
 
+
 def make_complex_data(shape, dtype):
     ar, ai = dtype(numpy.random.randn(2, *shape))
     return ar + 1j*ai
 
+
 def make_r2c_real_data(shape, dtype):
     return dtype(numpy.random.randn(*shape))
 
+
 def make_c2r_real_data(shape, dtype):
     return dtype(numpy.random.randn(*shape))
+
 
 # reuse from numpy tests
 make_complex_data = test_pyfftw_numpy_interface.make_complex_data
@@ -82,6 +88,7 @@ io_dtypes = {
         'complex': (complex_dtypes, make_complex_data),
         'r2c': (real_dtypes, make_r2c_real_data),
         'c2r': (real_dtypes, make_c2r_real_data)}
+
 
 @unittest.skipIf(not has_scipy_fft, 'scipy.fft is unavailable')
 class InterfacesScipyFFTTestSimple(unittest.TestCase):
@@ -134,6 +141,7 @@ if LooseVersion(scipy_version) >= '1.6.0':
 else:
     scipy_norms = ['ortho']
 
+
 @unittest.skipIf(not has_scipy_fft, 'scipy.fft is unavailable')
 class InterfacesScipyR2RFFTTest(unittest.TestCase):
     ''' Class template for building the scipy real to real tests.
@@ -168,7 +176,9 @@ class InterfacesScipyR2RFFTTest(unittest.TestCase):
         for transform_type in transform_types:
             data_hat_p = self.pyfftw_func(self.data, type=transform_type,
                                           overwrite_x=False, **self.kwargs)
-            self.assertEqual(numpy.linalg.norm(self.data - self.data_copy), 0.0)
+            self.assertEqual(numpy.linalg.norm(self.data - self.data_copy),
+                             0.0)
+
             data_hat_s = self.scipy_func(self.data, type=transform_type,
                                          overwrite_x=False, **self.kwargs)
             self.assertTrue(numpy.allclose(data_hat_p, data_hat_s,
@@ -181,15 +191,15 @@ class InterfacesScipyR2RFFTTest(unittest.TestCase):
         for norm in scipy_norms:
             for transform_type in transform_types:
                 data_hat_p = self.pyfftw_func(self.data, type=transform_type,
-                                              norm=norm,
-                                              overwrite_x=False, **self.kwargs)
+                                              norm=norm, overwrite_x=False,
+                                              **self.kwargs)
                 if norm == 'ortho':
                     self.assertEqual(
-                        numpy.linalg.norm(self.data - self.data_copy), 0.0
-                    )
+                        numpy.linalg.norm(self.data - self.data_copy), 0.0)
+
                 data_hat_s = self.scipy_func(self.data, type=transform_type,
-                                             norm=norm,
-                                             overwrite_x=False, **self.kwargs)
+                                             norm=norm, overwrite_x=False,
+                                             **self.kwargs)
                 self.assertTrue(numpy.allclose(data_hat_p, data_hat_s,
                                                atol=self.atol, rtol=self.rtol))
 
@@ -199,11 +209,11 @@ class InterfacesScipyR2RFFTTest(unittest.TestCase):
         for transform_type in transform_types:
             inverse_type = {1: 1, 2: 3, 3: 2, 4: 4}[transform_type]
             forward = self.pyfftw_func(self.data, type=transform_type,
-                                       norm='ortho',
-                                       overwrite_x=False, **self.kwargs)
+                                       norm='ortho', overwrite_x=False,
+                                       **self.kwargs)
             result = self.pyfftw_func(forward, type=inverse_type,
-                                      norm='ortho',
-                                      overwrite_x=False, **self.kwargs)
+                                      norm='ortho', overwrite_x=False,
+                                      **self.kwargs)
             self.assertTrue(numpy.allclose(self.data, result,
                                            atol=self.atol, rtol=self.rtol))
 
@@ -238,7 +248,9 @@ class InterfacesScipyR2RFFTNTest(InterfacesScipyR2RFFTTest):
         for transform_type in transform_types:
             data_hat_p = self.pyfftw_func(self.data, type=transform_type,
                                           overwrite_x=False, axes=None)
-            self.assertEqual(numpy.linalg.norm(self.data - self.data_copy), 0.0)
+            self.assertEqual(numpy.linalg.norm(self.data - self.data_copy),
+                             0.0)
+
             data_hat_s = self.scipy_func(self.data, type=transform_type,
                                          overwrite_x=False, axes=None)
             self.assertTrue(numpy.allclose(data_hat_p, data_hat_s,
@@ -250,7 +262,9 @@ class InterfacesScipyR2RFFTNTest(InterfacesScipyR2RFFTTest):
         for transform_type in transform_types:
             data_hat_p = self.pyfftw_func(self.data, type=transform_type,
                                           overwrite_x=False, axes=-1)
-            self.assertEqual(numpy.linalg.norm(self.data - self.data_copy), 0.0)
+            self.assertEqual(numpy.linalg.norm(self.data - self.data_copy),
+                             0.0)
+
             data_hat_s = self.scipy_func(self.data, type=transform_type,
                                          overwrite_x=False, axes=-1)
             self.assertTrue(numpy.allclose(data_hat_p, data_hat_s,
@@ -328,7 +342,6 @@ for each_func in funcs:
 
 test_cases.append(InterfacesScipyFFTTestSimple)
 test_set = None
-
 
 if __name__ == '__main__':
     run_test_suites(test_cases, test_set)

--- a/test/test_pyfftw_scipy_interface.py
+++ b/test/test_pyfftw_scipy_interface.py
@@ -54,29 +54,34 @@ else:
 import unittest
 from .test_pyfftw_base import run_test_suites, miss
 from . import test_pyfftw_numpy_interface
-
-'''pyfftw.interfaces.scipy_fftpack wraps pyfftw.interfaces.numpy_fft and
+'''
+pyfftw.interfaces.scipy_fftpack wraps pyfftw.interfaces.numpy_fft and
 implements the dct and dst functions.
 
 All the tests here just check that the call is made correctly.
-'''
 
+'''
 funcs = ('fft', 'ifft', 'fft2', 'ifft2', 'fftn', 'ifftn',
          'rfft', 'irfft')
 
 acquired_names = ('diff', 'tilbert', 'itilbert', 'hilbert',
-        'ihilbert', 'cs_diff', 'sc_diff', 'ss_diff', 'cc_diff', 'shift',
-        'fftshift', 'ifftshift', 'fftfreq', 'rfftfreq', 'convolve')
+                  'ihilbert', 'cs_diff', 'sc_diff', 'ss_diff',
+                  'cc_diff', 'shift', 'fftshift', 'ifftshift',
+                  'fftfreq', 'rfftfreq', 'convolve')
+
 
 def make_complex_data(shape, dtype):
     ar, ai = dtype(numpy.random.randn(2, *shape))
     return ar + 1j*ai
 
+
 def make_r2c_real_data(shape, dtype):
     return dtype(numpy.random.randn(*shape))
 
+
 def make_c2r_real_data(shape, dtype):
     return dtype(numpy.random.randn(*shape))
+
 
 make_complex_data = test_pyfftw_numpy_interface.make_complex_data
 
@@ -94,16 +99,17 @@ else:
 complex_dtypes = [x for x in complex_dtypes if x != numpy.clongdouble]
 real_dtypes = [x for x in real_dtypes if x != numpy.longdouble]
 
+
 def numpy_fft_replacement(a, s, axes, overwrite_input, planner_effort,
-        threads, auto_align_input, auto_contiguous):
+                          threads, auto_align_input, auto_contiguous):
 
     return (a, s, axes, overwrite_input, planner_effort,
-        threads, auto_align_input, auto_contiguous)
+            threads, auto_align_input, auto_contiguous)
 
-io_dtypes = {
-        'complex': (complex_dtypes, make_complex_data),
-        'r2c': (real_dtypes, make_r2c_real_data),
-        'c2r': (real_dtypes, make_c2r_real_data)}
+
+io_dtypes = {'complex': (complex_dtypes, make_complex_data),
+             'r2c': (real_dtypes, make_r2c_real_data),
+             'c2r': (real_dtypes, make_c2r_real_data)}
 
 if '64' in _supported_types:
     default_floating_type = numpy.float64
@@ -111,11 +117,13 @@ elif '32' in _supported_types:
     default_floating_type = numpy.float32
 elif 'ld' in _supported_types:
     default_floating_type = numpy.longdouble
+
 atol_dict = dict(f=1e-5, d=1e-7, g=1e-7)
 rtol_dict = dict(f=1e-4, d=1e-5, g=1e-5)
 
-@unittest.skipIf(scipy_missing, 'scipy is not installed, so this feature is'
-                 'unavailable')
+
+@unittest.skipIf(scipy_missing, 'scipy is not installed, so this feature '
+                 'is unavailable')
 class InterfacesScipyR2RFFTPackTestSimple(unittest.TestCase):
     ''' A really simple test suite to check simple implementation.
     '''
@@ -139,7 +147,6 @@ class InterfacesScipyR2RFFTPackTestSimple(unittest.TestCase):
                 1j*numpy.random.randn(*a.shape))
         b[:] = (numpy.random.randn(*b.shape) +
                 1j*numpy.random.randn(*b.shape))
-
 
         scipy_c = scipy.signal.fftconvolve(a, b)
 
@@ -168,7 +175,7 @@ class InterfacesScipyR2RFFTPackTestSimple(unittest.TestCase):
         for each_func in funcs:
             func_being_replaced = getattr(scipy_fftpack, each_func)
 
-            #create args (8 of them)
+            # create args (8 of them)
             args = []
             for n in range(8):
                 args.append(object())
@@ -199,11 +206,13 @@ class InterfacesScipyR2RFFTPackTestSimple(unittest.TestCase):
 
             self.assertIs(fftpack_attr, acquired_attr)
 
+
 transform_types = [1, 2, 3, 4]
+
 
 @unittest.skipIf(scipy_missing or
                  (LooseVersion(scipy.__version__) <= LooseVersion('1.2.0')),
-                'SciPy >= 1.2.0 is not installed')
+                 'SciPy >= 1.2.0 is not installed')
 class InterfacesScipyR2RFFTTest(unittest.TestCase):
     ''' Class template for building the scipy real to real tests.
     '''
@@ -237,7 +246,8 @@ class InterfacesScipyR2RFFTTest(unittest.TestCase):
         for transform_type in transform_types:
             data_hat_p = self.pyfftw_func(self.data, type=transform_type,
                                           overwrite_x=False, **self.kwargs)
-            self.assertEqual(numpy.linalg.norm(self.data - self.data_copy), 0.0)
+            self.assertEqual(numpy.linalg.norm(self.data - self.data_copy),
+                             0.0)
             data_hat_s = self.scipy_func(self.data, type=transform_type,
                                          overwrite_x=False, **self.kwargs)
             self.assertTrue(numpy.allclose(data_hat_p, data_hat_s,
@@ -251,10 +261,11 @@ class InterfacesScipyR2RFFTTest(unittest.TestCase):
             data_hat_p = self.pyfftw_func(self.data, type=transform_type,
                                           norm='ortho',
                                           overwrite_x=False, **self.kwargs)
-            self.assertEqual(numpy.linalg.norm(self.data - self.data_copy), 0.0)
+            self.assertEqual(numpy.linalg.norm(self.data - self.data_copy),
+                             0.0)
             data_hat_s = self.scipy_func(self.data, type=transform_type,
-                                         norm='ortho',
-                                         overwrite_x=False, **self.kwargs)
+                                         norm='ortho', overwrite_x=False,
+                                         **self.kwargs)
             self.assertTrue(numpy.allclose(data_hat_p, data_hat_s,
                                            atol=self.atol, rtol=self.rtol))
 
@@ -264,13 +275,14 @@ class InterfacesScipyR2RFFTTest(unittest.TestCase):
         for transform_type in transform_types:
             inverse_type = {1: 1, 2: 3, 3: 2, 4: 4}[transform_type]
             forward = self.pyfftw_func(self.data, type=transform_type,
-                                       norm='ortho',
-                                       overwrite_x=False, **self.kwargs)
+                                       norm='ortho', overwrite_x=False,
+                                       **self.kwargs)
             result = self.pyfftw_func(forward, type=inverse_type,
-                                      norm='ortho',
-                                      overwrite_x=False, **self.kwargs)
+                                      norm='ortho', overwrite_x=False,
+                                      **self.kwargs)
             self.assertTrue(numpy.allclose(self.data, result,
                                            atol=self.atol, rtol=self.rtol))
+
 
 @unittest.skipIf(scipy_missing or
                  (LooseVersion(scipy.__version__) <= LooseVersion('1.2.0')),
@@ -304,7 +316,8 @@ class InterfacesScipyR2RFFTNTest(InterfacesScipyR2RFFTTest):
         for transform_type in transform_types:
             data_hat_p = self.pyfftw_func(self.data, type=transform_type,
                                           overwrite_x=False, axes=None)
-            self.assertEqual(numpy.linalg.norm(self.data - self.data_copy), 0.0)
+            self.assertEqual(numpy.linalg.norm(self.data - self.data_copy),
+                             0.0)
             data_hat_s = self.scipy_func(self.data, type=transform_type,
                                          overwrite_x=False, axes=None)
             self.assertTrue(numpy.allclose(data_hat_p, data_hat_s,
@@ -321,7 +334,8 @@ class InterfacesScipyR2RFFTNTest(InterfacesScipyR2RFFTTest):
                 continue
             data_hat_p = self.pyfftw_func(self.data, type=transform_type,
                                           overwrite_x=False, axes=-1)
-            self.assertEqual(numpy.linalg.norm(self.data - self.data_copy), 0.0)
+            self.assertEqual(numpy.linalg.norm(self.data - self.data_copy),
+                             0.0)
             data_hat_s = self.scipy_func(self.data, type=transform_type,
                                          overwrite_x=False, axes=-1)
             self.assertTrue(numpy.allclose(data_hat_p, data_hat_s,
@@ -397,8 +411,7 @@ for each_func in funcs:
                   'overwrite_input_flag': 'overwrite_x',
                   'default_s_from_shape_slicer': slice(None)}
 
-    globals()[class_name] = type(class_name,
-            (parent_class,), class_dict)
+    globals()[class_name] = type(class_name, (parent_class,), class_dict)
 
     # unlike numpy, none of the scipy functions support the norm kwarg
     globals()[class_name].has_norm_kwarg = False
@@ -407,13 +420,10 @@ for each_func in funcs:
 
 built_classes = tuple(built_classes)
 
-test_cases = (
-        InterfacesScipyR2RFFTPackTestSimple,) + built_classes
+test_cases = (InterfacesScipyR2RFFTPackTestSimple,) + built_classes
 
 test_set = None
-#test_set = {'InterfacesScipyR2RFFTPackTestIFFTN': ['test_auto_align_input']}
-
+# test_set = {'InterfacesScipyR2RFFTPackTestIFFTN': ['test_auto_align_input']}
 
 if __name__ == '__main__':
-
     run_test_suites(test_cases, test_set)

--- a/test/test_pyfftw_utils.py
+++ b/test/test_pyfftw_utils.py
@@ -41,12 +41,11 @@ import platform
 import os
 from numpy.testing import assert_, assert_equal
 
-def get_cpus_info():
 
+def get_cpus_info():
     if 'Linux' in platform.system():
         # A simple /proc/cpuinfo parser
-        with open(os.path.join('/', 'proc','cpuinfo'), 'r') as f:
-
+        with open(os.path.join('/', 'proc', 'cpuinfo'), 'r') as f:
             cpus_info = []
             idx = 0
             for line in f.readlines():
@@ -60,24 +59,23 @@ def get_cpus_info():
                     cpus_info[idx][key] = values
                 except IndexError:
                     cpus_info.append({key: values})
-
     else:
         cpus_info = None
 
     return cpus_info
 
+
 class UtilsTest(unittest.TestCase):
 
     def setUp(self):
-
         return
 
     def tearDown(self):
-
         return
 
     @unittest.skipIf('Linux' not in platform.system(),
-            'Skipping as we only have it set up for Linux at present.')
+                     'Skipping as we only have it set up for Linux '
+                     'at present.')
     def test_get_alignment(self):
         cpus_info = get_cpus_info()
 
@@ -93,9 +91,7 @@ class UtilsTest(unittest.TestCase):
 class NextFastLenTest(unittest.TestCase):
 
     def __init__(self, *args, **kwargs):
-
         super(NextFastLenTest, self).__init__(*args, **kwargs)
-
         if not hasattr(self, 'assertRaisesRegex'):
             self.assertRaisesRegex = self.assertRaisesRegexp
 
@@ -164,12 +160,10 @@ class NextFastLenTest(unittest.TestCase):
         for x, y in strict_test_cases.items():
             assert_equal(pyfftw.next_fast_len(x), y)
 
-test_cases = (
-        UtilsTest,
-        NextFastLenTest)
+
+test_cases = (UtilsTest, NextFastLenTest)
 
 test_set = None
 
 if __name__ == '__main__':
-
     run_test_suites(test_cases, test_set)

--- a/test/test_pyfftw_wisdom.py
+++ b/test/test_pyfftw_wisdom.py
@@ -32,10 +32,9 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
-from pyfftw import (
-        FFTW, empty_aligned,
-        export_wisdom, import_wisdom, forget_wisdom,
-        _supported_types, _supported_nptypes_complex)
+from pyfftw import (FFTW, empty_aligned,
+                    export_wisdom, import_wisdom, forget_wisdom,
+                    _supported_types, _supported_nptypes_complex)
 
 from .test_pyfftw_base import run_test_suites
 
@@ -45,19 +44,19 @@ import sys
 
 import unittest
 
+
 class FFTWWisdomTest(unittest.TestCase):
 
     def generate_wisdom(self):
         for each_dtype in _supported_nptypes_complex:
             n = 16
-            a = empty_aligned((1,1024), each_dtype, n=n)
+            a = empty_aligned((1, 1024), each_dtype, n=n)
             b = empty_aligned(a.shape, dtype=a.dtype, n=n)
-            fft = FFTW(a,b)
-
+            fft = FFTW(a, b)
 
     def compare_single(self, prec, before, after):
         # skip over unsupported data types where wisdom is the empty string
-        if  prec in _supported_types:
+        if prec in _supported_types:
             # wisdom not updated for ld, at least on appveyor; e.g.
             # https://ci.appveyor.com/project/hgomersall/pyfftw/build/job/vweyed25jx8oxxcb
             if prec == 'ld' and sys.platform.startswith("win"):
@@ -68,47 +67,32 @@ class FFTWWisdomTest(unittest.TestCase):
             self.assertEqual(before, b'')
             self.assertEqual(before, after)
 
-
     def compare(self, before, after):
-        for prec, ind in zip(['64', '32', 'ld'], [0,1,2]):
+        for prec, ind in zip(['64', '32', 'ld'], [0, 1, 2]):
             self.compare_single(prec, before[ind], after[ind])
 
-
     def test_export(self):
-
         forget_wisdom()
-
         before_wisdom = export_wisdom()
-
         self.generate_wisdom()
-
         after_wisdom = export_wisdom()
-
         self.compare(before_wisdom, after_wisdom)
 
     def test_import(self):
-
         forget_wisdom()
-
         self.generate_wisdom()
-
         after_wisdom = export_wisdom()
-
         forget_wisdom()
         before_wisdom = export_wisdom()
-
         success = import_wisdom(after_wisdom)
-
         self.compare(before_wisdom, after_wisdom)
+        self.assertEqual(success, tuple([x in _supported_types for x in ['64',
+                                        '32', 'ld']]))
 
-        self.assertEqual(success, tuple([x in _supported_types for x in ['64', '32', 'ld']]))
 
-
-test_cases = (
-        FFTWWisdomTest,)
+test_cases = (FFTWWisdomTest,)
 
 test_set = None
 
 if __name__ == '__main__':
-
     run_test_suites(test_cases, test_set)

--- a/test/test_r2r.py
+++ b/test/test_r2r.py
@@ -99,6 +99,7 @@ nodes_lookup = {
     'FFTW_REDFT11': lambda n: (numpy.arange(n) + 0.5)/n,
 }
 
+
 @unittest.skipIf('64' not in _supported_types, 'double precision unavailable')
 class TestRealToRealLookups(unittest.TestCase):
     '''Test that the lookup tables correctly pair node choices and
@@ -108,10 +109,10 @@ class TestRealToRealLookups(unittest.TestCase):
         n = rand.randint(10, 20)
         j = rand.randint(5, n) - 3
         for transform in real_transforms:
-            nodes   = nodes_lookup[transform](n)
-            data    = interpolated_function_lookup[transform](j, nodes)
-            output  = numpy.empty_like(data)
-            plan    = pyfftw.FFTW(data, output, direction=[transform])
+            nodes = nodes_lookup[transform](n)
+            data = interpolated_function_lookup[transform](j, nodes)
+            output = numpy.empty_like(data)
+            plan = pyfftw.FFTW(data, output, direction=[transform])
             data[:] = interpolated_function_lookup[transform](j, nodes)
             plan.execute()
             tol = 4*j*n*1e-16
@@ -121,6 +122,7 @@ class TestRealToRealLookups(unittest.TestCase):
                 self.assertTrue(abs(output[j] - n + 1) < tol)
             else:
                 self.assertTrue(abs(output[j] - n) < tol)
+
 
 class TestRealTransform(object):
     '''Common set of functionality for performing tests on the real to
@@ -147,16 +149,16 @@ class TestRealTransform(object):
             self.axes = axes
         for dim in dims:
             if dim < 3:
-                raise NotImplementedError("Due to complications with the DCT1, "
-                                          "arrays must be of length at least "
-                                          "three.")
+                raise NotImplementedError("Due to complications with the "
+                                          "DCT1, arrays must be of length "
+                                          "at least three.")
 
         if len(self.axes) != len(directions):
             raise ValueError("There must be exactly one axis per direction.")
 
         self.directions = directions
         self.inverse_directions = [inverse_lookup[direction]
-                                    for direction in directions]
+                                   for direction in directions]
         self.dims = dims
         self._normalisation_factor = 1.0
         for index, axis in enumerate(self.axes):
@@ -170,10 +172,12 @@ class TestRealTransform(object):
         else:
             self._input_array = numpy.zeros(dims)
             self._output_array = numpy.zeros(dims)
+
         self.plan = pyfftw.FFTW(self._input_array, self._output_array,
-            axes=self.axes, direction=self.directions)
+                                axes=self.axes, direction=self.directions)
         self.inverse_plan = pyfftw.FFTW(self._input_array, self._output_array,
-            axes=self.axes, direction=self.inverse_directions)
+                                        axes=self.axes,
+                                        direction=self.inverse_directions)
 
         self.tol = 1e-10
         if dtype is None:
@@ -198,7 +202,8 @@ class TestRealTransform(object):
         self.inverse_plan.execute()
 
         data *= self._normalisation_factor
-        err = numpy.mean(numpy.abs(data - self._output_array))/self._normalisation_factor
+        err = numpy.mean(numpy.abs(data - self._output_array)
+                         )/self._normalisation_factor
         return err < self.tol
 
     def test_against_exact_data(self):
@@ -215,13 +220,18 @@ class TestRealTransform(object):
             else:
                 wavenumber_min = 0
                 wavenumber_max = self.dims[axis] - 2
-            _wavenumbers = sorted({rand.randint(wavenumber_min, wavenumber_max)
+            _wavenumbers = sorted({rand.randint(wavenumber_min,
+                                                wavenumber_max)
                                   for _ in range(self.dims[axis])})
+
             _factors = [rand.randint(1, 8) for _ in _wavenumbers]
             interpolated_function = interpolated_function_lookup[
                 self.directions[index]]
+
             data *= sum((factor*interpolated_function(wavenumber, points[axis])
-                         for factor, wavenumber in zip(_factors, _wavenumbers)))
+                         for factor, wavenumber in zip(_factors,
+                                                       _wavenumbers)))
+
             wavenumbers.append(numpy.array(_wavenumbers))
             factors.append(numpy.array(_factors))
 
@@ -265,8 +275,9 @@ def meshgrid(*x):
         args = numpy.atleast_1d(*x)
         s0 = (1,)*len(args)
         return list(map(numpy.squeeze,
-                        numpy.broadcast_arrays(*[x.reshape(s0[:i] + (-1,) + s0[i + 1::])
-                                              for i, x in enumerate(args)])))
+                        numpy.broadcast_arrays(*[x.reshape(s0[:i] + (-1,)
+                                                           + s0[i + 1::])
+                                               for i, x in enumerate(args)])))
 
 
 def grid(shape, axes, directions, aspect_ratio=None):
@@ -335,6 +346,7 @@ class RealToRealNormalisation(unittest.TestCase):
             testcase = random_testcase()
             self.assertTrue(testcase.test_normalisation())
 
+
 @unittest.skipIf('64' not in _supported_types, 'double precision unavailable')
 class RealToRealExactData(unittest.TestCase):
     def test_exact_data(self):
@@ -342,12 +354,14 @@ class RealToRealExactData(unittest.TestCase):
             testcase = random_testcase()
             self.assertTrue(testcase.test_against_exact_data())
 
+
 @unittest.skipIf('64' not in _supported_types, 'double precision unavailable')
 class RealToRealRandomData(unittest.TestCase):
     def test_random_data(self):
         for _ in range(50):
             testcase = random_testcase()
             self.assertTrue(testcase.test_against_random_data())
+
 
 test_cases = (TestRealToRealLookups,
               RealToRealNormalisation,


### PR DESCRIPTION
**ENH: update interfaces to support new numpy.fft normalization options**

Closes #295.

This PR extends the normalization options of the `pyfftw` builders and `numpy_interface`, so that they're up to date with the current `numpy.fft` options (see [numpy/numpy#16476](https://github.com/numpy/numpy/pull/16476)). In particular, the `norm` keyword argument now accepts the following values:
- `norm=backward` (alias of `norm=None`, default case) which scales the backward FFT with 1/N and leaves the forward unscaled;
- `norm=ortho` which scales both directions with 1/sqrt(N);
- `norm=forward` which scales the forward FFT with 1/N and leaves the backward unscaled. 

pyFFTW uses two boolean variables `ortho` and `normalise_idft` to determine the correct normalization, instead of one string variable `norm` like in NumPy. The main change is in the builders utilities function `_norm_args(norm)` which receives `norm` and outputs a dictionary with the correct scaling flags. Both the builders and the interfaces use this function. `_Xfftn` has also been modified to apply the correct normalization after the FFT has been executed. The `dct` and `dst` builders don't accept any normalization options other than the default, so no changes made there.

The main change in the NumPy interface is in the hermitian routines `hfft` and `ihfft`; due to symmetry, `hfft` is done via `irfft` and `ihfft` via `rfft`, which means that before calling the real FFTs we need to swap direction of the normalization flags. For that I've added the `_swap_direction_dict` module variable and the `_swap_direction(norm)` function, which make sure the "real" norm value is established correctly; that's now handled in the exact same way as in NumPy.

I've added tests in the builders testsuite that check the new norm options are called correctly, and that roundtrip equality holds for all norm values (i.e. `ifft(fft(a)) == a` up to numerical accuracy for all `norm` values). I've added those in the FFTW wrapper tests, since they require both forward and backward FFTs. For the NumPy interface I've added test cases for the new `norm` options, but couldn't figure out how to check for roundtrip consistency. The interfaces use the same underlying routines already checked by the builders tests, but it'd be nice to explicitly check the interface calls as well.

All tests pass at the time of writing, but I'm not sure my approach is correct so if someone more experienced could take a look at the tests that'd be appreciated. Just so that we're sure all cases are covered properly.