### PR TITLE
Query the version and compiler flags of fftw

### DIFF
--- a/pyfftw/__init__.py
+++ b/pyfftw/__init__.py
@@ -14,6 +14,7 @@ used by the helper routines can be controlled as via
 '''
 
 import os
+import re
 
 from .pyfftw import (
         FFTW,
@@ -33,6 +34,8 @@ from .pyfftw import (
         _supported_types,
         _supported_nptypes_complex,
         _supported_nptypes_real,
+        _fftw_version_dict,
+        _fftw_cc_dict,
         _all_types_human_readable,
         _all_types_np,
         _threading_type,
@@ -49,3 +52,16 @@ del builders.builders
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
+
+# retrieve fftw library version (only numbers) from the 'double' API
+fv_match = re.search(r'(\d+).(\d+).(\d+)', _fftw_version_dict.get('64', ''))
+if fv_match is not None:
+    fftw_version = fv_match.group()
+    fftw_version_tuple = tuple(int(n) for n in fv_match.groups())
+else:
+    fftw_version = ''
+    fftw_version_tuple = ()
+del fv_match
+
+# retrieve compiler flags from the 'double' API
+fftw_cc = _fftw_cc_dict.get('64', '')

--- a/pyfftw/pyfftw.pxd
+++ b/pyfftw/pyfftw.pxd
@@ -371,6 +371,10 @@ cdef extern from 'fftw3.h':
     void fftwf_forget_wisdom()
     void fftwl_forget_wisdom()
 
+    const char fftw_version[]
+    const char fftwf_version[]
+    const char fftwl_version[]
+
     double FFTW_NO_TIMELIMIT
 
 # Define function pointers that can act as a placeholder

--- a/pyfftw/pyfftw.pxd
+++ b/pyfftw/pyfftw.pxd
@@ -66,14 +66,14 @@ cdef extern from *:
     * have a cross platform/compiler solution.
     *
     * */
-    
+
     #ifndef PYFFTW_COMPLEX_H
     #define PYFFTW_COMPLEX_H
-    
+
     typedef float cfloat[2];
     typedef double cdouble[2];
     typedef long double clongdouble[2];
-    
+
     #endif /* Header guard */
     '''
 
@@ -493,5 +493,5 @@ cdef class FFTW:
     cdef fftw_exe get_fftw_exe(self)
 
     cdef void execute_nogil(self) noexcept nogil
-    
+
 cdef void execute_in_nogil(fftw_exe* exe_ptr) noexcept nogil

--- a/pyfftw/pyfftw.pxd
+++ b/pyfftw/pyfftw.pxd
@@ -379,6 +379,10 @@ cdef extern from 'fftw3.h':
     const char fftwf_cc[]
     const char fftwl_cc[]
 
+    const char fftw_codelet_optim[]
+    const char fftwf_codelet_optim[]
+    const char fftwl_codelet_optim[]
+
     double FFTW_NO_TIMELIMIT
 
 # Define function pointers that can act as a placeholder

--- a/pyfftw/pyfftw.pxd
+++ b/pyfftw/pyfftw.pxd
@@ -98,6 +98,9 @@ cdef extern from 'fftw3.h':
     #define fftw_import_wisdom_from_string(wisdom) (0)
     #define fftw_forget_wisdom() ((void)0)
     #define fftw_set_timelimit(...) ((void)0)
+    #define fftw_version ""
+    #define fftw_cc ""
+    #define fftw_codelet_optim ""
     #endif
 
     #if !PYFFTW_HAVE_SINGLE
@@ -115,6 +118,9 @@ cdef extern from 'fftw3.h':
     #define fftwf_import_wisdom_from_string(wisdom) (0)
     #define fftwf_forget_wisdom() ((void)0)
     #define fftwf_set_timelimit(...) ((void)0)
+    #define fftwf_version ""
+    #define fftwf_cc ""
+    #define fftwf_codelet_optim ""
     #endif
 
     #if !PYFFTW_HAVE_LONG
@@ -132,6 +138,9 @@ cdef extern from 'fftw3.h':
     #define fftwl_import_wisdom_from_string(wisdom) (0)
     #define fftwl_forget_wisdom() ((void)0)
     #define fftwl_set_timelimit(...) ((void)0)
+    #define fftwl_version ""
+    #define fftwl_cc ""
+    #define fftwl_codelet_optim ""
     #endif
 
     #if !PYFFTW_HAVE_DOUBLE_MULTITHREADING
