### PR TITLE
Work to fix the CI (failing related to scipy >= 1.12.0)

### DIFF
--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -94,7 +94,7 @@ jobs:
             cibw_arch: "universal2"
 
     env:
-      MACOSX_DEPLOYMENT_TARGET: "10.13"
+      MACOSX_DEPLOYMENT_TARGET: "12.0"
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
 
-        cibw_python: ["cp38", "cp39", "cp310", "cp311", "pp38"]
+        cibw_python: ["cp39", "cp310", "cp311", "pp39"]
         # SciPy and NumPy don't support musllinux
         cibw_libc: ["manylinux"]
         cibw_arch: ["x86_64", "i686", "aarch64"]
@@ -33,10 +33,10 @@ jobs:
           - cibw_python: "cp311"
             cibw_arch: "i686"
 
-          # Numpy only supports pypy38 x86_64 on Linux
-          - cibw_python: "pp38"
+          # Numpy only supports pypy39 x86_64 on Linux
+          - cibw_python: "pp39"
             cibw_arch: "i686"
-          - cibw_python: "pp38"
+          - cibw_python: "pp39"
             cibw_arch: "aarch64"
 
     steps:
@@ -79,7 +79,7 @@ jobs:
       matrix:
         os: [macos-12]
 
-        cibw_python: ["cp38", "cp39", "cp310", "cp311", "pp38"]
+        cibw_python: ["cp39", "cp310", "cp311", "pp39"]
         # See issue [#352](https://github.com/pyFFTW/pyFFTW/issues/352)
         # TODO: Add arm64 when we support it
         # Current problem seems to be that installed libfftw3 does not provide arm64
@@ -87,10 +87,10 @@ jobs:
         cibw_arch: ["x86_64"]
 
         exclude:
-          # cibuildwheel only supports pypy38 x86_64 on MacOS
-          - cibw_python: "pp38"
+          # cibuildwheel only supports pypy39 x86_64 on MacOS
+          - cibw_python: "pp39"
             cibw_arch: "arm64"
-          - cibw_python: "pp38"
+          - cibw_python: "pp39"
             cibw_arch: "universal2"
 
     env:
@@ -137,20 +137,17 @@ jobs:
       matrix:
         os: [windows-2022]
 
-        cibw_python: ["cp38", "cp39", "cp310", "cp311", "pp38"]
+        cibw_python: ["cp39", "cp310", "cp311", "pp39"]
         # # Add arm64 when we support it
         # # We don't support Windows 32-bit
         cibw_arch: ["_amd64", "32", "_arm64"]
 
         exclude:
-          # windows arm64 support is 3.9+
-          - cibw_python: "cp38"
-            cibw_arch: "_arm64"
 
-          # cibuildwheel only supports pypy38 AMD64 on Windows
-          - cibw_python: "pp38"
+          # cibuildwheel only supports pypy39 AMD64 on Windows
+          - cibw_python: "pp39"
             cibw_arch: "32"
-          - cibw_python: "pp38"
+          - cibw_python: "pp39"
             cibw_arch: "_arm64"
 
     steps:

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The documentation can be found on
 
 ## Requirements (i.e. what it was designed for)
 
