### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ FFT library.  The ultimate aim is to present a unified interface for all the
 possible transforms that FFTW can perform.
 
 Both the complex DFT and the real DFT are supported, as well as on arbitrary
-axes of abitrary shaped and strided arrays, which makes it almost
+axes of arbitrary shaped and strided arrays, which makes it almost
 feature equivalent to standard and real FFT functions of ``numpy.fft``
 (indeed, it supports the ``clongdouble`` dtype which ``numpy.fft`` does not).
 

--- a/docs/release/0.11.0.rst
+++ b/docs/release/0.11.0.rst
@@ -10,7 +10,7 @@ ultimate aim is to present a unified interface for all the possible transforms
 that FFTW can perform.
 
 Both the complex DFT and the real DFT are supported, as well as on arbitrary
-axes of abitrary shaped and strided arrays. Operating FFTW in multithreaded
+axes of arbitrary shaped and strided arrays. Operating FFTW in multithreaded
 mode is supported.
 
 pyFFTW implements the numpy and scipy fft interfaces in order for users to take

--- a/docs/release/0.12.0.rst
+++ b/docs/release/0.12.0.rst
@@ -14,7 +14,7 @@ ultimate aim is to present a unified interface for all the possible transforms
 that FFTW can perform.
 
 Both the complex DFT and the real DFT are supported, as well as on arbitrary
-axes of abitrary shaped and strided arrays. Operating FFTW in multithreaded
+axes of arbitrary shaped and strided arrays. Operating FFTW in multithreaded
 mode is supported.
 
 pyFFTW implements the numpy and scipy fft interfaces in order for users to take

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -346,7 +346,7 @@ transform is to be taken.
    fft_object_c = pyfftw.FFTW(a, b, axes=(0,1))
 
 For further information on all the supported transforms, including
-real transforms, as well as full documentaion on all the
+real transforms, as well as full documentation on all the
 instantiation arguments, see the :class:`pyfftw.FFTW` documentation.
 
 .. _wisdom_tutorial:

--- a/setup.py
+++ b/setup.py
@@ -649,7 +649,7 @@ class custom_build_ext(build_ext):
 
 class CreateChangelogCommand(Command):
     '''Depends on the ruby program github_changelog_generator. Install with
-    gem install gihub_changelog_generator.
+    gem install github_changelog_generator.
     '''
     user_options = []
 

--- a/test/test_pyfftw_config.py
+++ b/test/test_pyfftw_config.py
@@ -22,7 +22,7 @@ class ConfigTest(unittest.TestCase):
         return
 
     def tearDown(self):
-        # resstore original environment variables values
+        # restore original environment variables values
         for key in self.env_keys:
             val = self.orig_env[key]
             if val is None:

--- a/test/test_pyfftw_numpy_interface.py
+++ b/test/test_pyfftw_numpy_interface.py
@@ -415,7 +415,7 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
                 input_array = dtype_tuple[1](test_shape, dtype)
 
                 if len(args) > 2 and not self.has_norm_kwarg:
-                    # skip tests invovling norm argument if it isn't available
+                    # skip tests involving norm argument if it isn't available
                     continue
 
                 self.assertRaisesRegex(exception, e_str,


### PR DESCRIPTION
There are small typos in:
- README.md
- docs/release/0.11.0.rst
- docs/release/0.12.0.rst
- docs/source/tutorial.rst
- setup.py
- test/test_pyfftw_config.py
- test/test_pyfftw_numpy_interface.py

Fixes:
- Should read `arbitrary` rather than `abitrary`.
- Should read `restore` rather than `resstore`.
- Should read `involving` rather than `invovling`.
- Should read `github` rather than `gihub`.
- Should read `documentation` rather than `documentaion`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md