@@ -150,6 +159,25 @@ cdef extern from 'fftw3.h':
     #define fftwl_cleanup_threads() ((void)0)
     #define fftwl_init_threads() ((void)0)
     #define fftwl_plan_with_nthreads(...) ((void)0)
+    #endif
+
+    /* FFTW Windows' DLL (as of 3.3.5) doesn't export these symbols */
+    #if defined(_WIN32) || defined(MS_WINDOWS) || defined(_MSC_VER)
+    #if PYFFTW_HAVE_DOUBLE
+    #define fftw_version ""
+    #define fftw_cc ""
+    #define fftw_codelet_optim ""
+    #endif
+    #if PYFFTW_HAVE_SINGLE
+    #define fftwf_version ""
+    #define fftwf_cc ""
+    #define fftwf_codelet_optim ""
+    #endif
+    #if PYFFTW_HAVE_LONG
+    #define fftwl_version ""
+    #define fftwl_cc ""
+    #define fftwl_codelet_optim ""
+    #endif
     #endif
     """
 

--- a/pyfftw/pyfftw.pxd
+++ b/pyfftw/pyfftw.pxd
@@ -375,6 +375,10 @@ cdef extern from 'fftw3.h':
     const char fftwf_version[]
     const char fftwl_version[]
 
+    const char fftw_cc[]
+    const char fftwf_cc[]
+    const char fftwl_cc[]
+
     double FFTW_NO_TIMELIMIT
 
 # Define function pointers that can act as a placeholder

--- a/pyfftw/pyfftw.pyx
+++ b/pyfftw/pyfftw.pyx
@@ -69,19 +69,23 @@ if np.dtype(np.longdouble) != np.dtype(np.float64):
 _supported_types = []
 _supported_nptypes_complex = []
 _supported_nptypes_real = []
+_fftw_version_dict = {}
 
 if PYFFTW_HAVE_SINGLE:
     _supported_types.append('32')
     _supported_nptypes_complex.append(np.complex64)
     _supported_nptypes_real.append(np.float32)
+    _fftw_version_dict['32'] = fftwf_version.decode()
 if PYFFTW_HAVE_DOUBLE:
     _supported_types.append('64')
     _supported_nptypes_complex.append(np.complex128)
     _supported_nptypes_real.append(np.float64)
+    _fftw_version_dict['64'] = fftw_version.decode()
 if PYFFTW_HAVE_LONG:
     _supported_types.append('ld')
     _supported_nptypes_complex.append(np.clongdouble)
     _supported_nptypes_real.append(np.longdouble)
+    _fftw_version_dict['ld'] = fftwl_version.decode()
 
 if (PYFFTW_HAVE_SINGLE_OMP or PYFFTW_HAVE_DOUBLE_OMP or PYFFTW_HAVE_LONG_OMP):
     _threading_type = 'OMP'

--- a/pyfftw/pyfftw.pyx
+++ b/pyfftw/pyfftw.pyx
@@ -45,11 +45,7 @@ import platform
 import warnings
 import threading
 
-# the fftw .dll (3.3.5) does not export fftw*version, fftw*_cc and
-# fftw*_codelet_optim etc., so for Windows the version is hard-coded to
-# 3.3.5 and others as 'NOT_AVAILABLE'
 _ON_WINDOWS = platform.system() == 'Windows'
-_WINDOWS_FFTW_VERSION = '3.3.5'
 
 include 'utils.pxi'
 
@@ -80,12 +76,15 @@ _fftw_version_dict = {}
 _fftw_cc_dict = {}
 _fftw_codelet_optim_dict = {}
 
+# the fftw .dll (as of 3.3.5) does not export fftw*version, fftw*_cc and
+# fftw*_codelet_optim etc., so for Windows those information are simply
+# stated as 'NOT_AVAILABLE'
 if PYFFTW_HAVE_SINGLE:
     _supported_types.append('32')
     _supported_nptypes_complex.append(np.complex64)
     _supported_nptypes_real.append(np.float32)
     if _ON_WINDOWS:
-        _fftw_version_dict['32'] = _WINDOWS_FFTW_VERSION
+        _fftw_version_dict['32'] = 'NOT AVAILABLE'
         _fftw_cc_dict['32'] = 'NOT AVAILABLE'
         _fftw_codelet_optim_dict['32'] = 'NOT AVAILABLE'
     else:
@@ -97,7 +96,7 @@ if PYFFTW_HAVE_DOUBLE:
     _supported_nptypes_complex.append(np.complex128)
     _supported_nptypes_real.append(np.float64)
     if _ON_WINDOWS:
-        _fftw_version_dict['64'] = _WINDOWS_FFTW_VERSION
+        _fftw_version_dict['64'] = 'NOT AVAILABLE'
         _fftw_cc_dict['64'] = 'NOT AVAILABLE'
         _fftw_codelet_optim_dict['64'] = 'NOT AVAILABLE'
     else:
@@ -109,7 +108,7 @@ if PYFFTW_HAVE_LONG:
     _supported_nptypes_complex.append(np.clongdouble)
     _supported_nptypes_real.append(np.longdouble)
     if _ON_WINDOWS:
-        _fftw_version_dict['ld'] = _WINDOWS_FFTW_VERSION
+        _fftw_version_dict['ld'] = 'NOT AVAILABLE'
         _fftw_cc_dict['ld'] = 'NOT AVAILABLE'
         _fftw_codelet_optim_dict['ld'] = 'NOT AVAILABLE'
     else:

--- a/pyfftw/pyfftw.pyx
+++ b/pyfftw/pyfftw.pyx
@@ -1988,10 +1988,10 @@ cdef class FFTW:
 
         **For Cython use only.**
 
-        This is really only useful if you want to 
+        This is really only useful if you want to
         bundle a few :data:`pyfftw.fftw_exe` in a C array, and then call them all from
         within a nogil block.
-        
+
         '''
 
         cdef fftw_exe exe
@@ -2011,7 +2011,7 @@ cdef void execute_in_nogil(fftw_exe* exe_ptr) noexcept nogil:
     **For Cython use only.**
 
     Warning: This method is **NOT** thread-safe. Concurrent calls
-    to :func:`pyfftw.execute_in_nogil` with an aliased :data:`pyfftw.fftw_exe` will lead 
+    to :func:`pyfftw.execute_in_nogil` with an aliased :data:`pyfftw.fftw_exe` will lead
     to wrong FFT results.
 
     '''

--- a/pyfftw/pyfftw.pyx
+++ b/pyfftw/pyfftw.pyx
@@ -70,22 +70,26 @@ _supported_types = []
 _supported_nptypes_complex = []
 _supported_nptypes_real = []
 _fftw_version_dict = {}
+_fftw_cc_dict = {}
 
 if PYFFTW_HAVE_SINGLE:
     _supported_types.append('32')
     _supported_nptypes_complex.append(np.complex64)
     _supported_nptypes_real.append(np.float32)
     _fftw_version_dict['32'] = fftwf_version.decode()
+    _fftw_cc_dict['32'] = fftwf_cc.decode()
 if PYFFTW_HAVE_DOUBLE:
     _supported_types.append('64')
     _supported_nptypes_complex.append(np.complex128)
     _supported_nptypes_real.append(np.float64)
     _fftw_version_dict['64'] = fftw_version.decode()
+    _fftw_cc_dict['64'] = fftw_cc.decode()
 if PYFFTW_HAVE_LONG:
     _supported_types.append('ld')
     _supported_nptypes_complex.append(np.clongdouble)
     _supported_nptypes_real.append(np.longdouble)
     _fftw_version_dict['ld'] = fftwl_version.decode()
+    _fftw_cc_dict['ld'] = fftwl_cc.decode()
 
 if (PYFFTW_HAVE_SINGLE_OMP or PYFFTW_HAVE_DOUBLE_OMP or PYFFTW_HAVE_LONG_OMP):
     _threading_type = 'OMP'

--- a/pyfftw/pyfftw.pyx
+++ b/pyfftw/pyfftw.pyx
@@ -71,6 +71,7 @@ _supported_nptypes_complex = []
 _supported_nptypes_real = []
 _fftw_version_dict = {}
 _fftw_cc_dict = {}
+_fftw_codelet_optim_dict = {}
 
 if PYFFTW_HAVE_SINGLE:
     _supported_types.append('32')
@@ -78,18 +79,21 @@ if PYFFTW_HAVE_SINGLE:
     _supported_nptypes_real.append(np.float32)
     _fftw_version_dict['32'] = fftwf_version.decode()
     _fftw_cc_dict['32'] = fftwf_cc.decode()
+    _fftw_codelet_optim_dict['32'] = fftwf_codelet_optim.decode()
 if PYFFTW_HAVE_DOUBLE:
     _supported_types.append('64')
     _supported_nptypes_complex.append(np.complex128)
     _supported_nptypes_real.append(np.float64)
     _fftw_version_dict['64'] = fftw_version.decode()
     _fftw_cc_dict['64'] = fftw_cc.decode()
+    _fftw_codelet_optim_dict['64'] = fftw_codelet_optim.decode()
 if PYFFTW_HAVE_LONG:
     _supported_types.append('ld')
     _supported_nptypes_complex.append(np.clongdouble)
     _supported_nptypes_real.append(np.longdouble)
     _fftw_version_dict['ld'] = fftwl_version.decode()
     _fftw_cc_dict['ld'] = fftwl_cc.decode()
+    _fftw_codelet_optim_dict['ld'] = fftwl_codelet_optim.decode()
 
 if (PYFFTW_HAVE_SINGLE_OMP or PYFFTW_HAVE_DOUBLE_OMP or PYFFTW_HAVE_LONG_OMP):
     _threading_type = 'OMP'

--- a/pyfftw/pyfftw.pyx
+++ b/pyfftw/pyfftw.pyx
@@ -41,8 +41,15 @@ from libc.stdlib cimport calloc, malloc, free
 from libc.stdint cimport intptr_t, int64_t
 from libc cimport limits
 
+import platform
 import warnings
 import threading
+
+# the fftw .dll (3.3.5) does not export fftw*version, fftw*_cc and
+# fftw*_codelet_optim etc., so for Windows the version is hard-coded to
+# 3.3.5 and others as 'NOT_AVAILABLE'
+_ON_WINDOWS = platform.system() == 'Windows'
+_WINDOWS_FFTW_VERSION = '3.3.5'
 
 include 'utils.pxi'
 
@@ -77,23 +84,38 @@ if PYFFTW_HAVE_SINGLE:
     _supported_types.append('32')
     _supported_nptypes_complex.append(np.complex64)
     _supported_nptypes_real.append(np.float32)
-    _fftw_version_dict['32'] = fftwf_version.decode()
-    _fftw_cc_dict['32'] = fftwf_cc.decode()
-    _fftw_codelet_optim_dict['32'] = fftwf_codelet_optim.decode()
+    if _ON_WINDOWS:
+        _fftw_version_dict['32'] = _WINDOWS_FFTW_VERSION
+        _fftw_cc_dict['32'] = 'NOT AVAILABLE'
+        _fftw_codelet_optim_dict['32'] = 'NOT AVAILABLE'
+    else:
+        _fftw_version_dict['32'] = fftwf_version.decode()
+        _fftw_cc_dict['32'] = fftwf_cc.decode()
+        _fftw_codelet_optim_dict['32'] = fftwf_codelet_optim.decode()
 if PYFFTW_HAVE_DOUBLE:
     _supported_types.append('64')
     _supported_nptypes_complex.append(np.complex128)
     _supported_nptypes_real.append(np.float64)
-    _fftw_version_dict['64'] = fftw_version.decode()
-    _fftw_cc_dict['64'] = fftw_cc.decode()
-    _fftw_codelet_optim_dict['64'] = fftw_codelet_optim.decode()
+    if _ON_WINDOWS:
+        _fftw_version_dict['64'] = _WINDOWS_FFTW_VERSION
+        _fftw_cc_dict['64'] = 'NOT AVAILABLE'
+        _fftw_codelet_optim_dict['64'] = 'NOT AVAILABLE'
+    else:
+        _fftw_version_dict['64'] = fftw_version.decode()
+        _fftw_cc_dict['64'] = fftw_cc.decode()
+        _fftw_codelet_optim_dict['64'] = fftw_codelet_optim.decode()
 if PYFFTW_HAVE_LONG:
     _supported_types.append('ld')
     _supported_nptypes_complex.append(np.clongdouble)
     _supported_nptypes_real.append(np.longdouble)
-    _fftw_version_dict['ld'] = fftwl_version.decode()
-    _fftw_cc_dict['ld'] = fftwl_cc.decode()
-    _fftw_codelet_optim_dict['ld'] = fftwl_codelet_optim.decode()
+    if _ON_WINDOWS:
+        _fftw_version_dict['ld'] = _WINDOWS_FFTW_VERSION
+        _fftw_cc_dict['ld'] = 'NOT AVAILABLE'
+        _fftw_codelet_optim_dict['ld'] = 'NOT AVAILABLE'
+    else:
+        _fftw_version_dict['ld'] = fftwl_version.decode()
+        _fftw_cc_dict['ld'] = fftwl_cc.decode()
+        _fftw_codelet_optim_dict['ld'] = fftwl_codelet_optim.decode()
 
 if (PYFFTW_HAVE_SINGLE_OMP or PYFFTW_HAVE_DOUBLE_OMP or PYFFTW_HAVE_LONG_OMP):
     _threading_type = 'OMP'

--- a/setup.py
+++ b/setup.py
@@ -650,8 +650,6 @@ class custom_build_ext(build_ext):
         if get_platform() in ('win32', 'win-amd64'):
             # because Numpy 2.0 includes complex.h
             self._pyfftw_define_macros.append(("FFTW_NO_Complex", "1"))
-            # for import/export symbols correctly
-            self._pyfftw_define_macros.append(("FFTW_DLL", "1"))
 
         # call `extend()` to keep argument set neither by sniffer nor by
         # user. On windows there are includes set automatically, we

--- a/setup.py
+++ b/setup.py
@@ -650,6 +650,8 @@ class custom_build_ext(build_ext):
         if get_platform() in ('win32', 'win-amd64'):
             # because Numpy 2.0 includes complex.h
             self._pyfftw_define_macros.append(("FFTW_NO_Complex", "1"))
+            # for import/export symbols correctly
+            self._pyfftw_define_macros.append(("FFTW_DLL", "1"))
 
         # call `extend()` to keep argument set neither by sniffer nor by
         # user. On windows there are includes set automatically, we

--- a/tests/test_pyfftw_version.py
+++ b/tests/test_pyfftw_version.py
@@ -17,7 +17,7 @@ def test_fftw_version_tuple():
     fvt = pyfftw.fftw_version_tuple
     if fvt:
         # major, minor, release
-        assert len(fvt) == 3
+        assert fvt >= (3, 0, 0)
     else:
         # cannot get version from fftw
         assert True

--- a/tests/test_pyfftw_version.py
+++ b/tests/test_pyfftw_version.py
@@ -1,0 +1,28 @@
+import re
+
+import pyfftw
+
+
+def test_fftw_version_pattern():
+    fv = pyfftw.fftw_version
+    if fv != '':
+        match = re.search(r'(\d+).(\d+).(\d+)', fv)
+        assert match is not None
+    else:
+        # cannot get version from fftw
+        assert True
+
+
+def test_fftw_version_tuple():
+    fvt = pyfftw.fftw_version_tuple
+    if fvt:
+        # major, minor, release
+        assert len(fvt) == 3
+    else:
+        # cannot get version from fftw
+        assert True
+
+
+def test_fftw_cc():
+    # compiler flags cannot be empty (at least there is a C compiler)
+    assert len(pyfftw.fftw_cc) > 0


### PR DESCRIPTION
Fixes #355.

This is my first PR to pyfftw,  please let me know if I have missed anything, and I also want to take this chance to thank all the developers in pyfftw!

This PR exposes `fftw*_version`, `fftw*_cc` and `fftw*_codelet_optim` of the fftw library, addressing #355.

If users are interested in the version of fftw library, this can be queried in the high-level API, e.g.
```python
import pyfftw
print(pyfftw.fftw_version)
```
For easier comparison, the fftw version is also available as a 3-member tuple as `(major, minor, release)` (idea borrowed from h5py), e.g.
```python
import pyfftw
if pyfftw.fftw_version_tuple > (3, 3, 5):
    # do something if the fftw library version is newer than 3.3.5 
    ...
```
How the fftw library was compiled can be inspected by
```python
import pyfftw
print(pyfftw.fftw_cc)
```
For some rare cases, users may be interested in information from different precisions (float, double, long double), this is also available as dictionaries:
```python
import pyfftw
print(pyfftw.pyfftw._fftw_version_dict)
print(pyfftw.pyfftw._fftw_cc_dict)
print(pyfftw.pyfftw._fftw_codelet_optim_dict) # options for compiling the codelet
```
Ready for review.