### PR TITLE
Added out argument to numpy fft interface

### DIFF
--- a/pyfftw/interfaces/__init__.py
+++ b/pyfftw/interfaces/__init__.py
@@ -252,6 +252,14 @@ exceptions and with different defaults.
 
   The default is ``True``.
 
+* ``out``: A location into which the result of the requested operation
+  is stored. This argument is only supported by :mod:`~pyfftw.interfaces.numpy_fft`
+  for compatibility with NumPy 2.0+. If provided, the output array must have the
+  correct shape, dtype, and memory alignment that matches what the FFT plan expects,
+  otherwise an error is raised.
+
+  The default is ``None``, which causes a new array to be allocated and returned.
+
 '''
 
 from . import (

--- a/pyfftw/interfaces/_utils.py
+++ b/pyfftw/interfaces/_utils.py
@@ -62,6 +62,7 @@ def _Xfftn(
     normalise_idft=True,
     ortho=False,
     real_direction_flag=None,
+    output_array=None,
 ):
     work_with_copy = False
 
@@ -153,7 +154,8 @@ def _Xfftn(
             # the check and the lookup
             FFTW_object = None
 
-    if not cache.is_enabled() or FFTW_object is None:
+    new_object = not cache.is_enabled() or FFTW_object is None
+    if new_object:
         # If we're going to create a new FFTW object and are not
         # working with a copy, then we need to copy the input array to
         # preserve it, otherwise we can't actually  take the transform
@@ -174,23 +176,32 @@ def _Xfftn(
         if cache.is_enabled():
             cache._fftw_cache.insert(FFTW_object, key)
 
-        output_array = FFTW_object(normalise_idft=normalise_idft, ortho=ortho)
-
-    else:
-        orig_output_array = FFTW_object.output_array
-        output_shape = orig_output_array.shape
-        output_dtype = orig_output_array.dtype
-        output_alignment = FFTW_object.output_alignment
-
-        output_array = pyfftw.empty_aligned(
-            output_shape, output_dtype, n=output_alignment
-        )
-
-        FFTW_object(
-            input_array=a,
+    # If output_array is provided FFTW._output_array will be overwritten and the
+    # output of the requested operation on FFTW._output_array is returned. We do
+    # under no circumstances modify this external reference however, as subsequent
+    # operations either trigger the creation of a new FFTW object, or of a new output
+    # array if the output_array argument is None.
+    if new_object:
+        return FFTW_object(
             output_array=output_array,
             normalise_idft=normalise_idft,
             ortho=ortho,
         )
 
-    return output_array
+    # This can be moved above new_object for readability, but comes at a cost of one
+    # additional array instantiation that is not required.
+    orig_output_array = FFTW_object.output_array
+    if output_array is None:
+        output_shape = orig_output_array.shape
+        output_dtype = orig_output_array.dtype
+
+        output_array = pyfftw.empty_aligned(
+            output_shape, output_dtype, n=FFTW_object.output_alignment
+        )
+
+    return FFTW_object(
+        input_array=a,
+        output_array=output_array,
+        normalise_idft=normalise_idft,
+        ortho=ortho,
+    )

--- a/pyfftw/interfaces/numpy_fft.py
+++ b/pyfftw/interfaces/numpy_fft.py
@@ -112,6 +112,7 @@ def fft(
     threads=None,
     auto_align_input=True,
     auto_contiguous=True,
+    out=None,
 ):
     """Perform a 1D FFT.
 
@@ -135,6 +136,7 @@ def fft(
         auto_contiguous,
         calling_func,
         **_norm_args(norm),
+        output_array=out,
     )
 
 
@@ -148,6 +150,7 @@ def ifft(
     threads=None,
     auto_align_input=True,
     auto_contiguous=True,
+    out=None,
 ):
     """Perform a 1D inverse FFT.
 
@@ -170,6 +173,7 @@ def ifft(
         auto_contiguous,
         calling_func,
         **_norm_args(norm),
+        output_array=out,
     )
 
 
@@ -183,6 +187,7 @@ def fft2(
     threads=None,
     auto_align_input=True,
     auto_contiguous=True,
+    out=None,
 ):
     """Perform a 2D FFT.
 
@@ -205,6 +210,7 @@ def fft2(
         auto_contiguous,
         calling_func,
         **_norm_args(norm),
+        output_array=out,
     )
 
 
@@ -218,6 +224,7 @@ def ifft2(
     threads=None,
     auto_align_input=True,
     auto_contiguous=True,
+    out=None,
 ):
     """Perform a 2D inverse FFT.
 
@@ -240,6 +247,7 @@ def ifft2(
         auto_contiguous,
         calling_func,
         **_norm_args(norm),
+        output_array=out,
     )
 
 
@@ -253,6 +261,7 @@ def fftn(
     threads=None,
     auto_align_input=True,
     auto_contiguous=True,
+    out=None,
 ):
     """Perform an n-D FFT.
 
@@ -275,6 +284,7 @@ def fftn(
         auto_contiguous,
         calling_func,
         **_norm_args(norm),
+        output_array=out,
     )
 
 
@@ -288,6 +298,7 @@ def ifftn(
     threads=None,
     auto_align_input=True,
     auto_contiguous=True,
+    out=None,
 ):
     """Perform an n-D inverse FFT.
 
@@ -310,6 +321,7 @@ def ifftn(
         auto_contiguous,
         calling_func,
         **_norm_args(norm),
+        output_array=out,
     )
 
 
@@ -323,6 +335,7 @@ def rfft(
     threads=None,
     auto_align_input=True,
     auto_contiguous=True,
+    out=None,
 ):
     """Perform a 1D real FFT.
 
@@ -345,6 +358,7 @@ def rfft(
         auto_contiguous,
         calling_func,
         **_norm_args(norm),
+        output_array=out,
     )
 
 
@@ -358,6 +372,7 @@ def irfft(
     threads=None,
     auto_align_input=True,
     auto_contiguous=True,
+    out=None,
 ):
     """Perform a 1D real inverse FFT.
 
@@ -380,6 +395,7 @@ def irfft(
         auto_contiguous,
         calling_func,
         **_norm_args(norm),
+        output_array=out,
     )
 
 
@@ -393,6 +409,7 @@ def rfft2(
     threads=None,
     auto_align_input=True,
     auto_contiguous=True,
+    out=None,
 ):
     """Perform a 2D real FFT.
 
@@ -415,6 +432,7 @@ def rfft2(
         auto_contiguous,
         calling_func,
         **_norm_args(norm),
+        output_array=out,
     )
 
 
@@ -428,6 +446,7 @@ def irfft2(
     threads=None,
     auto_align_input=True,
     auto_contiguous=True,
+    out=None,
 ):
     """Perform a 2D real inverse FFT.
 
@@ -450,6 +469,7 @@ def irfft2(
         auto_contiguous,
         calling_func,
         **_norm_args(norm),
+        output_array=out,
     )
 
 
@@ -463,6 +483,7 @@ def rfftn(
     threads=None,
     auto_align_input=True,
     auto_contiguous=True,
+    out=None,
 ):
     """Perform an n-D real FFT.
 
@@ -485,6 +506,7 @@ def rfftn(
         auto_contiguous,
         calling_func,
         **_norm_args(norm),
+        output_array=out,
     )
 
 
@@ -498,6 +520,7 @@ def irfftn(
     threads=None,
     auto_align_input=True,
     auto_contiguous=True,
+    out=None,
 ):
     """Perform an n-D real inverse FFT.
 
@@ -520,6 +543,7 @@ def irfftn(
         auto_contiguous,
         calling_func,
         **_norm_args(norm),
+        output_array=out,
     )
 
 
@@ -533,6 +557,7 @@ def hfft(
     threads=None,
     auto_align_input=True,
     auto_contiguous=True,
+    out=None,
 ):
     """Perform a 1D FFT of a signal with hermitian symmetry.
     This yields a real output spectrum. See :func:`numpy.fft.hfft`
@@ -570,6 +595,7 @@ def hfft(
         auto_contiguous,
         calling_func,
         **_norm_args(new_norm),
+        output_array=out,
     )
 
 
@@ -583,6 +609,7 @@ def ihfft(
     threads=None,
     auto_align_input=True,
     auto_contiguous=True,
+    out=None,
 ):
     """Perform a 1D inverse FFT of a real-spectrum, yielding
     a signal with hermitian symmetry. See :func:`numpy.fft.ihfft`
@@ -604,17 +631,17 @@ def ihfft(
 
     new_norm = _swap_direction(norm)
 
-    return np.conjugate(
-        _Xfftn(
-            a,
-            n,
-            axis,
-            overwrite_input,
-            planner_effort,
-            threads,
-            auto_align_input,
-            auto_contiguous,
-            calling_func,
-            **_norm_args(new_norm),
-        )
+    ret = _Xfftn(
+        a,
+        n,
+        axis,
+        overwrite_input,
+        planner_effort,
+        threads,
+        auto_align_input,
+        auto_contiguous,
+        calling_func,
+        **_norm_args(new_norm),
+        output_array=out,
     )
+    return np.conjugate(ret, out=ret)

--- a/tests/test_pyfftw_numpy_interface.py
+++ b/tests/test_pyfftw_numpy_interface.py
@@ -183,6 +183,23 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
             ((32, 32, 2), {"axis": 1, "norm": "backward"}),
             ((32, 32, 2), {"axis": 1, "norm": "forward"}),
             ((64, 128, 16), {}),
+            ((64, 128, 16), {"out": None}),
+        )
+    elif numpy.__version__ >= "2.0":
+        test_shapes = (
+            ((100,), {}),
+            ((128, 64), {"axis": 0}),
+            ((128, 32), {"axis": -1}),
+            ((59, 100), {}),
+            ((59, 99), {"axis": -1}),
+            ((59, 99), {"axis": 0}),
+            ((32, 32, 4), {"axis": 1}),
+            ((32, 32, 2), {"axis": 1, "norm": "ortho"}),
+            ((32, 32, 2), {"axis": 1, "norm": None}),
+            ((32, 32, 2), {"axis": 1, "norm": "backward"}),
+            ((32, 32, 2), {"axis": 1, "norm": "forward"}),
+            ((64, 128, 16), {}),
+            ((64, 128, 16), {"out": None}),
         )
     else:
         test_shapes = (
@@ -196,6 +213,7 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
             ((32, 32, 2), {"axis": 1, "norm": "ortho"}),
             ((32, 32, 2), {"axis": 1, "norm": None}),
             ((64, 128, 16), {}),
+            ((64, 128, 16), {"out": None}),
         )
 
     # invalid_s_shapes is:
@@ -210,6 +228,10 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
     realinv = False
     has_norm_kwarg = _numpy_fft_has_norm_kwarg()
 
+    # out became available in version 2.0, but since the docstrings refer to it
+    # perhaps it makes more sense to include it in other numpy versions as well
+    has_out_kwarg = True
+
     @property
     def test_data(self):
         for test_shape, kwargs in self.test_shapes:
@@ -218,6 +240,9 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
 
             if not self.has_norm_kwarg and "norm" in kwargs:
                 kwargs.pop("norm")
+
+            if not self.has_out_kwarg and "out" in kwargs:
+                kwargs.pop("out")
 
             if self.realinv:
                 test_shape = list(test_shape)
@@ -299,6 +324,16 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
                 )
                 return
             try:
+                if "out" in kwargs:
+                    output_array = getattr(self.test_interface, self.func)(
+                        copy_func(np_input_array), s, **kwargs
+                    )
+
+                    # There seems to be a mismatch between type promotion schemes. This
+                    # avoid retrieving the correct dtype from fftw_schemes but at cost
+                    # of repeating the computation
+                    kwargs["out"] = copy_func(output_array)
+
                 output_array = getattr(self.test_interface, self.func)(
                     copy_func(np_input_array), s, **kwargs
                 )
@@ -315,6 +350,11 @@ class InterfacesNumpyFFTTestFFT(unittest.TestCase):
                     if len(w) > 0:
                         # Make sure a warning is raised
                         self.assertIs(w[-1].category, numpy.ComplexWarning)
+
+        if "out" in kwargs:
+            self.assertTrue(kwargs["out"] is output_array)
+            # Cleanup the test case dictionary
+            kwargs["out"] = None
 
         self.assertTrue(
             numpy.allclose(output_array, test_out_array, rtol=1e-2, atol=1e-4)

--- a/tests/test_pyfftw_scipy_fft.py
+++ b/tests/test_pyfftw_scipy_fft.py
@@ -390,6 +390,10 @@ for each_func in funcs:
     cls = unittest.skipIf(not has_scipy_fft, "scipy.fft is not available")(cls)
 
     globals()[class_name] = cls
+
+    # none of the scipy functions support the out kwarg
+    globals()[class_name].has_out_kwarg = False
+
     test_cases.append(cls)
 
 test_cases.append(InterfacesScipyFFTTestSimple)

--- a/tests/test_pyfftw_scipy_interface.py
+++ b/tests/test_pyfftw_scipy_interface.py
@@ -468,6 +468,9 @@ for each_func in funcs:
     # unlike numpy, none of the scipy functions support the norm kwarg
     globals()[class_name].has_norm_kwarg = False
 
+    # none of the scipy functions support the out kwarg
+    globals()[class_name].has_out_kwarg = False
+
     built_classes.append(globals()[class_name])
 
 built_classes = tuple(built_classes)


### PR DESCRIPTION
Fixes #409
Supersede #421 (same changes - to be checked - but cleaner since rebased on formatted code).

## Summary

This PR adds support for the `out` argument introduced in numpy 2.0 to the `pyfftw.interfaces.numpy` module (#409).

## Open Remarks

The changes from the initial discussion primarily target the test suite, making sure that the out argument is not propagated into the respective interface functions.

One issue I stumbled upon in the test cases is the type promotion scheme. `np.fft.fftn` returns complex128 for complex64 inputs whereas `pyfftw.interfaces.numpy_fft.fftn` returns complex64. In order to use the correct output dtype I compute the requested transform twice [see here](https://github.com/maurerv/pyFFTW/blob/a7e828f4eeac79379c04d78de02a31df2ade889f/tests/test_pyfftw_numpy_interface.py#L330).

Is there a way to compute the expected dtype of the transform ahead of time, e.g., have access to fftw_schemes to avoid this redundant computation during testing?
