### PR TITLE
remove use of distutils

### DIFF
--- a/pyfftw/interfaces/__init__.py
+++ b/pyfftw/interfaces/__init__.py
@@ -263,10 +263,10 @@ try:
 except ImportError:
     pass
 else:
-    from distutils.version import LooseVersion as _LooseVersion
+    from numpy.lib import NumpyVersion
 
-    has_scipy_fft = _LooseVersion(scipy.__version__) >= _LooseVersion('1.4.0')
-    del _LooseVersion
+    has_scipy_fft = NumpyVersion(scipy.__version__) >= NumpyVersion('1.4.0')
+    del NumpyVersion
     del scipy
 
     from . import scipy_fftpack

--- a/setup.py
+++ b/setup.py
@@ -36,9 +36,14 @@
 from setuptools import setup, Command
 from setuptools.command.build_ext import build_ext
 
-from distutils.errors import CompileError, LinkError
-from distutils.extension import Extension
-from distutils.util import get_platform
+try:
+    from setuptools.errors import CompileError, LinkError
+    from setuptools.extension import Extension
+except ImportError:
+    # fallback to distutils for older setuptools releases
+    from distutils.errors import CompileError, LinkError
+    from distutils.extension import Extension
+from pkg_resources import get_platform
 
 from contextlib import redirect_stderr, redirect_stdout
 import os


### PR DESCRIPTION
closes #328 

I used a try/except here so we can be compatible with older setuptools (`setuptools.errors` was only added very recently)