### PR TITLE
Add free-threaded CPython 3.14 (cp314t) wheel builds

### DIFF
--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04]
-        cibw_python: ["cp311", "cp312", "cp313", "cp314", "pp311"]
+        cibw_python: ["cp311", "cp312", "cp313", "cp314", "cp314t", "pp311"]
         # SciPy and NumPy don't support musllinux
         cibw_libc: ["manylinux"]
         cibw_arch: ["x86_64", "aarch64"]
@@ -70,7 +70,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-13]
-        cibw_python: ["cp311", "cp312", "cp313", "cp314", "pp311"]
+        cibw_python: ["cp311", "cp312", "cp313", "cp314", "cp314t", "pp311"]
         cibw_arch: ["x86_64"]
 
     env:
@@ -127,7 +127,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-14]
-        cibw_python: ["cp311", "cp312", "cp313", "cp314"]
+        cibw_python: ["cp311", "cp312", "cp313", "cp314", "cp314t"]
         cibw_arch: ["arm64"]
 
     env:
@@ -181,7 +181,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-2022]
-        cibw_python: ["cp311", "cp312", "cp313", "cp314", "pp311"]
+        cibw_python: ["cp311", "cp312", "cp313", "cp314", "cp314t", "pp311"]
         # Add arm64 when we support it
         cibw_arch: ["_amd64", "32"]
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Prebuilt wheels are available for the following configurations:
 |           CPython 3.12            |        ✔        |        ✔        |          ❌          |  ✔   | ✔        |       ✔       |         ✔         |
 |           CPython 3.13            |        ✔        |        ✔        |          ❌          |  ✔   | ✔        |       ✔       |         ✔         |
 |           CPython 3.14            |        ✔        |        ✔        |          ❌          |  ✔   | ✔        |       ✔       |         ✔         |
+|    CPython 3.14 (free-threaded)   |        ✔        |        ✔        |          ❌          |  ✔   | ✔        |       ✔       |         ✔         |
 |     PyPy < 3.11 (unsupported)     |        ❌        |        ❌        |          ❌          |  ❌   | ❌        |      ❌       |         ❌         |
 |             PyPy 3.11             |        ❌        |        ✔        |          ❌          |  ✔   | ✔        |       ✔       |         ❌         |
 | PyPy > 3.11 (unsupported for now) |        ❌        |        ❌        |          ❌          |  ❌   | ❌        |        ❌       |         ❌         |

--- a/pyfftw/pyfftw.pyx
+++ b/pyfftw/pyfftw.pyx
@@ -1,4 +1,5 @@
 # cython: language_level=3
+# cython: freethreading_compatible=True
 #
 # Copyright 2015 Knowledge Economy Developments Ltd
 # Copyright 2014 David Wells
