### PR TITLE
No need for setuptools at runtime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [
     "numpy>=1.20",
-    "setuptools>=70.1.1",
 ]
 readme = "README.md"
 license = {text = "BSD"}


### PR DESCRIPTION
I noticed that setuptools is mentioned as a runtime dependency and I don't understand why it would be needed. Let's try without.