### PR TITLE
Build wheels on GitHub Actions via cibuildwheel

### DIFF
--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -93,10 +93,8 @@ jobs:
           CIBW_MANYLINUX_I686_IMAGE: manylinux1
           CC: /usr/bin/clang
           CXX: /usr/bin/clang++
-          # CPPFLAGS: "-Xpreprocessor -fopenmp"
-          # CFLAGS: "-Wno-implicit-function-declaration -I/usr/local/opt/libomp/include"
-          # CXXFLAGS: "-I/usr/local/opt/libomp/include"
-          # LDFLAGS: "-Wl,-rpath,/usr/local/opt/libomp/lib -L/usr/local/opt/libomp/lib -lomp"
+          CFLAGS: "-Wno-implicit-function-declaration -I/usr/local/opt/fftw/include"
+          LDFLAGS: "-Wl,-rpath,/usr/local/opt/fftw/lib -L/usr/local/opt/fftw/lib"
 
       - uses: actions/upload-artifact@v2
         with:
@@ -130,6 +128,7 @@ jobs:
         env:
           CIBW_BUILD: "cp3?-*"
           CIBW_SKIP: "cp36-*"
+          CIBW_ARCHS_WINDOWS: "auto"  # auto is equivalent to "AMD64 x86"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
           CIBW_MANYLINUX_I686_IMAGE: manylinux1
 

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -1,0 +1,184 @@
+name: Build Wheels and Release
+on:
+  push:
+    branches:
+      - cibuildwheel
+    tags:
+      - 'v*'
+      - 'buildwheels*'
+env:
+  CIBW_BUILD_VERBOSITY: 2
+  CIBW_BEFORE_ALL_LINUX: yum install -y fftw-devel
+  CIBW_BEFORE_ALL_MACOS: brew install fftw
+  CIBW_BEFORE_ALL_WINDOWS:  # TODO: run cmd or powershell script to download and configure the FFTW libs
+  CIBW_ENVIRONMENT_MACOS: PYFFTW_INCLUDE="/usr/local/opt/fftw/include" PYFFTW_LIB_DIR="/usr/local/opt/fftw/lib"
+  CIBW_TEST_REQUIRES: # scipy dask
+  CIBW_TEST_COMMAND: >
+    python -c "import pyfftw; import numpy as np; from pyfftw.interfaces import numpy_fft as fft; np.testing.assert_allclose(fft.fft(np.zeros(8)), np.zeros(8));"
+
+jobs:
+  build_linux_37_and_above_wheels:
+    name: Build python ${{ matrix.cibw_python }} wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-18.04]
+        cibw_python: [ "cp37-*", "cp38-*" ]
+        cibw_manylinux: [ manylinux1 ]
+        include:
+          - os: ubuntu-18.04
+            cibw_python: "cp39-*"
+            cibw_manylinux: manylinux2010
+          - os: ubuntu-18.04
+            cibw_python: "cp310-*"
+            cibw_manylinux: manylinux2014
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.7'
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: arm64
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install cibuildwheel
+      - name: Build the wheel
+        run: |
+          python -m cibuildwheel --output-dir dist
+        env:
+          CIBW_BUILD: ${{ matrix.cibw_python }}
+          CIBW_ARCHS_LINUX: auto aarch64
+          CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
+          CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: ./dist/*.whl
+
+  build_macos_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest]
+    env:
+      MACOSX_DEPLOYMENT_TARGET: "10.13"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.7'
+
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install cibuildwheel
+      - name: Build wheels for CPython (MacOS)
+        run: |
+          python -m cibuildwheel --output-dir dist
+        env:
+          CIBW_BUILD: "cp3?-*"
+          CIBW_SKIP: "cp36-*"
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
+          CIBW_MANYLINUX_I686_IMAGE: manylinux1
+          CC: /usr/bin/clang
+          CXX: /usr/bin/clang++
+          # CPPFLAGS: "-Xpreprocessor -fopenmp"
+          # CFLAGS: "-Wno-implicit-function-declaration -I/usr/local/opt/libomp/include"
+          # CXXFLAGS: "-I/usr/local/opt/libomp/include"
+          # LDFLAGS: "-Wl,-rpath,/usr/local/opt/libomp/lib -L/usr/local/opt/libomp/lib -lomp"
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: ./dist/*.whl
+
+  build_windows_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.7'
+
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install cibuildwheel
+      - name: Build Windows wheels for CPython
+        run: |
+          python -m cibuildwheel --output-dir dist
+        env:
+          CIBW_BUILD: "cp3?-*"
+          CIBW_SKIP: "cp36-*"
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
+          CIBW_MANYLINUX_I686_IMAGE: manylinux1
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: ./dist/*.whl
+
+
+  deploy:
+    name: Release
+    needs: [build_linux_37_and_above_wheels, build_macos_wheels, build_windows_wheels]
+    if: github.repository_owner == 'pyFFTW' && startsWith(github.ref, 'refs/tags/v') && always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.7'
+      
+      - name: Install Twine
+        run: |
+          python -m pip install --upgrade pip
+          pip install twine
+      
+      - uses: actions/download-artifact@v2
+        id: download
+        with:
+          name: wheels
+          path: ./dist
+    
+      - name: Publish the source distribution on PyPI
+        run: |
+          PYFFTW_VERSION=$(git describe --tags)
+          python setup.py sdist
+          ls -la ${{ github.workspace }}/dist
+          # We prefer to release wheels before source because otherwise there is a
+          # small window during which users who pip install pyfftw will require compilation.
+          twine upload ${{ github.workspace }}/dist/*.whl
+          twine upload ${{ github.workspace }}/dist/pyfftw-${PYFFTW_VERSION:1}.tar.gz
+        env:
+          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+              
+      - name: Github release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,10 +3,30 @@ requires = [
     "wheel",
     "setuptools",
     "Cython>=0.29.18",
-    "numpy==1.16.5; python_version=='3.7'",
-    "numpy==1.17.3; python_version=='3.8'",
-    "numpy==1.19.5; python_version=='3.9'",
-    # do not pin numpy on future versions of python to avoid incompatible numpy and python versions
+
+    # NumPy dependencies - to update these, sync from
+    # https://github.com/scipy/oldest-supported-numpy/, and then
+    # update minimum version to match our install_requires min version
+    # ----------------------------------------------------------------
+
+    # numpy 1.19 was the first minor release to provide aarch64 wheels, but
+    # wheels require fixes contained in numpy 1.19.2
+    "numpy==1.19.2; python_version=='3.8' and platform_machine=='aarch64'",
+    # aarch64 for py39 is covered by default requirement below
+
+    # arm64 on Darwin supports Python 3.8 and above requires numpy>=1.20.0
+    "numpy==1.20.0; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin'",
+    "numpy==1.20.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin'",
+
+    # default numpy requirements
+    "numpy==1.17.3; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
+    "numpy==1.19.3; python_version=='3.9' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_python_implementation != 'PyPy'",
+
+    # For Python versions which aren't yet officially supported,
+    # we specify an unpinned NumPy which allows source distributions
+    # to be used and allows wheels to be used as soon as they
+    # become available.
     "numpy; python_version>='3.10'",
+    "numpy; python_version>='3.8' and platform_python_implementation=='PyPy'",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Description

This is an attempt to migrate our wheel builds from `multibuild` to [cibuildwheel](https://cibuildwheel.readthedocs.io/en/stable/). This will avoid the need to migrate Travis-CI and potential issues with free credit limits there. Also, this can run in this same repository rather than in the separate pyFFTW-wheels repo. Currently this succeeded for all linux wheels when I tested it on my branch (Python 3.7-3.10 for x86_64, i686 and aarch64). I just updated `pyproject.toml` and it is currently running again here: https://github.com/grlee77/pyFFTW/runs/3810963784?check_suite_focus=true. ~MacOS and~ Windows cases currently fail (on Windows, the FFTW libs are not yet being installed, so failure is expected).

This code was adapted from a recent PR to scikit-image (scikit-image/scikit-image#5397). Deployment only occurs when a tag is pushed and when all of the wheel builds for Linux, MacOS and Windows succeed. 

I will not be able to work on this again for at least 1 week and could use help in getting the Windows cases working.

### TODO

- [x] For MacOS I install the libraries with `brew install fftw` which seems to work ~, but then the libs are not being found during build. I tried setting environment variables, but so far this has not helped.~ **update**: setting CFLAGS resolved this

- [ ] For Windows, we will need a script similar to `appveyor/setup_fftw_dlls.cmd` to install precompiled FFTW wheels (can probably call such a script from the currently empty `CIBW_BEFORE_ALL_WINDOWS` entry in the .yml file). 

- [ ] Python 3.10 entries (`cp310-*`) still need to be added for Windows and MacOS (it looked like NumPy only had a wheel available for linux at the moment)

- [ ] possibly need to bump the manylinux version to be more recent in some places? 

- [ ] For automated deployment to PyPI, @hgomersall will need to add encrypted secrets named TWINE_USERNAME and TWINE_PASSWORD to the repository ([instructions here]()https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository). These should contain the username and password for upload to PyPI. If automated deployment fails, it is still possible to manually download the wheels from the GitHub action artifacts and upload them.

