### PR TITLE
setup: do not add /usr/include

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,9 +97,6 @@ def get_include_dirs():
     if 'PYFFTW_INCLUDE' in os.environ:
         include_dirs.append(os.environ['PYFFTW_INCLUDE'])
 
-    if get_platform().startswith("linux"):
-        include_dirs.append('/usr/include')
-
     if get_platform() in ('win32', 'win-amd64'):
         include_dirs.append(os.path.join(os.getcwd(), 'include', 'win'))
 


### PR DESCRIPTION
`/usr/include` should not be included at the level of our `setup.py`.

It can lead to issue with conda-forge. See https://conda-forge.zulipchat.com/#narrow/channel/457337-general/topic/fatal.20error.3A.20bits.2Flibc-header-start.2Eh.3A.20No.20such.20file.20or.20direc/with/516683148

I guess it should be the same for other OS (at least freebsd and macOS), but this one is simple, so let's fix that first.