@@ -159,8 +160,10 @@ flag_dict = {'FFTW_MEASURE': FFTW_MEASURE,
 _flag_dict = flag_dict.copy()
 
 # Need a global lock to protect FFTW planning so that multiple Python threads
-# do not attempt to plan simultaneously.
-cdef object plan_lock = threading.Lock()
+# do not attempt to plan simultaneously. Must be reentrant because GC can
+# trigger __dealloc__ (which acquires this lock) while another operation
+# already holds it on the same thread.
+cdef object plan_lock = threading.RLock()
 
 # Function wrappers
 # =================
@@ -1400,16 +1403,6 @@ cdef class FFTW:
         ## Point at which FFTW calls are made
         ## (and none should be made before this)
 
-        # noop if threads library not available
-        self._nthreads_plan_setter(threads)
-
-        # Set the timelimit
-        set_timelimit_func(_planning_timelimit)
-
-        # Finally, construct the plan, after acquiring the global planner lock
-        # (so that only one python thread can plan at a time, as the FFTW
-        # planning functions are not thread-safe)
-
         # no self-lookups allowed in nogil block, so must grab all these first
         cdef void *plan
         cdef fftw_generic_plan_guru fftw_planner = self._fftw_planner
@@ -1421,9 +1414,17 @@ cdef class FFTW:
         cdef void *_out = <void *>np.PyArray_DATA(self._output_array)
         cdef unsigned c_flags = self._flags
 
-        with plan_lock, nogil:
-            plan = fftw_planner(rank, dims, howmany_rank, howmany_dims,
-                                _in, _out, self._direction, c_flags)
+        # Acquire the global planner lock so that only one thread can plan
+        # at a time (FFTW planning functions are not thread-safe).
+        # nthreads and timelimit set FFTW global state, so they must be
+        # inside the lock to avoid races with other threads planning
+        # concurrently.
+        with plan_lock:
+            self._nthreads_plan_setter(threads)
+            set_timelimit_func(_planning_timelimit)
+            with nogil:
+                plan = fftw_planner(rank, dims, howmany_rank, howmany_dims,
+                                    _in, _out, self._direction, c_flags)
         self._plan = plan
 
         if self._plan == NULL:
@@ -2117,47 +2118,50 @@ def export_wisdom():
         intptr_t c_wisdomf_ptr = 0
         intptr_t c_wisdoml_ptr = 0
 
-    # count the length of the string and extract it manually rather than using
-    # `fftw_export_wisdom_to_string` to avoid calling `free` on the string
-    # potentially allocated by a different C library; see #3
-    if PYFFTW_HAVE_DOUBLE:
-        fftw_export_wisdom(&count_char, <void *>&counter)
-        c_wisdom = <char *>malloc(sizeof(char)*(counter + 1))
-        if c_wisdom == NULL:
-            raise MemoryError
-        # Set the pointers to the string pointers
-        c_wisdom_ptr = <intptr_t>c_wisdom
-        fftw_export_wisdom(&write_char_to_string, <void *>&c_wisdom_ptr)
-        # Write the last byte as the null byte
-        c_wisdom[counter] = 0
-        try:
-            py_wisdom = c_wisdom
-        finally:
-            free(c_wisdom)
-    if PYFFTW_HAVE_SINGLE:
-        fftwf_export_wisdom(&count_char, <void *>&counterf)
-        c_wisdomf = <char *>malloc(sizeof(char)*(counterf + 1))
-        if c_wisdomf == NULL:
-            raise MemoryError
-        c_wisdomf_ptr = <intptr_t>c_wisdomf
-        fftwf_export_wisdom(&write_char_to_string, <void *>&c_wisdomf_ptr)
-        c_wisdomf[counterf] = 0
-        try:
-            py_wisdomf = c_wisdomf
-        finally:
-            free(c_wisdomf)
-    if PYFFTW_HAVE_LONG:
-        fftwl_export_wisdom(&count_char, <void *>&counterl)
-        c_wisdoml = <char *>malloc(sizeof(char)*(counterl + 1))
-        if c_wisdoml == NULL:
-            raise MemoryError
-        c_wisdoml_ptr = <intptr_t>c_wisdoml
-        fftwl_export_wisdom(&write_char_to_string, <void *>&c_wisdoml_ptr)
-        c_wisdoml[counterl] = 0
-        try:
-            py_wisdoml = c_wisdoml
-        finally:
-            free(c_wisdoml)
+    # FFTW wisdom functions share global state with the planner and are not
+    # thread-safe, so we hold plan_lock for the entire operation.
+    with plan_lock:
+        # count the length of the string and extract it manually rather than
+        # using `fftw_export_wisdom_to_string` to avoid calling `free` on the
+        # string potentially allocated by a different C library; see #3
+        if PYFFTW_HAVE_DOUBLE:
+            fftw_export_wisdom(&count_char, <void *>&counter)
+            c_wisdom = <char *>malloc(sizeof(char)*(counter + 1))
+            if c_wisdom == NULL:
+                raise MemoryError
+            # Set the pointers to the string pointers
+            c_wisdom_ptr = <intptr_t>c_wisdom
+            fftw_export_wisdom(&write_char_to_string, <void *>&c_wisdom_ptr)
+            # Write the last byte as the null byte
+            c_wisdom[counter] = 0
+            try:
+                py_wisdom = c_wisdom
+            finally:
+                free(c_wisdom)
+        if PYFFTW_HAVE_SINGLE:
+            fftwf_export_wisdom(&count_char, <void *>&counterf)
+            c_wisdomf = <char *>malloc(sizeof(char)*(counterf + 1))
+            if c_wisdomf == NULL:
+                raise MemoryError
+            c_wisdomf_ptr = <intptr_t>c_wisdomf
+            fftwf_export_wisdom(&write_char_to_string, <void *>&c_wisdomf_ptr)
+            c_wisdomf[counterf] = 0
+            try:
+                py_wisdomf = c_wisdomf
+            finally:
+                free(c_wisdomf)
+        if PYFFTW_HAVE_LONG:
+            fftwl_export_wisdom(&count_char, <void *>&counterl)
+            c_wisdoml = <char *>malloc(sizeof(char)*(counterl + 1))
+            if c_wisdoml == NULL:
+                raise MemoryError
+            c_wisdoml_ptr = <intptr_t>c_wisdoml
+            fftwl_export_wisdom(&write_char_to_string, <void *>&c_wisdoml_ptr)
+            c_wisdoml[counterl] = 0
+            try:
+                py_wisdoml = c_wisdoml
+            finally:
+                free(c_wisdoml)
 
     return (py_wisdom, py_wisdomf, py_wisdoml)
 
@@ -2189,12 +2193,13 @@ def import_wisdom(wisdom):
         bint successf = False
         bint successl = False
 
-    if PYFFTW_HAVE_DOUBLE:
-        success = fftw_import_wisdom_from_string(c_wisdom)
-    if PYFFTW_HAVE_SINGLE:
-        successf = fftwf_import_wisdom_from_string(c_wisdomf)
-    if PYFFTW_HAVE_LONG:
-        successl = fftwl_import_wisdom_from_string(c_wisdoml)
+    with plan_lock:
+        if PYFFTW_HAVE_DOUBLE:
+            success = fftw_import_wisdom_from_string(c_wisdom)
+        if PYFFTW_HAVE_SINGLE:
+            successf = fftwf_import_wisdom_from_string(c_wisdomf)
+        if PYFFTW_HAVE_LONG:
+            successl = fftwl_import_wisdom_from_string(c_wisdoml)
     return (success, successf, successl)
 
 #def export_wisdom_to_files(
@@ -2289,9 +2294,10 @@ def forget_wisdom():
 
     Forget all the accumulated wisdom.
     '''
-    if PYFFTW_HAVE_DOUBLE:
-        fftw_forget_wisdom()
-    if PYFFTW_HAVE_SINGLE:
-        fftwf_forget_wisdom()
-    if PYFFTW_HAVE_LONG:
-        fftwl_forget_wisdom()
+    with plan_lock:
+        if PYFFTW_HAVE_DOUBLE:
+            fftw_forget_wisdom()
+        if PYFFTW_HAVE_SINGLE:
+            fftwf_forget_wisdom()
+        if PYFFTW_HAVE_LONG:
+            fftwl_forget_wisdom()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "wheel",
     "setuptools>=64",
     "setuptools-scm",
-    "Cython>=3",
+    "Cython>=3.1",
     # taken from scipy (2024/06/28)
     # numpy requirement for wheel builds for distribution on PyPI - building
     # against 2.x yields wheels that are also compatible with numpy 1.x at

--- a/tests/test_pyfftw_concurrent.py
+++ b/tests/test_pyfftw_concurrent.py
@@ -1,0 +1,163 @@
+# Copyright 2025 the PyFFTW contributors
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+"""Tests for concurrent pyFFTW operations from multiple Python threads.
+
+These tests verify that plan creation, execution, and wisdom operations
+are thread-safe. On free-threaded Python (3.13t+), the threads run truly
+in parallel; on regular Python, the GIL serializes Python code but the
+locking logic (plan_lock) is still exercised.
+"""
+
+import concurrent.futures
+import unittest
+
+import numpy as np
+
+import pyfftw
+
+from .test_pyfftw_base import run_test_suites
+
+
+class ConcurrentPlanCreationTest(unittest.TestCase):
+    """Multiple threads creating FFTW plans simultaneously."""
+
+    def test_concurrent_plan_creation(self):
+        def create_plan(size):
+            a = pyfftw.empty_aligned(size, dtype='complex128')
+            b = pyfftw.empty_aligned(size, dtype='complex128')
+            return pyfftw.FFTW(a, b, flags=('FFTW_ESTIMATE',))
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+            sizes = [32, 64, 128, 256] * 10
+            futures = [pool.submit(create_plan, s) for s in sizes]
+            plans = [f.result() for f in futures]
+
+        self.assertEqual(len(plans), 40)
+
+    def test_concurrent_plan_creation_varied_threads(self):
+        """Plans with different FFTW thread counts created concurrently.
+
+        Verifies that fftw_plan_with_nthreads is protected by plan_lock
+        so one thread's nthreads setting doesn't leak into another's plan.
+        """
+        results = {}
+
+        def create_plan_with_threads(n_fftw_threads):
+            a = pyfftw.empty_aligned(128, dtype='complex128')
+            b = pyfftw.empty_aligned(128, dtype='complex128')
+            return pyfftw.FFTW(
+                a, b, threads=n_fftw_threads, flags=('FFTW_ESTIMATE',)
+            )
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
+            futures = {}
+            for t in [1, 2, 4, 1, 2, 4] * 3:
+                futures[pool.submit(create_plan_with_threads, t)] = t
+            for f in concurrent.futures.as_completed(futures):
+                f.result()  # raises if plan creation failed
+
+
+class ConcurrentExecutionTest(unittest.TestCase):
+    """Multiple threads executing FFTs simultaneously."""
+
+    def test_concurrent_execution_correctness(self):
+        np.random.seed(42)
+        n_workers = 8
+        n_tasks = 32
+
+        tasks = []
+        for i in range(n_tasks):
+            size = 64 * (i % 4 + 1)
+            a = pyfftw.empty_aligned(size, dtype='complex128')
+            b = pyfftw.empty_aligned(size, dtype='complex128')
+            fft = pyfftw.FFTW(a, b, flags=('FFTW_ESTIMATE',))
+            data = np.random.randn(size) + 1j * np.random.randn(size)
+            expected = np.fft.fft(data)
+            tasks.append((fft, data, expected))
+
+        def execute_and_verify(task):
+            fft, data, expected = task
+            result = fft(data.copy())
+            return np.allclose(result, expected, atol=1e-10)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=n_workers) as pool:
+            futures = [pool.submit(execute_and_verify, t) for t in tasks]
+            results = [f.result() for f in futures]
+
+        self.assertTrue(all(results))
+
+
+class ConcurrentWisdomTest(unittest.TestCase):
+    """Wisdom operations from multiple threads simultaneously."""
+
+    def test_concurrent_wisdom_roundtrip(self):
+        def wisdom_roundtrip(_):
+            wisdom = pyfftw.export_wisdom()
+            pyfftw.import_wisdom(wisdom)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
+            futures = [pool.submit(wisdom_roundtrip, i) for i in range(20)]
+            for f in futures:
+                f.result()
+
+    def test_concurrent_plan_and_wisdom(self):
+        """Plan creation and wisdom operations interleaved."""
+        def create_plan(_):
+            a = pyfftw.empty_aligned(64, dtype='complex128')
+            b = pyfftw.empty_aligned(64, dtype='complex128')
+            pyfftw.FFTW(a, b, flags=('FFTW_ESTIMATE',))
+
+        def wisdom_op(_):
+            wisdom = pyfftw.export_wisdom()
+            pyfftw.import_wisdom(wisdom)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
+            futures = []
+            for i in range(30):
+                if i % 2 == 0:
+                    futures.append(pool.submit(create_plan, i))
+                else:
+                    futures.append(pool.submit(wisdom_op, i))
+            for f in futures:
+                f.result()
+
+
+test_cases = (
+    ConcurrentPlanCreationTest,
+    ConcurrentExecutionTest,
+    ConcurrentWisdomTest,
+)
+
+test_set = None
+
+if __name__ == '__main__':
+    run_test_suites(test_cases, test_set)


### PR DESCRIPTION
Hey, I noticed there were no free-threaded builds on pypi. So, I've looked at the project, and it seems that even though the code (almost) supported free-threaded Python, there were just a few minor things:

- We specify a build matrix. The build tool cibuildwheel seems to build t wheels by default now, but it just wasn't picked up yet.
- Some code around planning wasn't properly thread-safe. We already have a `plan_lock`, so just a bit more locking is done for the planner, wisdom and the global functions. I've used this https://www.fftw.org/fftw3_doc/Thread-safety.html as a guide.

Because I'm not that familiair with the project, I have used AI to assist me. That's reflected in the `Co-Authored-By` commit trailer. I can remove that, depending on what is desired.

Also, because this can mess up the build, I would love someone who worked with the builds to verify that this is correct.

P.S. my apologies, I hit enter a bit too soon, before editing this message :)
