### PR TITLE
fix capitalization of the source tarball filename in the deploy step

### DIFF
--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -205,7 +205,7 @@ jobs:
           # We prefer to release wheels before source because otherwise there is a
           # small window during which users who pip install pyfftw will require compilation.
           twine upload ${{ github.workspace }}/dist/*.whl
-          twine upload ${{ github.workspace }}/dist/pyfftw-${PYFFTW_VERSION:1}.tar.gz
+          twine upload ${{ github.workspace }}/dist/pyFFTW-${PYFFTW_VERSION:1}.tar.gz
         env:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}


### PR DESCRIPTION
The automated release for v0.19.0rc0 [failed to upload the source release to PyPI](https://github.com/pyFFTW/pyFFTW/runs/4619310415?check_suite_focus=true#step:6:224). I suspect it is just an issue of case-sensitivity in the filename.
