### PR TITLE
Increase time allowed for cache clearance in test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,6 @@ test-command = "pytest --import-mode=append {project}"
 
     [tool.cibuildwheel.macos]
 
-    # See: https://github.com/pyFFTW/pyFFTW/issues/327
-    test-skip = "*"
-
     archs = [
         "x86_64",
 

--- a/tests/test_pyfftw_interfaces_cache.py
+++ b/tests/test_pyfftw_interfaces_cache.py
@@ -319,11 +319,7 @@ class CacheTest(unittest.TestCase):
         # still should be there
         self.assertIs(_cache.lookup(key), obj)
 
-        if os.name == 'nt':
-            # As above, but with a bit longer
-            time.sleep(old_keepalive_time * 16)
-        else:
-            time.sleep(old_keepalive_time * 8)
+        time.sleep(old_keepalive_time * 16)
 
         self.assertRaises(KeyError, _cache.lookup, key)
 


### PR DESCRIPTION
closes #327

This PR extends the timing allowed for cache clearance in the test cases that was occasionally failing on MacOS. Hopefully everything will pass now...