-- [Python](https://python.org) >= 3.8 (lower versions *may* work)
+- [Python](https://python.org) >= 3.9 (lower versions *may* work)
 - [Numpy](https://www.numpy.org) >= 1.20 (lower versions *may* work)
 - [FFTW](https://www.fftw.org) >= 3.3 (lower versions *may* work) libraries for
   single, double, and long double precision in serial and multithreading
@@ -57,7 +57,7 @@ The documentation can be found on
 In practice, pyFFTW *may* work with older versions of these dependencies, but
 it is not tested against them.
 
-We build wheels for PyPy 3.8, but this platform has not been tested.
+We build wheels for PyPy 3.9, but this platform has not been tested.
 
 ## Optional Dependencies
 
@@ -100,8 +100,7 @@ Prebuilt wheels are available for the following configurations:
 
 |          Python version          | Windows (32 bit) | Windows (64 bit) | Windows ARM (64 bit) | MacOS | MacOS ARM | Linux (32 bit) | Linux (64 bit) | Linux ARM (64 bit) |
 | :------------------------------: | :--------------: | :--------------: | :------------------: | :---: | :-------- | :------------: | :------------: | :----------------: |
-|   CPython < 3.8 (unsupported)    |        ❌        |        ❌        |          ❌          |  ❌   | ❌        |       ❌       |       ❌       |         ❌         |
-|           CPython 3.8            |        ✔        |        ✔        |          ❌          |  ✔   | ❌        |       ✔       |       ✔       |         ✔         |
+|   CPython < 3.9 (unsupported)    |        ❌        |        ❌        |          ❌          |  ❌   | ❌        |       ❌       |       ❌       |         ❌         |
 |           CPython 3.9            |        ✔        |        ✔        |          ✔          |  ✔   | ❌        |       ✔       |       ✔       |         ✔         |
 |           CPython 3.10           |        ✔        |        ✔        |          ✔          |  ✔   | ❌        |       ❌       |       ✔       |         ✔         |
 |           CPython 3.11           |        ✔        |        ✔        |          ✔          |  ✔   | ❌        |       ❌       |       ✔       |         ✔         |

--- a/pyfftw/interfaces/scipy_fftpack.py
+++ b/pyfftw/interfaces/scipy_fftpack.py
@@ -581,11 +581,10 @@ def _dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
 
     if type == 3 and norm == 'ortho':
         x = numpy.copy(x)
+        x /= math.sqrt(2*x.shape[axis])
         sp = list(it.repeat(Ellipsis, len(x.shape)))
-        sp[axis] = 0
-        x[tuple(sp)] /= math.sqrt(x.shape[axis])
-        sp[axis] = slice(1, None, None)
-        x[tuple(sp)] /= math.sqrt(2*x.shape[axis])
+        sp[axis] = -1
+        x[tuple(sp)] *= math.sqrt(2)
 
     type_flag_lookup = {
         1: 'FFTW_RODFT00',
@@ -614,10 +613,10 @@ def _dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
         if type == 1:
             result *= 1 / math.sqrt(2 * (x.shape[axis] + 1))
         elif type == 2:
-            sp = list(it.repeat(Ellipsis, len(x.shape)))
-            sp[axis] = 0
-            result[tuple(sp)] *= 1 / math.sqrt(2)
             result *= 1 / math.sqrt(2 * x.shape[axis])
+            sp = list(it.repeat(Ellipsis, len(x.shape)))
+            sp[axis] = -1
+            result[tuple(sp)] *= 1 / math.sqrt(2)
         elif type == 4:
             result *= 1 / math.sqrt(2 * x.shape[axis])
     elif norm == 'forward':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,21 +96,6 @@ test-command = "pytest --import-mode=append {project}"
     # The best choice of manylinux is determined by the following:
     # manylinux version for numpy version for given python version
 
-    # Use manylinux2010 for Python3.8, as <3.8.4 does not initially work with manylinux2014
-    [[tool.cibuildwheel.overrides]]
-    select = "{c,p}p38-manylinux*"
-
-    manylinux-x86_64-image = "manylinux2010"
-    manylinux-i686-image = "manylinux2010"
-    manylinux-aarch64-image = "manylinux2014"
-    manylinux-ppc64le-image = "manylinux2014"
-    manylinux-s390x-image = "manylinux2014"
-    manylinux-pypy_x86_64-image = "manylinux2010"
-    manylinux-pypy_i686-image = "manylinux2010"
-    manylinux-pypy_aarch64-image = "manylinux2014"
-
-    before-all = "yum install -y fftw-devel"
-
     # Use manylinux2014 for Python3.9, as <3.9.5 does not initially work with manylinux_x_y
     [[tool.cibuildwheel.overrides]]
     select = "{c,p}p39-manylinux*"
@@ -178,12 +163,6 @@ requires = [
 
     # now matches minimum supported version, keep here as separate requirement
     # to be able to sync more easily with oldest-supported-numpy
-    "numpy==1.19.5; python_version=='3.8' and platform_machine=='aarch64' and platform_python_implementation != 'PyPy'",
-
-    # arm64 on Darwin supports Python 3.8 and above requires numpy>=1.21.0
-    # (first version with arm64 wheels available)
-    "numpy==1.21.0; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin'",
-    "numpy==1.21.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin'",
 
     # loongarch64 requires numpy>=1.22.0
     "numpy==1.22.0; platform_machine=='loongarch64'",
@@ -194,7 +173,6 @@ requires = [
     "numpy==1.22.3; python_version=='3.10' and platform_system=='Windows' and platform_python_implementation != 'PyPy'",
 
     # default numpy requirements
-    "numpy==1.19.5; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64' and platform_machine!='loongarch64' and platform_python_implementation != 'PyPy'",
     "numpy==1.19.5; python_version=='3.9' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='loongarch64' and platform_python_implementation != 'PyPy'",
     # Note that 1.21.3 was the first version with a complete set of 3.10 wheels,
     # however macOS was broken and it's safe C API/ABI-wise to build against 1.21.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,11 +180,12 @@ requires = [
     "numpy==1.21.6; python_version=='3.10' and (platform_system!='Windows' and platform_machine!='loongarch64') and platform_python_implementation != 'PyPy'",
     "numpy==1.23.2; python_version=='3.11' and platform_python_implementation != 'PyPy'",
 
+    "numpy<2.0; python_version>='3.9' and platform_python_implementation=='PyPy'",
+
     # For Python versions which aren't yet officially supported,
     # we specify an unpinned NumPy which allows source distributions
     # to be used and allows wheels to be used as soon as they
     # become available.
     "numpy; python_version>='3.12'",
-    "numpy; python_version>='3.9' and platform_python_implementation=='PyPy'",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -807,7 +807,6 @@ def setup_package():
         'classifiers': [
             'Programming Language :: Python',
             'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.10',
             'Programming Language :: Python :: 3.11',
@@ -823,7 +822,7 @@ def setup_package():
             'Topic :: Multimedia :: Sound/Audio :: Analysis'
         ],
         'cmdclass': cmdclass,
-        'python_requires': ">=3.8",
+        'python_requires': ">=3.9",
     }
 
     setup_args['setup_requires'] = build_requires

--- a/tests/test_pyfftw_scipy_fft.py
+++ b/tests/test_pyfftw_scipy_fft.py
@@ -191,6 +191,13 @@ class InterfacesScipyR2RFFTTest(unittest.TestCase):
                 data_hat_s = self.scipy_func(self.data, type=transform_type,
                                              norm=norm,
                                              overwrite_x=False, **self.kwargs)
+
+                if not numpy.allclose(data_hat_p, data_hat_s, atol=self.atol, rtol=self.rtol):
+                    print("func name: ", self.func_name)
+                    print("pyfftw:", data_hat_p)
+                    print("scipy: ", data_hat_s)
+                    print("diff:  ", data_hat_p - data_hat_s)
+
                 self.assertTrue(numpy.allclose(data_hat_p, data_hat_s,
                                                atol=self.atol, rtol=self.rtol))
 

--- a/tests/test_pyfftw_scipy_fft.py
+++ b/tests/test_pyfftw_scipy_fft.py
@@ -193,13 +193,11 @@ class InterfacesScipyR2RFFTTest(unittest.TestCase):
                                              overwrite_x=False, **self.kwargs)
 
                 if not numpy.allclose(data_hat_p, data_hat_s, atol=self.atol, rtol=self.rtol):
-                    print("func name: ", self.func_name)
-                    print("pyfftw:", data_hat_p)
+                    info = f"{self.func_name=}, {norm=}, {transform_type=}"
+                    print(info)
                     print("scipy: ", data_hat_s)
-                    print("diff:  ", data_hat_p - data_hat_s)
-
-                self.assertTrue(numpy.allclose(data_hat_p, data_hat_s,
-                                               atol=self.atol, rtol=self.rtol))
+                    print("ratio:  ", data_hat_p / data_hat_s)
+                    raise ValueError(info)
 
     def test_normalization_inverses(self):
         '''Test normalization in all of the pyfftw scipy wrappers.
@@ -212,8 +210,11 @@ class InterfacesScipyR2RFFTTest(unittest.TestCase):
             result = self.pyfftw_func(forward, type=inverse_type,
                                       norm='ortho',
                                       overwrite_x=False, **self.kwargs)
-            self.assertTrue(numpy.allclose(self.data, result,
-                                           atol=self.atol, rtol=self.rtol))
+            if not numpy.allclose(self.data, result, atol=self.atol, rtol=self.rtol):
+                info = f"{self.func_name=}, norm='ortho', {transform_type=}"
+                print(info)
+                print("ratio: ", result / self.data)
+                raise ValueError(info)
 
 
 @unittest.skipIf(not has_scipy_fft, 'scipy.fft is unavailable')


### PR DESCRIPTION
Pyfftw tests are broken with scipy >= 1.12.0. I can reproduce locally with Python 3.9 and scipy >= 1.12.0. The tests pass with scipy == 1.11.4.

Last successful CI was run in 5 months ago: https://github.com/pyFFTW/pyFFTW/actions

```
FAILED tests/test_pyfftw_scipy_fft.py::InterfacesScipyR2RFFTTestDSTFloat32::test_normalized - AssertionError: False is not true
FAILED tests/test_pyfftw_scipy_fft.py::InterfacesScipyR2RFFTTestIDSTFloat32::test_normalized - AssertionError: False is not true
FAILED tests/test_pyfftw_scipy_fft.py::InterfacesScipyR2RFFTTestDSTNFloat32::test_normalized - AssertionError: False is not true
FAILED tests/test_pyfftw_scipy_fft.py::InterfacesScipyR2RFFTTestIDSTNFloat32::test_normalized - AssertionError: False is not true
FAILED tests/test_pyfftw_scipy_fft.py::InterfacesScipyR2RFFTNTestDSTNFloat32::test_normalized - AssertionError: False is not true
FAILED tests/test_pyfftw_scipy_fft.py::InterfacesScipyR2RFFTTestDSTFloat64::test_normalized - AssertionError: False is not true
FAILED tests/test_pyfftw_scipy_fft.py::InterfacesScipyR2RFFTTestIDSTFloat64::test_normalized - AssertionError: False is not true
FAILED tests/test_pyfftw_scipy_fft.py::InterfacesScipyR2RFFTTestDSTNFloat64::test_normalized - AssertionError: False is not true
FAILED tests/test_pyfftw_scipy_fft.py::InterfacesScipyR2RFFTTestIDSTNFloat64::test_normalized - AssertionError: False is not true
```

Currently I don't understand the difference between scipy >= 1.12.0 and pyfftw and therefore I don't know how to fix pyfftw's CI.

The goal of this PR is to trigger the CI to show that it is broken without any changes in pyfftw code.