### PR TITLE
Upgrade setuptools and configparser for Python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,7 +166,7 @@ test-command = "pytest --import-mode=append {project}"
 [build-system]
 requires = [
     "wheel",
-    "setuptools<=59.4.0",
+    "setuptools", #<=59.4.0",
     "Cython>=3",
 
     # NumPy dependencies - to update these, sync from

--- a/setup.py
+++ b/setup.py
@@ -811,6 +811,7 @@ def setup_package():
             'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.10',
             'Programming Language :: Python :: 3.11',
+            'Programming Language :: Python :: 3.12',
             'Development Status :: 4 - Beta',
             'License :: OSI Approved :: BSD License',
             'Operating System :: OS Independent',
@@ -824,6 +825,7 @@ def setup_package():
         ],
         'cmdclass': cmdclass,
         'python_requires': ">=3.8",
+        'py_modules': ['pyfftw'],
     }
 
     setup_args['setup_requires'] = build_requires

--- a/versioneer.py
+++ b/versioneer.py
@@ -339,9 +339,9 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+        parser.read_file(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):
@@ -418,7 +418,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
     return stdout, p.returncode
 
 
-LONG_VERSION_PY['git'] = '''
+LONG_VERSION_PY['git'] = r'''
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build


### PR DESCRIPTION
The current version of PyFFTW does not install with Python 3.12, see [Issue 336](https://github.com/pyFFTW/pyFFTW/issues/366).
This PR proposes to lift the setuptools version constraint, and upgrade versioneer to replace SafeConfigParser which was removed in Python 3.12.
I had also to add "py_modules" explicitely in `setup.py`, and change a string to a raw-string in versioneer because of a non-escaped '\s' in the string.

PyFFTW now builds and installs fine, but I get a number of pytest failures,
```
===================================================================== short test summary info =====================================================================
FAILED tests/test_pyfftw_builders.py::BuildersTestFFT::test_auto_align_input - AssertionError: False is not true
FAILED tests/test_pyfftw_builders.py::BuildersTestIFFT::test_auto_align_input - AssertionError: False is not true
FAILED tests/test_pyfftw_builders.py::BuildersTestRFFT::test_auto_align_input - AssertionError: False is not true
FAILED tests/test_pyfftw_builders.py::BuildersTestIRFFT::test_auto_align_input - AssertionError: False is not true
FAILED tests/test_pyfftw_builders.py::BuildersTestFFT2::test_auto_align_input - AssertionError: False is not true
FAILED tests/test_pyfftw_builders.py::BuildersTestIFFT2::test_auto_align_input - AssertionError: False is not true
FAILED tests/test_pyfftw_builders.py::BuildersTestRFFT2::test_auto_align_input - AssertionError: False is not true
FAILED tests/test_pyfftw_builders.py::BuildersTestIRFFT2::test_auto_align_input - AssertionError: False is not true
FAILED tests/test_pyfftw_builders.py::BuildersTestFFTN::test_auto_align_input - AssertionError: False is not true
FAILED tests/test_pyfftw_builders.py::BuildersTestIFFTN::test_auto_align_input - AssertionError: False is not true
FAILED tests/test_pyfftw_builders.py::BuildersTestRFFTN::test_auto_align_input - AssertionError: False is not true
FAILED tests/test_pyfftw_builders.py::BuildersTestIRFFTN::test_auto_align_input - AssertionError: False is not true
FAILED tests/test_pyfftw_class_misc.py::FFTWMiscTest::test_aligned_flag - AssertionError: False is not true
FAILED tests/test_pyfftw_complex.py::Complex128FFTWTest::test_alignment - AssertionError: False is not true
FAILED tests/test_pyfftw_real_backward.py::RealBackwardDoubleFFTWTest::test_alignment - AssertionError: False is not true
FAILED tests/test_pyfftw_real_forward.py::RealForwardDoubleFFTWTest::test_alignment - AssertionError: False is not true
FAILED tests/test_pyfftw_scipy_fft.py::InterfacesScipyR2RFFTTestDSTFloat64::test_normalized - AssertionError: False is not true
FAILED tests/test_pyfftw_scipy_fft.py::InterfacesScipyR2RFFTTestIDSTFloat64::test_normalized - AssertionError: False is not true
FAILED tests/test_pyfftw_scipy_fft.py::InterfacesScipyR2RFFTTestDSTNFloat64::test_normalized - AssertionError: False is not true
FAILED tests/test_pyfftw_scipy_fft.py::InterfacesScipyR2RFFTTestIDSTNFloat64::test_normalized - AssertionError: False is not true
FAILED tests/test_pyfftw_scipy_fft.py::InterfacesScipyR2RFFTNTestIDSTNFloat64::test_normalized - AssertionError: False is not true
FAILED tests/test_pyfftw_scipy_interface.py::InterfacesScipyR2RFFTTestDSTFloat64::test_normalized - AssertionError: False is not true
FAILED tests/test_pyfftw_scipy_interface.py::InterfacesScipyR2RFFTTestIDSTFloat64::test_normalized - AssertionError: False is not true
FAILED tests/test_pyfftw_scipy_interface.py::InterfacesScipyR2RFFTTestDSTNFloat64::test_normalized - AssertionError: False is not true
FAILED tests/test_pyfftw_scipy_interface.py::InterfacesScipyR2RFFTTestIDSTNFloat64::test_normalized - AssertionError: False is not true
FAILED tests/test_pyfftw_scipy_interface.py::InterfacesScipyR2RFFTNTestDSTNFloat64::test_normalized - AssertionError: False is not true
FAILED tests/test_pyfftw_scipy_interface.py::InterfacesScipyR2RFFTNTestIDSTNFloat64::test_normalized - AssertionError: False is not true
==================================================== 27 failed, 1351 passed, 337 skipped, 1 warning in 32.94s =====================================================
```

I don't know if these were failing already, or if these are specified to Python 3.12, macOS Sonoma or Apple M1, or caused in any way by the changed proposed in this PR.