### PR TITLE
Restrict Cython to <3 for now

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,7 +167,7 @@ test-command = "pytest --import-mode=append {project}"
 requires = [
     "wheel",
     "setuptools<=59.4.0",
-    "Cython>=0.29.18",
+    "Cython>=0.29.18,<3",
 
     # NumPy dependencies - to update these, sync from
     # https://github.com/scipy/oldest-supported-numpy/


### PR DESCRIPTION
On M1 Macs, installing from source is broken. Likely due to the recent release of Cython 3.0. I've seen issues with Cython 3 being reported [more broadly](https://github.com/yaml/pyyaml/issues/601) though so I've restricted `build-system.requires` to `cython<3` for all platforms.